### PR TITLE
Type Tweaks

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,6 +14,5 @@ export default {
 			sourcemap: true,
 		},
 	],
-	external: ["@repeaterjs/repeater"],
 	plugins: [typescript(), resolve()],
 };

--- a/src/__tests__/dom.tsx
+++ b/src/__tests__/dom.tsx
@@ -469,6 +469,13 @@ describe("render", () => {
 		expect(document.body.innerHTML).toEqual("<span>1</span><span>2</span>");
 	});
 
+	test("iterable", () => {
+		renderer.render(["1", 2, <div>3</div>], document.body);
+		expect(document.body.innerHTML).toEqual("12<div>3</div>");
+		renderer.render(null, document.body);
+		expect(document.body.innerHTML).toEqual("");
+	});
+
 	test("array", () => {
 		renderer.render(
 			<div>

--- a/src/__tests__/types.tsx
+++ b/src/__tests__/types.tsx
@@ -41,6 +41,15 @@ describe("types", () => {
 
 		elem = createElement(MyFunctionComponent, {message: "hello"});
 
+		elem = createElement(
+			MyFunctionComponent,
+			{message: "hello"},
+			"a",
+			1,
+			{},
+			[],
+			() => {},
+		);
 		// @ts-expect-error
 		elem = createElement("myIntrinsic", {poop: 1});
 
@@ -48,6 +57,16 @@ describe("types", () => {
 		elem = createElement("myIntrinsic", {message: 1});
 
 		elem = createElement("myIntrinsic", {message: "hello"});
+
+		elem = createElement(
+			"myIntrinsic",
+			{message: "hello"},
+			"a",
+			1,
+			{},
+			[],
+			() => {},
+		);
 	});
 
 	test("not components", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1099,8 +1099,11 @@ export class Renderer<T> {
 		}
 	}
 
-	render(child: Child, root?: object): MaybePromise<T> {
+	render(children: Children, root?: object): MaybePromise<T> {
 		let portal: Element<Portal>;
+		const child: Child = isNonStringIterable(children)
+			? createElement(Fragment, null, children)
+			: children;
 		if (isElement(child) && child.tag === Portal) {
 			portal = child;
 		} else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,25 +119,25 @@ export function isElement(value: any): value is Element {
 export function createElement<TTag extends Tag>(
 	tag: TTag,
 	props?: TagProps<TTag> | null,
-	...children: Array<Children>
+	...children: Array<unknown>
 ): Element<TTag>;
 export function createElement<TTag extends Tag>(
 	tag: TTag,
 	props?: TagProps<TTag> | null,
 ): Element<TTag> {
-	const assignedProps = Object.assign({}, props);
-	const key = assignedProps["crank-key"];
+	const props1 = Object.assign({}, props);
+	const key = props1["crank-key"];
 	if (key != null) {
-		delete assignedProps["crank-key"];
+		delete props1["crank-key"];
 	}
 
 	if (arguments.length > 3) {
-		assignedProps.children = Array.from(arguments).slice(2);
+		props1.children = Array.from(arguments).slice(2);
 	} else if (arguments.length > 2) {
-		assignedProps.children = arguments[2];
+		props1.children = arguments[2];
 	}
 
-	return {[ElementSigil]: true, tag, props: assignedProps, key};
+	return {[ElementSigil]: true, tag, props: props1, key};
 }
 
 type NormalizedChild = Element | string | undefined;


### PR DESCRIPTION
- Tweaks the typings of createElement so people can do gross stuff like render props as children with raw createElement calls 🤮
- Allows arbitrary iterables to be passed to `renderer.render`;