### PR TITLE
removing event delegates in favor of onevent props

### DIFF
--- a/src/__tests__/index.tsx
+++ b/src/__tests__/index.tsx
@@ -535,17 +535,17 @@ describe("sync generator component", () => {
 	test("events", () => {
 		function* Component(this: Context): Generator<Element> {
 			let count = 0;
-			this.addEventListener("click", (ev) => {
-				if ((ev.target as HTMLElement).id === "button") {
-					count++;
-					this.refresh();
-				}
-			});
+			const onClick = () => {
+				count++;
+				this.refresh();
+			};
 
 			for (const _ of this) {
 				yield (
 					<div>
-						<button id="button">Click me</button>
+						<button onclick={onClick} id="button">
+							Click me
+						</button>
 						<span>Button has been clicked {count} times</span>
 					</div>
 				);

--- a/src/events.ts
+++ b/src/events.ts
@@ -46,41 +46,8 @@ export class CrankEventTarget extends EventTargetShim implements EventTarget {
 	// type -> capture -> listener record
 	// for efficient querying
 	private listeners: EventListenerRecord[] = [];
-	private delegates: Set<EventTarget> = new Set();
 	constructor(private parent?: CrankEventTarget) {
 		super();
-	}
-
-	setDelegates(delegates: Iterable<unknown>) {
-		const delegates1 = new Set(Array.from(delegates).filter(isEventTarget));
-		const removed = new Set(
-			Array.from(this.delegates).filter((d) => !delegates1.has(d)),
-		);
-		const added = new Set(
-			Array.from(delegates1).filter((d) => !this.delegates.has(d)),
-		);
-
-		for (const delegate of removed) {
-			for (const listener of this.listeners) {
-				delegate.removeEventListener(
-					listener.type,
-					listener.callback,
-					listener.options,
-				);
-			}
-		}
-
-		for (const delegate of added) {
-			for (const listener of this.listeners) {
-				delegate.addEventListener(
-					listener.type,
-					listener.callback,
-					listener.options,
-				);
-			}
-		}
-
-		this.delegates = delegates1;
 	}
 
 	addEventListener<T extends string>(
@@ -119,10 +86,6 @@ export class CrankEventTarget extends EventTargetShim implements EventTarget {
 			}
 		}
 
-		for (const delegate of this.delegates) {
-			delegate.addEventListener(type, callback, options);
-		}
-
 		return super.addEventListener(type, callback, options);
 	}
 
@@ -147,9 +110,6 @@ export class CrankEventTarget extends EventTargetShim implements EventTarget {
 		const record = this.listeners[idx];
 		if (record !== undefined) {
 			this.listeners.splice(idx, 1);
-		}
-		for (const delegate of this.delegates) {
-			delegate.removeEventListener(type, callback, options);
 		}
 
 		return super.removeEventListener(type, callback, options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -840,7 +840,6 @@ class ComponentNode<T> extends ParentNode<T> {
 
 	commit(): undefined {
 		const childValues = this.getChildValues();
-		this.ctx.setDelegates(childValues);
 		this.value = childValues.length > 1 ? childValues : childValues[0];
 		if (!this.updating) {
 			// TODO: batch this per macrotask


### PR DESCRIPTION
This (draft) PR removes assigning and removing event handlers to delegates (child dom elements).  My proposal is for Crank to use onevent props for all [global event handlers](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers) emitted from dom elements.  By removing delegates, we can reduce complexity in Crank, make the mental model for how events work easier to understand, and remove a potentially expensive process of looping through child elements to add/remove listeners.

Related discussion around onevent props: https://github.com/bikeshaving/crank/issues/10, 

This would leave the methods inherited from `CrankEventTarget` to be used for other, equally important scenarios.  The power of having an event emitter that limits event bubbling to parent _components_ is super powerful (as compared to a global event emitter like what's in node).  In this way, `CrankEventTarget` gives the power of a beautiful redux-like experience built into the framework (and a lot more).

Related discussion: https://github.com/bikeshaving/crank/issues/15

Todo: 
- [ ] tests
- [ ] update documentation & website
- [ ] update examples

I'd love to see these suggestions implemented in Crank and it seems there's a good number of folks who feel the same way.  Thanks for reading and I'm looking forward to getting feedback on this PR!
