### PR TITLE
removing module type from package.json

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,5 @@
 {
   "private": true,
-  "type": "module",
   "scripts": {
     "build": "ts-node build.tsx && echo crank.js.org > dist/CNAME",
     "predeploy": "yarn build",


### PR DESCRIPTION
In node 13+, running `yarn build` in the `website` directory, you'll get an error similar to:

```
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".tsx" for /Users/ryhinchey/Code/crank/website/build.tsx
    at Loader.defaultGetFormat [as _getFormat] (internal/modules/esm/get_format.js:65:15)
    at Loader.getFormat (internal/modules/esm/loader.js:113:42)
    at Loader.getModuleJob (internal/modules/esm/loader.js:244:31)
    at Loader.import (internal/modules/esm/loader.js:178:17)
```

removing `type: module` fixes this