### PR TITLE
Add export to ChildIterable

### DIFF
--- a/src/crank.ts
+++ b/src/crank.ts
@@ -101,7 +101,7 @@ export type Raw = typeof Raw;
 export type Child = Element | string | number | boolean | null | undefined;
 
 // NOTE: we use a recursive interface rather than making the Children type directly recursive because recursive type aliases were added in TypeScript 3.7.
-interface ChildIterable extends Iterable<Child | ChildIterable> {}
+export interface ChildIterable extends Iterable<Child | ChildIterable> {}
 
 /**
  * Describes all valid values of an element tree, including arbitrarily nested iterables of such values.


### PR DESCRIPTION
This fixes TypeScript error TS4082 that occurs when exporting a `Children` type that gets expanded into `Child | ChildIterable` by the compiler.

I'm not sure exactly what causes TS to expand the type in this case. It occurs when exporting a [connected component](https://github.com/toddlucas/crank-redux/blob/190629c3eac93e3b886fed114081b992750dcdce/src/index.ts#L30) in a new experimental library, based on the generated `.d.ts` declaration.

```
const MyComponent = () => createElement('div');
export default connect(MyComponent);
```