### PR TITLE
adding initial github actions config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,24 @@
+name: Crank CI Workflow
+
+on:  
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: yarn install --frozen-lockfile
+    - run: yarn build
+    - run: yarn test
+    - run: yarn lint


### PR DESCRIPTION
This PR adds a basic github actions workflow to Crank.  It'll run for node 10, 12, and 14.  Runs the build, tests, and linting.

Here's an example of the output:
https://github.com/ryhinchey/crank/pull/1/checks?check_run_id=624688094

`--frozen-lockfile` is needed in the install step so yarn won't install optional dependencies like `fsevents` that will break the build

Closes https://github.com/bikeshaving/crank/issues/59