### PR TITLE
Tweaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@b9g/crank",
-  "version": "0.5.0-beta.6",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@b9g/crank",
-      "version": "0.5.0-beta.6",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@arkweid/lefthook": "^0.7.7",
@@ -25,7 +25,7 @@
         "shx": "^0.3.4",
         "sinon": "^15.0.1",
         "ts-node": "^10.9.1",
-        "typescript": "^4.9.4",
+        "typescript": "^4.9.5",
         "uvu": "^0.5.6"
       }
     },
@@ -4872,9 +4872,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -8442,9 +8442,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "shx": "^0.3.4",
     "sinon": "^15.0.1",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4",
+    "typescript": "^4.9.5",
     "uvu": "^0.5.6"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,14 @@
       "import": "./dist/html.js",
       "require": "./dist/html.cjs"
     },
+    "./jsx-dev-runtime": {
+      "import": "./dist/jsx-runtime.js",
+      "require": "./dist/jsx-runtime.cjs"
+    },
+    "./jsx-dev-runtime.js": {
+      "import": "./dist/jsx-runtime.js",
+      "require": "./dist/jsx-runtime.cjs"
+    },
     "./jsx-runtime": {
       "import": "./dist/jsx-runtime.js",
       "require": "./dist/jsx-runtime.cjs"

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -55,7 +55,8 @@ export const impl: Partial<RendererImpl<Node, string>> = {
 			typeof tag === "string" &&
 			tag.toUpperCase() !== (node as Element).tagName
 		) {
-			console.error(`Expected <${tag}> while hydrating but found:`, node);
+			// TODO: consider pros and cons of hydration warnings
+			//console.error(`Expected <${tag}> while hydrating but found:`, node);
 			return undefined;
 		}
 
@@ -278,7 +279,8 @@ export const impl: Partial<RendererImpl<Node, string>> = {
 		if (hydrationData != null) {
 			let value = hydrationData.children.shift();
 			if (typeof value !== "string" || !value.startsWith(text)) {
-				console.error(`Expected "${text}" while hydrating but found:`, value);
+				// TODO: consider pros and cons of hydration warnings
+				//console.error(`Expected "${text}" while hydrating but found:`, value);
 			} else if (text.length < value.length) {
 				value = value.slice(text.length);
 				hydrationData.children.unshift(value);

--- a/test/hydration.tsx
+++ b/test/hydration.tsx
@@ -299,7 +299,7 @@ test("split text", async () => {
 	Assert.is(document.body.firstChild!.childNodes[1], button);
 });
 
-test("mismatched tag", () => {
+test.skip("mismatched tag", () => {
 	document.body.innerHTML = "<div>Hello</div>";
 	const Component = Sinon.fake(function () {
 		return <button onclick={onclick}>Click</button>;
@@ -311,7 +311,7 @@ test("mismatched tag", () => {
 	Assert.is(consoleError.callCount, 1);
 });
 
-test("mismatched text", () => {
+test.skip("mismatched text", () => {
 	document.body.innerHTML = "<button>Do not click</button>";
 	const button = document.body.firstChild as HTMLButtonElement;
 	const onclick = Sinon.fake();

--- a/test/types.tsx
+++ b/test/types.tsx
@@ -249,7 +249,7 @@ test("Props inference", () => {
 	function* MyComponent(
 		this: Context<typeof MyComponent>,
 		props: {message: string},
-	): any {
+	): unknown {
 		for (const props1 of this) {
 			// @ts-expect-error
 			props1.poop;
@@ -260,12 +260,27 @@ test("Props inference", () => {
 	async function* MyAsyncComponent(
 		this: Context<typeof MyAsyncComponent>,
 		props: {message: string},
-	): any {
+	): unknown {
 		for await (const props1 of this) {
 			// @ts-expect-error
 			props1.poop;
 			yield props1.message;
 		}
+	}
+
+	function* FunctionWithNoParameters(
+		this: Context<typeof FunctionWithNoParameters>,
+	): unknown {
+		for ({} of this) {
+			// pass
+		}
+
+		// @ts-expect-error
+		for (const {poop} of this) {
+			// pass
+		}
+
+		yield "hello";
 	}
 });
 


### PR DESCRIPTION
### Bug Fixes
- Allow `Context<typeof Component>` context types to be passed components with
	0 parameters.
- Alias jsx-dev-runtime to jsx-runtime for parcel/other bundlers
### Changes
- Disable hydration mismatch warnings until we figure out the expected DX for
	warning suppression.


Should be published under `0.5.2`