### PR TITLE
Provide example of when CSS object is preferred over string

### DIFF
--- a/website/documents/guides/06-special-props-and-tags.md
+++ b/website/documents/guides/06-special-props-and-tags.md
@@ -132,7 +132,7 @@ Therefore, the `children` prop should be treated as a black box, only to be rend
 The following props are specific to host elements for the HTML and DOM renderers.
 
 ### style
-The style prop can be used to add inline styles to an element. It can either be a CSS string, in which case it works exactly as it does in HTML, or it can also be an object, in which case CSS properties can be set individually.
+The style prop can be used to add inline styles to an element. It can either be a CSS string, in which case it works exactly as it does in HTML, or it can also be an object, in which case CSS properties can be set individually. The latter is helpful, for example, if you have an outside process that handles animating CSS styles and you don't want to reset them during a component re-render.
 
 ```jsx
 <div style="color: red"><span style={{"font-size": "16px"}}>Hello</span></div>


### PR DESCRIPTION
It should have been obvious, but this bit me for a couple of days as I tried to figure out why my animations weren't working properly. Maybe someone else might benefit from the example in the future :)