### PR TITLE
Fixes

### DIFF
--- a/src/__tests__/html.tsx
+++ b/src/__tests__/html.tsx
@@ -1,5 +1,5 @@
 /** @jsx createElement */
-import {createElement, Fragment, Raw} from "../index";
+import {Context, createElement, Fragment, Raw} from "../index";
 import {renderer} from "../html";
 
 describe("render", () => {
@@ -154,5 +154,48 @@ describe("render", () => {
 				</div>,
 			),
 		).toEqual('<div>Raw: <span id="raw">Hi</span></div>');
+	});
+
+	test("sync generator components are cleaned up", () => {
+		const mock = jest.fn();
+		function* Component() {
+			let i = 0;
+			try {
+				while (true) {
+					yield <div>{i++}</div>;
+				}
+			} finally {
+				mock();
+			}
+		}
+
+		expect(renderer.render(<Component />)).toEqual("<div>0</div>");
+		expect(renderer.render(<Component />)).toEqual("<div>0</div>");
+		expect(mock).toHaveBeenCalledTimes(2);
+	});
+
+	test("async generator components are cleaned up", async () => {
+		const mock = jest.fn();
+		async function* Component(this: Context) {
+			let i = 0;
+			// TODO: investigate why using a while loop causes renderer.render to
+			// resolve to <div>1</div>
+			try {
+				for await (const _ of this) {
+					yield <div>{i++}</div>;
+				}
+			} finally {
+				mock();
+			}
+		}
+
+		await expect(renderer.render(<Component />)).resolves.toEqual(
+			"<div>0</div>",
+		);
+		await expect(renderer.render(<Component />)).resolves.toEqual(
+			"<div>0</div>",
+		);
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(mock).toHaveBeenCalledTimes(2);
 	});
 });

--- a/src/__tests__/index.tsx
+++ b/src/__tests__/index.tsx
@@ -112,6 +112,21 @@ describe("sync function component", () => {
 		expect(document.body.innerHTML).toEqual("<div>Hello 8</div>");
 		expect(Child).toHaveBeenCalledTimes(4);
 	});
+
+	test("children wrapped in an implicit fragment", () => {
+		function Component({copy}: {copy?: boolean}) {
+			if (copy) {
+				return <Copy />;
+			} else {
+				return [1, 2, 3];
+			}
+		}
+
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toEqual("123");
+		renderer.render(<Component copy={true} />, document.body);
+		expect(document.body.innerHTML).toEqual("123");
+	});
 });
 
 describe("async function component", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ export type ChildGenerator<T = any> =
 
 export type GeneratorComponent = (this: Context, props: Props) => ChildIterator;
 
-// TODO: component cannot be a union of FunctionComponent | GeneratorComponent
+// TODO: Component cannot be a union of FunctionComponent | GeneratorComponent
 // because this breaks Function.prototype methods.
 // https://github.com/microsoft/TypeScript/issues/33815
 export type Component = (
@@ -684,6 +684,14 @@ class ComponentNode<T> extends ParentNode<T> {
 		this.tag = tag;
 		this.key = key;
 		this.ctx = new Context(this, parent.ctx);
+	}
+
+	protected updateChildren(children: Children): MaybePromise<undefined> {
+		if (isNonStringIterable(children)) {
+			children = createElement(Fragment, null, children);
+		}
+
+		return super.updateChildren(children);
 	}
 
 	private step(): [MaybePromise<undefined>, MaybePromise<undefined>] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -617,7 +617,7 @@ class HostNode<T> extends ParentNode<T> {
 					this.iterator.return();
 				} catch (err) {
 					if (this.parent !== undefined) {
-						this.parent.catch(err);
+						return this.parent.catch(err);
 					}
 
 					throw err;
@@ -1067,7 +1067,13 @@ export class Renderer<T> {
 		}
 
 		return Pledge.resolve(host.update(portal.props))
-			.then(() => host!.value!)
+			.then(() => {
+				if (root === undefined) {
+					host!.unmount();
+				}
+
+				return host!.value!;
+			})
 			.execute();
 	}
 


### PR DESCRIPTION
Some bug fixes that didn’t make launch:
1. Wrapping non-string iterables returned from components in a fragment.
Previously Crank had the behavior where a component which returned or yielded an iterable would treat that iterable as its children. This led to surprising behavior where yielding a `Copy` after yielding an iterable would result in only the first element of the iterable being preserved. This change makes sure that the iterable is treated as a single unit, which is less surprising.
2. Unmounting stateless render roots.
Previously stateless server renderings didn’t unmount generator components. This can lead to zombie processes in node. We now unmount components after every render when root object isn’t provided.