### PR TITLE
add warnings when components yield or return undefined

### DIFF
--- a/src/__tests__/components.tsx
+++ b/src/__tests__/components.tsx
@@ -93,6 +93,7 @@ describe("sync function component", () => {
 		let ctx!: Context;
 		function Component(this: Context) {
 			ctx = this;
+			return null;
 		}
 
 		renderer.render(<Component />, document.body);
@@ -498,6 +499,7 @@ describe("sync generator component", () => {
 			yield <span>1</span>;
 			yield <div>2</div>;
 			yield <span>3</span>;
+			yield null;
 		}
 
 		renderer.render(
@@ -525,6 +527,7 @@ describe("sync generator component", () => {
 			yield <span>Hello</span>;
 			yield <div>Hello</div>;
 			yield <span>Hello</span>;
+			yield null;
 		}
 
 		renderer.render(

--- a/src/__tests__/copy.tsx
+++ b/src/__tests__/copy.tsx
@@ -301,9 +301,9 @@ describe("Copy", () => {
 			}
 		}
 
-		let refresh!: () => unknown;
+		let ctx!: Context;
 		function* Parent(this: Context) {
-			refresh = this.refresh.bind(this);
+			ctx = this;
 			let i = 1;
 			for (const _ of this) {
 				const children = Array.from({length: i}, (_, j) =>
@@ -317,7 +317,11 @@ describe("Copy", () => {
 
 		await renderer.render(<Parent />, document.body);
 		expect(document.body.innerHTML).toEqual("<div><span>0</span></div>");
-		await refresh();
+		await ctx.refresh();
+		expect(document.body.innerHTML).toEqual(
+			"<div><span>0</span><span>0</span></div>",
+		);
+		await new Promise((resolve) => setTimeout(resolve, 100));
 		expect(document.body.innerHTML).toEqual(
 			"<div><span>0</span><span>0</span></div>",
 		);

--- a/src/__tests__/events.tsx
+++ b/src/__tests__/events.tsx
@@ -101,13 +101,15 @@ describe("events", () => {
 
 	test("delegation with unmounting children", () => {
 		let ctx!: Context;
-		function* Component(this: Context): Generator<Element> {
+		function* Component(this: Context): Generator<Element | null> {
 			ctx = this;
 			yield (
 				<div>
 					<button>Click me</button>
 				</div>
 			);
+
+			yield null;
 		}
 
 		renderer.render(<Component />, document.body);

--- a/src/__tests__/warnings.tsx
+++ b/src/__tests__/warnings.tsx
@@ -1,0 +1,37 @@
+/** @jsx createElement */
+import {createElement} from "../crank";
+import {renderer} from "../dom";
+
+describe("warnings", () => {
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
+
+	test("sync component warns on implicit return", () => {
+		const mock = jest.spyOn(console, "error").mockImplementation();
+		function Component() {}
+
+		renderer.render(<Component />, document.body);
+		expect(mock).toHaveBeenCalledTimes(1);
+		mock.mockRestore();
+	});
+
+	test("async component warns on implicit return", async () => {
+		const mock = jest.spyOn(console, "error").mockImplementation();
+		async function Component() {}
+
+		await renderer.render(<Component />, document.body);
+		expect(mock).toHaveBeenCalledTimes(1);
+		mock.mockRestore();
+	});
+
+	test("sync generator component warns on implicit return", async () => {
+		const mock = jest.spyOn(console, "error").mockImplementation();
+		function* Component() {}
+
+		await renderer.render(<Component />, document.body);
+		expect(mock).toHaveBeenCalledTimes(1);
+		mock.mockRestore();
+	});
+});

--- a/src/crank.ts
+++ b/src/crank.ts
@@ -2231,6 +2231,7 @@ function handleChildError<TNode>(
 		iteration = ctx._it.throw(err);
 	} catch (err) {
 		ctx._f |= IsDone;
+		ctx._f |= IsUnmounted;
 		throw err;
 	} finally {
 		ctx._f &= ~IsExecuting;
@@ -2247,6 +2248,7 @@ function handleChildError<TNode>(
 			},
 			(err) => {
 				ctx._f |= IsDone;
+				ctx._f |= IsUnmounted;
 				throw err;
 			},
 		);

--- a/src/crank.ts
+++ b/src/crank.ts
@@ -1754,14 +1754,21 @@ function stepCtx<TNode, TResult>(
 				// async function component
 				const result1 =
 					result instanceof Promise ? result : Promise.resolve(result);
-				const value = result1.then((result) =>
-					updateCtxChildren<TNode, TResult>(ctx, result),
+				const value = result1.then(
+					(result) => updateCtxChildren<TNode, TResult>(ctx, result),
+					(err) => {
+						ctx._f |= IsErrored;
+						throw err;
+					},
 				) as Promise<ElementValue<TNode>>;
 				return [result1, value];
 			} else {
 				// sync function component
 				return [undefined, updateCtxChildren<TNode, TResult>(ctx, result)];
 			}
+		} catch (err) {
+			ctx._f |= IsErrored;
+			throw err;
 		} finally {
 			ctx._f &= ~IsExecuting;
 		}


### PR DESCRIPTION
Implements warnings for when components yield or return null.

This PR unearthed some deeply spooky shit where a test which contained only synchronous code started failing occasionally. It only happened in a sad path test (an infinite loop edge case), but it confused the shit out of me. You can reproduce by checkout out the failing commit (https://github.com/bikeshaving/crank/pull/203/commits/9ba44d7d0c7e1ec71becdac067a88d53b1949268). I briefly investigated this, and it was due to a stack overflow error happening randomly. My suspicion is that it’s something to do with Jest, but who knows, I may have also stumbled upon an edge case to do with generators. In either case, I’ve mitigated it by adding another flag for when components error so whatever.