### PR TITLE
Check for properties rather than using instanceof

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -15,7 +15,7 @@ export class DOMRenderer extends Renderer<Node, string | undefined> {
 		root: Node,
 		ctx?: Context,
 	): Promise<ElementValue<Node>> | ElementValue<Node> {
-		if (!root.nodeName) {
+		if (!(root != null && typeof root.nodeType === "number")) {
 			throw new TypeError(
 				`root (${root && (root as any).toString()}) is not a node`,
 			);
@@ -69,7 +69,7 @@ export class DOMRenderer extends Renderer<Node, string | undefined> {
 	}
 
 	patch(el: CrankElement<string | symbol>, node: Element): void {
-		const isSvg = node.toString() === "[object SVGElement]";
+		const isSvg = node.namespaceURI === SVG_NAMESPACE;
 		for (let name in el.props) {
 			let forceAttribute = false;
 			const value = el.props[name];
@@ -142,7 +142,10 @@ export class DOMRenderer extends Renderer<Node, string | undefined> {
 		parent: Node,
 		children: Array<Node | string>,
 	): void {
-		if (el.tag === Portal && !parent.nodeName) {
+		if (
+			el.tag === Portal &&
+			!(parent != null && typeof parent.nodeType === "number")
+		) {
 			throw new TypeError("Portal root is not a node");
 		}
 

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -15,7 +15,7 @@ export class DOMRenderer extends Renderer<Node, string | undefined> {
 		root: Node,
 		ctx?: Context,
 	): Promise<ElementValue<Node>> | ElementValue<Node> {
-		if (!(root instanceof Node)) {
+		if (!root.nodeName) {
 			throw new TypeError(
 				`root (${root && (root as any).toString()}) is not a node`,
 			);
@@ -69,7 +69,7 @@ export class DOMRenderer extends Renderer<Node, string | undefined> {
 	}
 
 	patch(el: CrankElement<string | symbol>, node: Element): void {
-		const isSvg = node instanceof SVGElement;
+		const isSvg = node.toString() === "[object SVGElement]";
 		for (let name in el.props) {
 			let forceAttribute = false;
 			const value = el.props[name];
@@ -142,7 +142,7 @@ export class DOMRenderer extends Renderer<Node, string | undefined> {
 		parent: Node,
 		children: Array<Node | string>,
 	): void {
-		if (el.tag === Portal && !(parent instanceof Node)) {
+		if (el.tag === Portal && !parent.nodeName) {
 			throw new TypeError("Portal root is not a node");
 		}
 


### PR DESCRIPTION
I worked out the issue with [#145](https://github.com/bikeshaving/crank/issues/145). I'm using nw.js, which runs node modules in a different context from the "browser". Thus instanceof fails. This is the same if you were using elements in an iframe.

https://docs.nwjs.io/en/latest/For%20Users/Advanced/JavaScript%20Contexts%20in%20NW.js/#problem-with-instanceof

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof

Would you consider swapping instanceof for duck typing to test an instance type? I'm not sure of the best way to do that (I can research and submit a second pull request if this is something you will support); this pull request is just a rough guess.

nw.js is a bit annoying for these edge cases, but it's really fun to quickly roll applications, and crank pairs nicely with this use case. I really like what you've built.

Thanks!