### PR TITLE
support className in the html renderer

### DIFF
--- a/src/__tests__/html.tsx
+++ b/src/__tests__/html.tsx
@@ -83,6 +83,21 @@ describe("render", () => {
 		);
 	});
 
+	test("class and className", () => {
+		expect(
+			renderer.render(
+				<Fragment>
+					<div class="class1 class2" />
+					<div className="class1 class2" />
+					<div className="hidden" class="override" />
+					<div class="override" className="hidden" />
+				</Fragment>,
+			),
+		).toEqual(
+			'<div class="class1 class2"></div><div class="class1 class2"></div><div class="override"></div><div class="override"></div>',
+		);
+	});
+
 	test("null", () => {
 		expect(renderer.render(null)).toEqual("");
 	});

--- a/src/html.ts
+++ b/src/html.ts
@@ -63,6 +63,11 @@ function printAttrs(props: Record<string, any>): string {
 					attrs.push(`style="${escape(printStyleObject(value))}"`);
 				}
 				break;
+			case name === "className":
+				if (!("class" in props)) {
+					attrs.push(`class="${escape(value)}"`);
+				}
+				break;
 			case typeof value === "string":
 				attrs.push(`${escape(name)}="${escape(value)}"`);
 				break;


### PR DESCRIPTION
Previously, the HTML renderer didn’t understand the React-style `className` prop and rendered it as an attribute.

This PR fixes it. If both `class` and `className` are detected we defer to `class` (this behavior differs in the DOM renderer, but it’s an edge case and I’m too lazy to fix it right now.