### PR TITLE
Esnext esm rollup, optionally w/o EventTargetShim

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,6 @@
       "eslint"
     ]
   },
-  "dependencies": {
-    "event-target-shim": "^5.0.1"
-  },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^7.1.3",
     "@types/jest": "^25.2.1",
@@ -55,6 +52,7 @@
     "eslint-plugin-jest": "^23.8.2",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.19.0",
+    "event-target-shim": "^5.0.1",
     "husky": "^3.1.0",
     "jest": "^25.3.0",
     "lint-staged": "^10.0.8",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,18 +1,36 @@
 import resolve from "@rollup/plugin-node-resolve";
 import typescript from "rollup-plugin-typescript2";
-export default {
-	input: ["src/index.ts", "src/dom.ts", "src/html.ts"],
-	output: [
-		{
-			format: "cjs",
-			dir: "cjs",
-			sourcemap: true,
-		},
-		{
-			format: "esm",
-			dir: "esm",
-			sourcemap: true,
-		},
-	],
-	plugins: [typescript(), resolve()],
-};
+function generateBundle(_, bundle) {
+	for (var f in bundle)
+		if (bundle[f].fileName.endsWith(".d.ts"))
+			bundle[f].source = bundle[f].source
+				.replace(/.*event-target-shim.*\s*/, "")
+				.replace(/Shim implements EventTarget/, "");
+}
+export default [
+	{
+		input: ["src/index.ts", "src/dom.ts", "src/html.ts"],
+		output: [{format: "cjs", dir: "cjs", sourcemap: true}],
+		plugins: [typescript(), resolve(), {generateBundle}],
+	},
+	{
+		input: ["src/index.ts", "src/dom.ts", "src/html.ts"],
+		output: [{format: "esm", dir: "esm", sourcemap: true}],
+		plugins: [
+			typescript({tsconfigOverride: {compilerOptions: {target: "esnext"}}}),
+			process.env.EVTSHIM !== "0" && resolve(),
+			process.env.EVTSHIM === "0" && {
+				transform(code) {
+					return {
+						code: code.replace(
+							/.*event-target-shim.*/,
+							'var EventTargetShim=typeof EventTarget=="function"?EventTarget:/*ssr dummy*/Object',
+						),
+						map: null,
+					};
+				},
+			},
+			{generateBundle},
+		],
+	},
+];


### PR DESCRIPTION
Split cjs,esm plugin rollup config. For esm, override tsconfig target compiler option with esnext. For both, replace EventTargetShim d.ts import with DOM EventTarget in the generateBundle hook. Move event-target-shim back to build dependencies.

If EVTSHIM=0 rollup, use native EventTarget only without importing event-target-shim or inlining it in the js. Dummy EventTarget=Object if undefined, so that serverside import doesn't crash (I split fetch and render, not using events there). This results in 30% smaller file, winning TTI milliseconds on embedded devices where I build engines from source and so know they're modern enough.

Size of esm is 184k before (commit 003d2c2), 152k after, 92k with EVTSHIM=0. Resolves #65. Please build and try this in some real-world app copy before merging, because my app is still Preact-based, I only ran this against the few hundred lines of small components I could port to Crank quickly.