### PR TITLE
Allow overriding xmlns

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -12,10 +12,10 @@ const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
 
 export const impl: Partial<RendererImpl<Node, string>> = {
 	scope(
-    xmlns: string | undefined,
-    tag: string | symbol,
-    props: any
-  ): string | undefined {
+		xmlns: string | undefined,
+		tag: string | symbol,
+		props: any
+	): string | undefined {
 		// TODO: Should we handle xmlns???
 		switch (tag) {
 			case Portal:

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -73,7 +73,7 @@ export const impl: Partial<RendererImpl<Node, string>> = {
 		}
 
 		// TODO: extract props from nodes
-		return { props, children };
+		return {props, children};
 	},
 
 	patch(
@@ -105,7 +105,7 @@ export const impl: Partial<RendererImpl<Node, string>> = {
 						style.cssText = "";
 					}
 
-					for (const styleName in { ...(oldValue as {}), ...(value as {}) }) {
+					for (const styleName in {...(oldValue as {}), ...(value as {})}) {
 						const styleValue = value && (value as any)[styleName];
 						if (styleValue == null) {
 							style.removeProperty(styleName);
@@ -382,6 +382,6 @@ export const renderer = new DOMRenderer();
 
 declare global {
 	module Crank {
-		interface EventMap extends GlobalEventHandlersEventMap { }
+		interface EventMap extends GlobalEventHandlersEventMap {}
 	}
 }

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -14,9 +14,8 @@ export const impl: Partial<RendererImpl<Node, string>> = {
 	scope(
 		xmlns: string | undefined,
 		tag: string | symbol,
-		props: any
+		props: Record<string, any>
 	): string | undefined {
-		// TODO: Should we handle xmlns???
 		switch (tag) {
 			case Portal:
 				xmlns = undefined;
@@ -26,7 +25,7 @@ export const impl: Partial<RendererImpl<Node, string>> = {
 				break;
 		}
 
-		return props?.xmlns ?? xmlns;
+		return props.xmlns || xmlns;
 	},
 
 	create(
@@ -74,7 +73,7 @@ export const impl: Partial<RendererImpl<Node, string>> = {
 		}
 
 		// TODO: extract props from nodes
-		return {props, children};
+		return { props, children };
 	},
 
 	patch(
@@ -106,7 +105,7 @@ export const impl: Partial<RendererImpl<Node, string>> = {
 						style.cssText = "";
 					}
 
-					for (const styleName in {...(oldValue as {}), ...(value as {})}) {
+					for (const styleName in { ...(oldValue as {}), ...(value as {}) }) {
 						const styleValue = value && (value as any)[styleName];
 						if (styleValue == null) {
 							style.removeProperty(styleName);
@@ -383,6 +382,6 @@ export const renderer = new DOMRenderer();
 
 declare global {
 	module Crank {
-		interface EventMap extends GlobalEventHandlersEventMap {}
+		interface EventMap extends GlobalEventHandlersEventMap { }
 	}
 }

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -11,11 +11,14 @@ import {
 const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
 
 export const impl: Partial<RendererImpl<Node, string>> = {
-	scope(xmlns: string | undefined, tag: string | symbol): string | undefined {
+	scope(
+    xmlns: string | undefined,
+    tag: string | symbol,
+    props: any
+  ): string | undefined {
 		// TODO: Should we handle xmlns???
 		switch (tag) {
 			case Portal:
-			case "foreignObject":
 				xmlns = undefined;
 				break;
 			case "svg":
@@ -23,7 +26,7 @@ export const impl: Partial<RendererImpl<Node, string>> = {
 				break;
 		}
 
-		return xmlns;
+		return props.xmlns ?? xmlns;
 	},
 
 	create(

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -26,7 +26,7 @@ export const impl: Partial<RendererImpl<Node, string>> = {
 				break;
 		}
 
-		return props.xmlns ?? xmlns;
+		return props?.xmlns ?? xmlns;
 	},
 
 	create(

--- a/test/svg.tsx
+++ b/test/svg.tsx
@@ -77,9 +77,14 @@ test("foreignObject", () => {
 		document.body,
 	);
 	Assert.ok(document.body.firstChild instanceof SVGElement);
-	Assert.ok(
-		document.body.firstChild!.firstChild!.firstChild instanceof HTMLElement,
-	);
+
+	const foreignObject = document.body.firstChild!.firstChild!;
+	Assert.ok(foreignObject instanceof SVGElement);
+	Assert.is(foreignObject.namespaceURI, "http://www.w3.org/2000/svg");
+
+	const div = foreignObject.firstChild! as HTMLElement;
+	Assert.ok(div instanceof HTMLElement);
+	Assert.is(div.namespaceURI, "http://www.w3.org/1999/xhtml");
 });
 
 test("classes", () => {


### PR DESCRIPTION
A foreignObject element within an svg tag should not lose its SVG_NAMESPACE, because it is still an SVG element.

In addition, children of a foreignObject element should be allowed to specify their xmlns, since it is likely they will be of some other namespace than the foreignObject, e.g. a child div would need to be xhtml.

This PR allows such child elements to specify their xmlns, when needed.