### PR TITLE
Add warnings to Crank

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   "scripts": {
     "prebuild": "yarn run clean",
     "build": "rollup -c rollup.config.js",
-    "clean": "shx rm -rf cjs dist umd index.js dom.js html.js *.d.ts *.js.map",
+    "clean": "shx rm -rf cjs dist umd index.js crank.js dom.js html.js *.d.ts *.js.map",
     "debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "prepublishOnly": "yarn run test && yarn run build",

--- a/src/__tests__/cascades.tsx
+++ b/src/__tests__/cascades.tsx
@@ -3,9 +3,80 @@ import {createElement, Context} from "../index";
 import {renderer} from "../dom";
 
 describe("parent-child refresh cascades", () => {
-	afterEach(async () => {
+	afterEach(() => {
 		document.body.innerHTML = "";
-		await renderer.render(null, document.body);
+		renderer.render(null, document.body);
+	});
+
+	test("sync function calls refresh directly", () => {
+		function Component(this: Context) {
+			this.refresh();
+			return <div>Hello</div>;
+		}
+
+		const mock = jest.spyOn(console, "error").mockImplementation();
+		try {
+			renderer.render(<Component />, document.body);
+			expect(document.body.innerHTML).toEqual("<div>Hello</div>");
+			expect(mock).toHaveBeenCalledTimes(1);
+		} finally {
+			mock.mockRestore();
+		}
+	});
+
+	test("async function calls refresh directly", async () => {
+		async function Component(this: Context) {
+			this.refresh();
+			return <div>Hello</div>;
+		}
+
+		const mock = jest.spyOn(console, "error").mockImplementation();
+		try {
+			await renderer.render(<Component />, document.body);
+			expect(document.body.innerHTML).toEqual("<div>Hello</div>");
+			expect(mock).toHaveBeenCalledTimes(1);
+		} finally {
+			mock.mockRestore();
+		}
+	});
+
+	test("sync generator calls refresh directly", () => {
+		function* Component(this: Context) {
+			while (true) {
+				this.refresh();
+				yield <div>Hello</div>;
+			}
+		}
+
+		const mock = jest.spyOn(console, "error").mockImplementation();
+		try {
+			renderer.render(<Component />, document.body);
+			expect(document.body.innerHTML).toEqual("<div>Hello</div>");
+			expect(mock).toHaveBeenCalledTimes(1);
+		} finally {
+			mock.mockRestore();
+		}
+	});
+
+	test("async generator calls refresh directly", async () => {
+		async function* Component(this: Context) {
+			yield <span>Hello</span>;
+			this.refresh();
+			for await (const _ of this) {
+				yield <span>Hello again</span>;
+			}
+		}
+
+		const mock = jest.spyOn(console, "error").mockImplementation();
+		try {
+			await renderer.render(<Component />, document.body);
+			expect(document.body.innerHTML).toEqual("<span>Hello</span>");
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			expect(document.body.innerHTML).toEqual("<span>Hello</span>");
+			expect(mock).toHaveBeenCalledTimes(1);
+		} finally {
+			mock.mockRestore();
+		}
 	});
 
 	test("sync function parent and sync function child", () => {
@@ -32,8 +103,16 @@ describe("parent-child refresh cascades", () => {
 				);
 			}
 
-			renderer.render(<Parent />, document.body);
-			expect(document.body.innerHTML).toEqual("<div><span>child</span></div>");
+			const mock = jest.spyOn(console, "error").mockImplementation();
+			try {
+				renderer.render(<Parent />, document.body);
+				expect(document.body.innerHTML).toEqual(
+					"<div><span>child</span></div>",
+				);
+				expect(mock).toHaveBeenCalledTimes(1);
+			} finally {
+				mock.mockRestore();
+			}
 		});
 	});
 
@@ -63,8 +142,16 @@ describe("parent-child refresh cascades", () => {
 				}
 			}
 
-			renderer.render(<Parent />, document.body);
-			expect(document.body.innerHTML).toEqual("<div><span>child</span></div>");
+			const mock = jest.spyOn(console, "error").mockImplementation();
+			try {
+				renderer.render(<Parent />, document.body);
+				expect(document.body.innerHTML).toEqual(
+					"<div><span>child</span></div>",
+				);
+				expect(mock).toHaveBeenCalledTimes(1);
+			} finally {
+				mock.mockRestore();
+			}
 		});
 	});
 
