### PR TITLE
Feat/umdbundle - supports umd-bundle with corresponding rollup.config and npm-script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+umd
 cjs
 esm
 lib

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "types": "esm/index.d.ts",
   "scripts": {
     "prebuild": "yarn run clean",
-    "build": "rollup -c rollup.config.js",
+    "build": "rollup -c rollup.config.js && npm run build:umd",
     "build:umd": "rollup -c rollup.config.umd.js",
     "clean": "shx rm -rf ./cjs ./esm",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "prebuild": "yarn run clean",
     "build": "rollup -c rollup.config.js",
+    "build:umd": "rollup -c rollup.config.umd.js",
     "clean": "shx rm -rf ./cjs ./esm",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "prepublishOnly": "yarn run test && yarn run build",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "description": "JSX-based components with functions, promises and generators.",
   "files": [
+    "umd",
     "cjs",
     "esm",
     "dom.d.ts",

--- a/rollup.config.umd.js
+++ b/rollup.config.umd.js
@@ -1,0 +1,15 @@
+import resolve from "@rollup/plugin-node-resolve";
+import typescript from "rollup-plugin-typescript2";
+export default {
+	input: "./src/umd/index.ts",
+	output: [
+		{
+			format: "umd",
+			dir: "umd",
+			sourcemap: true,
+			name: "Crank",
+		},
+	],
+	external: ["@repeaterjs/repeater"],
+	plugins: [typescript(), resolve()],
+};

--- a/src/umd/index.ts
+++ b/src/umd/index.ts
@@ -1,0 +1,2 @@
+export * from "../index";
+export * from "../dom";


### PR DESCRIPTION
For possible umd usage, we need a umd bundle:
- supports umd-bundle with corresponding rollup.config and npm-script
- call build:umd in build cmd

Live demo, check it out ---> 
https://coldemo.github.io/#/playground/crank-async-generator.jsx
https://coldemo.github.io/#/playground/crank-todomvc.jsx

(I've published a temp npm-pkg named 'crank-umd' to get it work)
(It can be removed at some time if crank gets umd supported itself)

(codesandbox can be broken due to some network issues in some area somehow)
(for example, I personally never had luck to open any of them in the docs)

Similar merged PR: https://github.com/kelekexiao123/genjijs/pull/6

PS: I tried to patch the existing rollup.config but failed with

```plain
src/index.ts, src/dom.ts, src/html.ts → umd, cjs, esm...
[!] Error: UMD and IIFE output formats are not supported for code-splitting builds.
```

so I've added a new file: rollup.config.umd
