### PR TITLE
add unmount event

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -865,6 +865,7 @@ class ComponentNode<T> extends ParentNode<T> {
 		}
 
 		this.updating = false;
+		this.ctx.dispatchEvent(new CustomEvent("unmount"));
 		this.unmounted = true;
 		this.ctx.clearEventListeners();
 		if (!this.finished) {


### PR DESCRIPTION
This PR adds an `unmount` event that gets fired when a component unmounts. This allows you to do something like this:

```jsx
function App() { 
  const id = setInterval(() => {
    console.log('something');
  }, 1000);

  this.addEventListener('unmount', e => {
    clearInterval(id);
  });

  return (
    <h1>...</h1>
  )
}
```

The event does not bubble up to parents.

This is the first event fired from within Crank core out to components.  It's been mentioned a few times that having an `unmount` event would be handy as an alternative to `try/finally` and I think this would be a nice addition to Crank.  It also opens the door to discuss what other events Crank might want to fire.  Do we want to namespace these events (something like `crank:unmount`)?

If we're on board bringing this change in, I'll update the docs.