### PR TITLE
Export mjs files so Node can natively import them.

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -1,1 +1,1 @@
-export * from "./esm/dom.js";
+export * from "./esm/dom.mjs";

--- a/html.js
+++ b/html.js
@@ -1,1 +1,1 @@
-export * from "./esm/html.js";
+export * from "./esm/html.mjs";

--- a/package.json
+++ b/package.json
@@ -3,6 +3,38 @@
   "version": "0.1.3",
   "description": "JSX-based components with functions, promises and generators.",
   "license": "MIT",
+  "exports": {
+    ".": {
+      "import": "./esm/index.mjs",
+      "require": "./cjs/index.js"
+    },
+    "./html": {
+      "import": "./esm/html.mjs",
+      "require": "./cjs/html.js"
+    },
+    "./dom": {
+      "import": "./esm/dom.mjs",
+      "require": "./cjs/dom.js"
+    },
+    "./cjs": {
+      "require": "./cjs/index.js"
+    },
+    "./cjs/index.js": {
+      "require": "./cjs/index.js"
+    },
+    "./cjs/html": {
+      "require": "./cjs/html.js"
+    },
+    "./cjs/dom": {
+      "require": "./cjs/dom.js"
+    },
+    "./cjs/html.js": {
+      "require": "./cjs/html.js"
+    },
+    "./cjs/dom.js": {
+      "require": "./cjs/dom.js"
+    }
+  },
   "files": [
     "cjs",
     "esm",
@@ -12,7 +44,7 @@
     "html.js"
   ],
   "main": "cjs/index.js",
-  "module": "esm/index.js",
+  "module": "esm/index.mjs",
   "types": "esm/index.d.ts",
   "homepage": "https://crank.js.org",
   "repository": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,18 +1,19 @@
 import resolve from "@rollup/plugin-node-resolve";
 import typescript from "rollup-plugin-typescript2";
-export default {
-	input: ["src/index.ts", "src/dom.ts", "src/html.ts"],
+import {basename} from "path";
+export default ["src/index.ts", "src/dom.ts", "src/html.ts"].map((input) => ({
+	input,
 	output: [
 		{
 			format: "cjs",
-			dir: "cjs",
+			file: `cjs/${basename(input).replace(/\.ts$/, ".js")}`,
 			sourcemap: true,
 		},
 		{
 			format: "esm",
-			dir: "esm",
+			file: `esm/${basename(input).replace(/\.ts$/, ".mjs")}`,
 			sourcemap: true,
 		},
 	],
 	plugins: [typescript(), resolve()],
-};
+}));


### PR DESCRIPTION
Fixes #87.

Based on https://nodejs.org/api/esm.html it seems like there's just two things we need to do here.

1. The esm scripts need to have `.mjs` extensions
2. `package.json` needs to have an `exports` section, defining the ESM and CJS exports.

I think it would be nice to add built-in automated tests of this stuff, but I have no clear idea of how to do that.

Here's the test script I used to verify that I did no harm and that I fixed the bug.

```bash
#!/bin/bash -x

rm -rf testesm
mkdir testesm
cd testesm
npm init -y
npm i ../crank
cat <<EOF > index.mjs
import {createElement} from "@bikeshaving/crank";
import {renderer} from "@bikeshaving/crank/html";

console.log(renderer.render(createElement("div", null, "Hello world")));
EOF
node index.mjs

cat <<EOF > index.js
const {createElement} = require("@bikeshaving/crank");
const {renderer} = require("@bikeshaving/crank/html");

console.log(renderer.render(createElement("div", null, "Hello world")));
EOF
node index.js
```