### PR TITLE
Breaking Changes

### DIFF
--- a/src/__tests__/provisions.tsx
+++ b/src/__tests__/provisions.tsx
@@ -13,7 +13,7 @@ describe("context", () => {
 	function* Provider(this: Context): Generator<Element> {
 		let i = 1;
 		for (const {children, message = "Hello "} of this) {
-			this.set("greeting", message + i++);
+			this.provide("greeting", message + i++);
 			yield <Fragment>{children}</Fragment>;
 		}
 	}
@@ -30,7 +30,7 @@ describe("context", () => {
 	}
 
 	function Consumer(this: Context): Element {
-		const greeting = this.get("greeting");
+		const greeting = this.consume("greeting");
 		return <div>{greeting}</div>;
 	}
 

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -70,11 +70,8 @@ export class DOMRenderer extends Renderer<Node, string | undefined> {
 			: document.createElement(el.tag);
 	}
 
-	patch(
-		el: CrankElement<string | symbol>,
-		node: Element,
-		ns: string | undefined,
-	): void {
+	patch(el: CrankElement<string | symbol>, node: Element): void {
+		const isSvg = node instanceof SVGElement;
 		for (let name in el.props) {
 			let forceAttribute = false;
 			const value = el.props[name];
@@ -110,7 +107,7 @@ export class DOMRenderer extends Renderer<Node, string | undefined> {
 						node.setAttribute("class", "");
 					} else if (!value) {
 						node.removeAttribute("class");
-					} else if (!ns) {
+					} else if (!isSvg) {
 						(node as any)["className"] = value;
 					} else {
 						node.setAttribute("class", value);
@@ -128,7 +125,7 @@ export class DOMRenderer extends Renderer<Node, string | undefined> {
 				default: {
 					if (value == null) {
 						node.removeAttribute(name);
-					} else if (!forceAttribute && !ns && name in node) {
+					} else if (!forceAttribute && !isSvg && name in node) {
 						(node as any)[name] = value;
 					} else if (value === true) {
 						node.setAttribute(name, "");

--- a/src/html.ts
+++ b/src/html.ts
@@ -1,4 +1,4 @@
-import {ElementValue, Portal, Renderer} from "./index";
+import {Element, ElementValue, Portal, Renderer} from "./index";
 
 declare module "./index" {
 	interface EventMap extends GlobalEventHandlersEventMap {}
@@ -119,24 +119,25 @@ export class StringRenderer extends Renderer<
 	}
 
 	arrange(
-		tag: any,
-		props: Record<string, any>,
+		el: Element<string | symbol>,
 		node: Node,
 		children: Array<Node | string>,
 	): void {
-		if (tag === Portal) {
+		if (el.tag === Portal) {
 			return;
+		} else if (typeof el.tag !== "string") {
+			throw new Error(`Unknown tag: ${el.tag.toString()}`);
 		}
 
-		const attrs = printAttrs(props);
-		const open = `<${tag}${attrs.length ? " " : ""}${attrs}>`;
+		const attrs = printAttrs(el.props);
+		const open = `<${el.tag}${attrs.length ? " " : ""}${attrs}>`;
 		let result: string;
-		if (voidTags.has(tag)) {
+		if (voidTags.has(el.tag)) {
 			result = open;
 		} else {
-			const close = `</${tag}>`;
+			const close = `</${el.tag}>`;
 			const contents =
-				"innerHTML" in props ? props["innerHTML"] : join(children);
+				"innerHTML" in el.props ? el.props["innerHTML"] : join(children);
 			result = `${open}${contents}${close}`;
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1480,9 +1480,9 @@ export class Context<TProps = any, TResult = any> implements EventTarget {
 		this._el = el;
 	}
 
-	get<TKey extends keyof ProvisionMap>(key: TKey): ProvisionMap[TKey];
-	get(key: unknown): any;
-	get(key: unknown): any {
+	consume<TKey extends keyof ProvisionMap>(key: TKey): ProvisionMap[TKey];
+	consume(key: unknown): any;
+	consume(key: unknown): any {
 		for (let parent = this._pa; parent !== undefined; parent = parent._pa) {
 			if (typeof parent._ps === "object" && parent._ps.has(key)) {
 				return parent._ps.get(key)!;
@@ -1490,12 +1490,12 @@ export class Context<TProps = any, TResult = any> implements EventTarget {
 		}
 	}
 
-	set<TKey extends keyof ProvisionMap>(
+	provide<TKey extends keyof ProvisionMap>(
 		key: TKey,
 		value: ProvisionMap[TKey],
 	): void;
-	set(key: unknown, value: any): void;
-	set(key: unknown, value: any): void {
+	provide(key: unknown, value: any): void;
+	provide(key: unknown, value: any): void {
 		if (typeof this._ps === "undefined") {
 			this._ps = new Map();
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -625,11 +625,7 @@ export class Renderer<
 	 * @remarks
 	 * Used to mutate the node associated with an element when new props are passed.
 	 */
-	patch(
-		_el: Element<string | symbol>,
-		_node: TNode,
-		_scope: TScope | undefined,
-	): unknown {
+	patch(_el: Element<string | symbol>, _node: TNode): unknown {
 		return;
 	}
 
@@ -1142,7 +1138,7 @@ function commit<TNode, TScope, TRoot, TResult>(
 			el._n = renderer.create(el as Element<string | symbol>, scope);
 		}
 
-		renderer.patch(el as Element<string | symbol>, el._n, scope);
+		renderer.patch(el as Element<string | symbol>, el._n);
 		renderer.arrange(el as Element<string | symbol>, el._n, values);
 		value = el._n;
 	}


### PR DESCRIPTION
Modifications to the internal Renderer API, and renaming the `get` and `set` methods to `consume` and `provide`.