### PR TITLE
Fix keyed components stopping cleanup

### DIFF
--- a/src/crank.ts
+++ b/src/crank.ts
@@ -2674,7 +2674,12 @@ function resumePropsIterator(ctx: ContextImpl): void {
 
 // TODO: async unmounting
 function unmountComponent(ctx: ContextImpl): void {
+	if (ctx.f & IsUnmounted) {
+		return;
+	}
+
 	clearEventListeners(ctx);
+
 	const callbacks = cleanupMap.get(ctx);
 	if (callbacks) {
 		cleanupMap.delete(ctx);

--- a/src/crank.ts
+++ b/src/crank.ts
@@ -1039,7 +1039,7 @@ function diffChildren<TNode, TScope, TRoot extends TNode, TResult>(
 	// cleanup remaining retainers
 	for (; oi < oldLength; oi++) {
 		const ret = oldRetained[oi];
-		if (typeof ret === "object" && typeof ret.el.key === "undefined") {
+		if (typeof ret === "object") {
 			(graveyard = graveyard || []).push(ret);
 		}
 	}

--- a/test/keys.tsx
+++ b/test/keys.tsx
@@ -732,4 +732,32 @@ test("duplicate keys", () => {
 	}
 });
 
+// https://github.com/bikeshaving/crank/issues/267
+test("component unmounts with key", () => {
+	const fn = Sinon.fake();
+	function *Component() {
+		this.cleanup(() => {
+			fn();
+		});
+		for ({} of this) {
+			yield <div>Hello</div>;
+		}
+
+		fn();
+	}
+
+	renderer.render(
+		<div>
+			<Component crank-key="1" />
+		</div>,
+		document.body,
+	);
+	renderer.render(
+		<div>{null}</div>,
+		document.body,
+	);
+
+	Assert.is(fn.callCount, 2);
+});
+
 test.run();


### PR DESCRIPTION
Fixes https://github.com/bikeshaving/crank/issues/267.

Seems like an overzealous condition in the cleanup branch of the diffing process. I think the bug also only happens when the component element has no siblings, which is not an edge case in the JSX world, but something we don’t have a lot of tests for.

I have tried blaming the branch but it seems to have been preserved since 0.4.0 before I stopped checking. In any case, removing the guard is probably harmless. I have made `unmountComponent()` idempotent in any case. 