### PR TITLE
Fix how read-only DOM attributes are set

### DIFF
--- a/src/__tests__/svg.tsx
+++ b/src/__tests__/svg.tsx
@@ -139,7 +139,7 @@ describe("render", () => {
 	test("non-string values", () => {
 		renderer.render(
 			<svg xmlns="http://www.w3.org/2000/svg">
-				<rect class="rectClass" x={10} y={20.5} width={5_000} height={null} />
+				<rect class="rectClass" x={10} y={20.5} width={5000} height={null} />
 			</svg>,
 			document.body,
 		);

--- a/src/__tests__/svg.tsx
+++ b/src/__tests__/svg.tsx
@@ -35,10 +35,33 @@ describe("render", () => {
 			</svg>,
 			document.body,
 		);
+
+		let svgRoot = document.body.firstChild;
 		expect(document.body.firstChild).toBeInstanceOf(SVGElement);
-		for (const child of Array.from(document.body.firstChild!.childNodes)) {
-			expect(child).toBeInstanceOf(SVGElement);
-		}
+
+		let rect = svgRoot!.childNodes[0] as SVGElement;
+		expect(rect).toBeInstanceOf(SVGElement);
+		expect(rect.tagName).toEqual("rect");
+		expect(rect.getAttribute("width")).toEqual("100%");
+		expect(rect.getAttribute("height")).toEqual("100%");
+		expect(rect.getAttribute("fill")).toEqual("red");
+
+		let circle = svgRoot!.childNodes[1] as SVGElement;
+		expect(circle).toBeInstanceOf(SVGElement);
+		expect(circle.tagName).toEqual("circle");
+		expect(circle.getAttribute("cx")).toEqual("150");
+		expect(circle.getAttribute("cy")).toEqual("100");
+		expect(circle.getAttribute("r")).toEqual("80");
+		expect(circle.getAttribute("fill")).toEqual("green");
+
+		let text = svgRoot!.childNodes[2] as SVGElement;
+		expect(text).toBeInstanceOf(SVGElement);
+		expect(text.tagName).toEqual("text");
+		expect(text.getAttribute("x")).toEqual("150");
+		expect(text.getAttribute("y")).toEqual("125");
+		expect(text.getAttribute("font-size")).toEqual("60");
+		expect(text.getAttribute("text-anchor")).toEqual("middle");
+		expect(text.getAttribute("fill")).toEqual("white");
 	});
 
 	test("foreignObject", () => {
@@ -69,12 +92,14 @@ describe("render", () => {
 			document.body,
 		);
 
-		const rect = document.body.firstChild!.firstChild!;
-		const circle = rect.nextSibling;
+		const rect = document.body.firstChild!.firstChild as SVGElement;
+		const circle = rect.nextSibling as SVGElement;
 		expect(rect).toBeInstanceOf(SVGElement);
+		expect(rect.tagName).toEqual("rect");
 		expect(circle).toBeInstanceOf(SVGElement);
-		expect((rect as SVGElement).getAttribute("class")).toBe("rectClass");
-		expect((circle as SVGElement).getAttribute("class")).toBe("circleClass");
+		expect(circle.tagName).toEqual("circle");
+		expect(rect.getAttribute("class")).toBe("rectClass");
+		expect(circle.getAttribute("class")).toBe("circleClass");
 	});
 
 	test("g", () => {
@@ -88,8 +113,9 @@ describe("render", () => {
 			document.body,
 		);
 
-		const g = document.body.firstChild!.firstChild!;
+		const g = document.body.firstChild!.firstChild as SVGElement;
 		expect(g).toBeInstanceOf(SVGElement);
+		expect(g.tagName).toEqual("g");
 		expect(g.childNodes[0]).toBeInstanceOf(SVGElement);
 		expect(g.childNodes[1]).toBeInstanceOf(SVGElement);
 	});
@@ -103,8 +129,44 @@ describe("render", () => {
 			</svg>,
 			document.body,
 		);
-		const nested = document.body.firstChild!.firstChild!;
+		const nested = document.body.firstChild!.firstChild as SVGElement;
 		expect(nested).toBeInstanceOf(SVGElement);
+		expect(nested.tagName).toEqual("svg");
 		expect(nested.firstChild).toBeInstanceOf(SVGElement);
+		expect((nested.firstChild as SVGElement).tagName).toEqual("circle");
+	});
+
+	test("non-string values", () => {
+		renderer.render(
+			<svg xmlns="http://www.w3.org/2000/svg">
+				<rect class="rectClass" x={10} y={20.5} width={5_000} height={null} />
+			</svg>,
+			document.body,
+		);
+
+		const rect = document.body.firstChild!.firstChild! as SVGElement;
+		expect(rect).toBeInstanceOf(SVGElement);
+		expect(rect.getAttribute("x")).toEqual("10");
+		expect(rect.getAttribute("y")).toEqual("20.5");
+		expect(rect.getAttribute("width")).toEqual("5000");
+		expect(rect.getAttribute("height")).toEqual(null);
+	});
+
+	test("custom attributes", () => {
+		renderer.render(
+			<svg xmlns="http://www.w3.org/2000/svg">
+				<circle cx="25" cy="10" r="5" data-foo="abc" barBaz={true} />
+			</svg>,
+			document.body,
+		);
+
+		const circle = document.body.firstChild!.firstChild! as SVGElement;
+		expect(circle).toBeInstanceOf(SVGElement);
+		expect(circle.getAttribute("cx")).toEqual("25");
+		expect(circle.getAttribute("cy")).toEqual("10");
+		expect(circle.getAttribute("r")).toEqual("5");
+		expect(circle.getAttribute("data-foo")).toEqual("abc");
+		expect(circle.getAttribute("barBaz")).toEqual("");
+		expect(circle.getAttribute("does-not-exist")).toEqual(null);
 	});
 });

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -128,7 +128,10 @@ export const impl: Partial<RendererImpl<Node, string>> = {
 					// get the descriptor for the named property and check whether it
 					// implies that the property is writable
 					const descriptor = Object.getOwnPropertyDescriptor(obj, name);
-					if (descriptor?.writable === true || descriptor?.set !== undefined) {
+					if (
+						descriptor != null &&
+						(descriptor.writable === true || descriptor.set !== undefined)
+					) {
 						(node as any)[name] = value;
 						return;
 					}


### PR DESCRIPTION
Hello!

I've been using Crank for a small project (delightful, by the way!) and found a bug with how SVG attributes are being set during DOM patching. I discovered this bug when I wrote code like this:

```jsx
renderer.render(
  <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
    <rect x="0" y="0" width="10" height="20" class="foo" data-bar="1" />
  </svg>
);
```

and found that this didn't produce the desired DOM state, but instead something like this:

```html
<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
  <rect class="foo" data-bar="1"></rect>
</svg>
```

where the x, y, width, and height attributes are missing.

I read the patch implementation and figured out the cause. The intent of the code as currently written appears to be this: try writing to the node property (`node[name] = value`), and if that throws an error, fall back to setting as an attribute (`node.setAttribute(name, value)`).

However, it seems based on my ad-hoc testing, attempting to set a read-only property on a DOM element (either an HTMLElement like `<p>` or an SVGElement like `<rect>`) doesn't actually throw an error; rather the assigned value is silently discarded.

```js
let p = document.createElement("p");
p.id = "foo"; // id is a writable property
console.log(p.id); // => foo

p.isContentEditable = true; // isContentEditable is a read-only property
console.log(p.isContentEditable); // => false

// same story but for SVG
let rect = document.createElementNS("http://www.w3.org/2000/svg", "rect")
console.log(rect.x);
// => SVGAnimatedLength {
// animVal: SVGLength {unitType: 1, value: 0, valueInSpecifiedUnits: 0, valueAsString: '0'}
// baseVal: SVGLength {unitType: 1, value: 0, valueInSpecifiedUnits: 0, valueAsString: '0'}
// }
rect.x = 10; // x is read-only
console.log(rect.x); // same as above
```

The solution I came up with is this: instead of `try`ing to set the property and falling back to `setAttribute` on error, instead walk up the object's prototype chain to find the owner of the property, and then get the descriptor of the property and use that to check if it's writable or not.

I added some additional test assertions for this, but these tests wouldn't actually have caught the bug, because JSDOM appears to permit writing to any Element property.

Feel free to let me know if you'd prefer a different approach; I'm happy to rework the code if you have feedback.

Thanks for your time, and for sharing Crank! It's really been a pleasure to use, and I really appreciate the care that was put into the docs and the motivation blog post.