@@ -96,8 +183,16 @@ describe("parent-child refresh cascades", () => {
 				}
 			}
 
-			renderer.render(<Parent />, document.body);
-			expect(document.body.innerHTML).toEqual("<div><span>child</span></div>");
+			const mock = jest.spyOn(console, "error").mockImplementation();
+			try {
+				renderer.render(<Parent />, document.body);
+				expect(document.body.innerHTML).toEqual(
+					"<div><span>child</span></div>",
+				);
+				expect(mock).toHaveBeenCalledTimes(1);
+			} finally {
+				mock.mockRestore();
+			}
 		});
 	});
 });

--- a/src/__tests__/components.tsx
+++ b/src/__tests__/components.tsx
@@ -88,6 +88,24 @@ describe("sync function component", () => {
 		expect(document.body.innerHTML).toEqual("<div>Hello 8</div>");
 		expect(fn).toHaveBeenCalledTimes(4);
 	});
+
+	test("refresh called on unmounted component", () => {
+		let ctx!: Context;
+		function Component(this: Context) {
+			ctx = this;
+		}
+
+		renderer.render(<Component />, document.body);
+		renderer.render(null, document.body);
+		const mock = jest.spyOn(console, "error").mockImplementation();
+		try {
+			ctx.refresh();
+			ctx.refresh();
+			expect(mock).toHaveBeenCalledTimes(2);
+		} finally {
+			mock.mockRestore();
+		}
+	});
 });
 
 describe("async function component", () => {
@@ -864,7 +882,7 @@ describe("sync generator component", () => {
 		}
 
 		expect(() => renderer.render(<Component />, document.body)).toThrow(
-			"You must yield",
+			"Context iterated twice",
 		);
 		expect(i).toBe(1);
 	});
@@ -879,7 +897,7 @@ describe("sync generator component", () => {
 
 		renderer.render(<Component />, document.body);
 		await expect((() => ctx![Symbol.asyncIterator]().next())()).rejects.toThrow(
-			"Use for...of",
+			"Use for…of",
 		);
 	});
 });
@@ -1280,7 +1298,7 @@ describe("async generator component", () => {
 		}
 
 		await expect(renderer.render(<Component />, document.body)).rejects.toThrow(
-			"You must yield",
+			"Context iterated twice",
 		);
 		expect(i).toBe(1);
 	});
@@ -1294,6 +1312,6 @@ describe("async generator component", () => {
 		}
 
 		await renderer.render(<Component />, document.body);
-		expect(() => ctx[Symbol.iterator]().next()).toThrow("Use for await...of");
+		expect(() => ctx[Symbol.iterator]().next()).toThrow("Use for await…of");
 	});
 });

--- a/src/__tests__/events.tsx
+++ b/src/__tests__/events.tsx
@@ -284,4 +284,32 @@ describe("events", () => {
 		expect(listener1).toHaveBeenCalledTimes(1);
 		expect(listener2).toHaveBeenCalledTimes(0);
 	});
+
+	test("error thrown in listener and dispatchEvent", () => {
+		let ctx!: Context;
+		function Component(this: Context) {
+			ctx = this;
+			return <span>Hello</span>;
+		}
+
+		const mock = jest.spyOn(console, "error").mockImplementation();
+		try {
+			renderer.render(
+				<div>
+					<Component />
+				</div>,
+				document.body,
+			);
+
+			const error = new Error("error thrown in listener and dispatchEvent");
+			const listener = () => {
+				throw error;
+			};
+			ctx.addEventListener("foo", listener);
+			ctx.dispatchEvent(new Event("foo"));
+			expect(mock).toHaveBeenCalledWith(error);
+		} finally {
+			mock.mockRestore();
+		}
+	});
 });

--- a/src/__tests__/keys.tsx
+++ b/src/__tests__/keys.tsx
@@ -692,4 +692,38 @@ describe("keys", () => {
 		expect(span5).toBe(document.body.firstChild!.childNodes[4]);
 		expect(span6).toBe(document.body.firstChild!.childNodes[5]);
 	});
+
+	test("duplicate keys", () => {
+		const mock = jest.spyOn(console, "error").mockImplementation();
+		try {
+			renderer.render(
+				<div>
+					<span crank-key="1">1</span>
+					<span crank-key="1">2</span>
+					<span crank-key="1">3</span>
+				</div>,
+				document.body,
+			);
+			expect(document.body.innerHTML).toEqual(
+				"<div><span>1</span><span>2</span><span>3</span></div>",
+			);
+
+			expect(mock).toHaveBeenCalledTimes(2);
+			renderer.render(
+				<div>
+					<span crank-key="2">1</span>
+					<span crank-key="1">2</span>
+					<span crank-key="2">3</span>
+				</div>,
+				document.body,
+			);
+			expect(document.body.innerHTML).toEqual(
+				"<div><span>1</span><span>2</span><span>3</span></div>",
+			);
+
+			expect(mock).toHaveBeenCalledTimes(3);
+		} finally {
+			mock.mockRestore();
+		}
+	});
 });

--- a/src/crank.ts
+++ b/src/crank.ts
@@ -514,7 +514,7 @@ export class Renderer<
 			}
 		} else {
 			if (portal._ctx !== ctx) {
-				throw new Error("Context mismatch.");
+				throw new Error("Context mismatch");
 			}
 
 			portal.props = {children, root};
@@ -1544,9 +1544,9 @@ export class Context<TProps = any, TResult = any> implements EventTarget {
 		const el = this._el;
 		while (!(this._f & Unmounted)) {
 			if (this._f & Iterating) {
-				throw new Error("You must yield for each iteration of this.");
+				throw new Error("Context iterated twice without a yield");
 			} else if (this._f & IsAsyncGen) {
-				throw new Error("Use for await...of in async generator components.");
+				throw new Error("Use for await…of in async generator components");
 			}
 
 			this._f |= Iterating;
@@ -1558,9 +1558,9 @@ export class Context<TProps = any, TResult = any> implements EventTarget {
 		const el = this._el;
 		do {
 			if (this._f & Iterating) {
-				throw new Error("You must yield for each iteration of this.");
+				throw new Error("Context iterated twice without a yield");
 			} else if (this._f & IsSyncGen) {
-				throw new Error("Use for...of in sync generator components.");
+				throw new Error("Use for…of in sync generator components");
 			}
 
 			this._f |= Iterating;
@@ -1589,11 +1589,11 @@ export class Context<TProps = any, TResult = any> implements EventTarget {
 	refresh(): Promise<TResult> | TResult {
 		if (this._f & Unmounted) {
 			// eslint-disable-next-line no-console
-			console.error("Component is unmounted.");
+			console.error("Component is unmounted");
 			return this._re.read(undefined);
 		} else if (this._f & Executing) {
 			// eslint-disable-next-line no-console
-			console.error("Component is already executing.");
+			console.error("Component is already executing");
 			return this._re.read(undefined);
 		}
 
@@ -1902,7 +1902,7 @@ type ChildrenIteration =
  *
  * @returns A tuple [block, value]
  * block - A possible promise which represents the duration during which the component is blocked from updating.
- * value - The actual rendered value of the children.
+ * value - A possible promise resolving to the rendered value of children.
  *
  * @remarks
  * Each component type will block/unblock according to the type of the component.

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -16,7 +16,9 @@ export class DOMRenderer extends Renderer<Node, string | undefined> {
 		ctx?: Context,
 	): Promise<ElementValue<Node>> | ElementValue<Node> {
 		if (!(root instanceof Node)) {
-			throw new TypeError("root is not a node");
+			throw new TypeError(
+				`root (${root && (root as any).toString()}) is not a node`,
+			);
 		}
 
 		return super.render(children, root, ctx);


### PR DESCRIPTION
Added some basic warnings (via `console.error`) for various situations:
- duplicate keys
- refresh called on unmounted component context
- refresh called on a component which is currently executing