### PR TITLE
React style compat

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -74,7 +74,7 @@ export default [
 		output: {
 			format: "esm",
 			dir: "dist",
-			chunkFileNames: "[hash].js",
+			preserveModules: true,
 			sourcemap: true,
 			exports: "named",
 		},
@@ -85,7 +85,7 @@ export default [
 		output: {
 			format: "cjs",
 			dir: "dist",
-			chunkFileNames: "[hash].cjs",
+			preserveModules: true,
 			entryFileNames: "[name].cjs",
 			sourcemap: true,
 			exports: "named",

--- a/src/_css.ts
+++ b/src/_css.ts
@@ -1,0 +1,76 @@
+/**
+ * CSS utility functions for style property transformation.
+ *
+ * This module handles camelCase to kebab-case conversion and automatic
+ * px unit conversion for numeric CSS values, making Crank more React-compatible.
+ */
+
+/**
+ * Converts camelCase CSS property names to kebab-case.
+ * Handles vendor prefixes correctly (WebkitTransform -> -webkit-transform).
+ */
+export function camelToKebabCase(str: string): string {
+	// Handle vendor prefixes that start with capital letters (WebkitTransform -> -webkit-transform)
+	if (/^[A-Z]/.test(str)) {
+		return `-${str.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`).slice(1)}`;
+	}
+	// Handle normal camelCase (fontSize -> font-size)
+	return str.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
+}
+
+/**
+ * CSS properties that should remain unitless when given numeric values.
+ * Based on React's list of unitless properties.
+ */
+export const UNITLESS_PROPERTIES = new Set([
+	"animation-iteration-count",
+	"aspect-ratio",
+	"border-image-outset",
+	"border-image-slice",
+	"border-image-width",
+	"box-flex",
+	"box-flex-group",
+	"box-ordinal-group",
+	"column-count",
+	"columns",
+	"flex",
+	"flex-grow",
+	"flex-positive",
+	"flex-shrink",
+	"flex-negative",
+	"flex-order",
+	"font-weight",
+	"grid-area",
+	"grid-column",
+	"grid-column-end",
+	"grid-column-span",
+	"grid-column-start",
+	"grid-row",
+	"grid-row-end",
+	"grid-row-span",
+	"grid-row-start",
+	"line-height",
+	"opacity",
+	"order",
+	"orphans",
+	"tab-size",
+	"widows",
+	"z-index",
+	"zoom",
+]);
+
+/**
+ * Formats CSS property values, automatically adding "px" to numeric values
+ * for properties that are not unitless.
+ */
+export function formatStyleValue(name: string, value: unknown): string {
+	if (typeof value === "number") {
+		// If the property should remain unitless, keep the number as-is
+		if (UNITLESS_PROPERTIES.has(name)) {
+			return String(value);
+		}
+		// Otherwise, append "px" for numeric values
+		return `${value}px`;
+	}
+	return String(value);
+}

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -6,6 +6,7 @@ import {
 	Renderer,
 	RenderAdapter,
 } from "./crank.js";
+import {camelToKebabCase, formatStyleValue} from "./_css.js";
 
 const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
 
@@ -286,32 +287,36 @@ export const adapter: Partial<RenderAdapter<Node, string, Element>> = {
 						}
 
 						for (const styleName in {...oldValue, ...value}) {
+							const cssName = camelToKebabCase(styleName);
 							const styleValue = value && (value as any)[styleName];
 							if (styleValue == null) {
-								if (isHydrating && style.getPropertyValue(styleName) !== "") {
+								if (isHydrating && style.getPropertyValue(cssName) !== "") {
 									emitHydrationWarning(
 										name,
 										quietProps,
 										null,
-										style.getPropertyValue(styleName),
+										style.getPropertyValue(cssName),
 										element,
 										`style.${styleName}`,
 									);
 								}
-								style.removeProperty(styleName);
-							} else if (style.getPropertyValue(styleName) !== styleValue) {
-								// TODO: hydration warnings for style props
-								//if (isHydrating) {
-								//	emitHydrationWarning(
-								//		name,
-								//		quietProps,
-								//		styleValue,
-								//		style.getPropertyValue(styleName),
-								//		element,
-								//		`style.${styleName}`,
-								//	);
-								//}
-								style.setProperty(styleName, styleValue);
+								style.removeProperty(cssName);
+							} else {
+								const formattedValue = formatStyleValue(cssName, styleValue);
+								if (style.getPropertyValue(cssName) !== formattedValue) {
+									// TODO: hydration warnings for style props
+									//if (isHydrating) {
+									//	emitHydrationWarning(
+									//		name,
+									//		quietProps,
+									//		formattedValue,
+									//		style.getPropertyValue(cssName),
+									//		element,
+									//		`style.${styleName}`,
+									//	);
+									//}
+									style.setProperty(cssName, formattedValue);
+								}
 							}
 						}
 					}

--- a/src/html.ts
+++ b/src/html.ts
@@ -1,5 +1,6 @@
 import {Portal, Renderer} from "./crank.js";
 import type {ElementValue, RenderAdapter} from "./crank.js";
+import {camelToKebabCase, formatStyleValue} from "./_css.js";
 
 const voidTags = new Set([
 	"area",
@@ -43,7 +44,9 @@ function printStyleObject(style: Record<string, any>): string {
 	const cssStrings = [];
 	for (const [name, value] of Object.entries(style)) {
 		if (value != null) {
-			cssStrings.push(`${name}:${value};`);
+			const cssName = camelToKebabCase(name);
+			const cssValue = formatStyleValue(cssName, value);
+			cssStrings.push(`${cssName}:${cssValue};`);
 		}
 	}
 

--- a/test/dom.tsx
+++ b/test/dom.tsx
@@ -554,6 +554,58 @@ test("removing styles", () => {
 	Assert.is(div.style.backgroundColor, "");
 });
 
+test("style object camelCase", () => {
+	renderer.render(
+		<div
+			style={{
+				fontSize: "16px",
+				backgroundColor: "red",
+				marginTop: "10px",
+				borderRadius: "4px",
+				WebkitTransform: "rotate(45deg)",
+			}}
+		/>,
+		document.body,
+	);
+
+	// Check HTML output has kebab-case properties
+	// Note: Browser normalizes -webkit-transform to transform in innerHTML
+	const expectedHTML =
+		'<div style="font-size: 16px; background-color: red; margin-top: 10px; border-radius: 4px; transform: rotate(45deg);"></div>';
+	Assert.is(document.body.innerHTML, expectedHTML);
+
+	// Check DOM element properties are accessible via camelCase
+	const div = document.body.firstChild as HTMLElement;
+	Assert.is(div.style.fontSize, "16px");
+	Assert.is(div.style.backgroundColor, "red");
+	Assert.is(div.style.marginTop, "10px");
+	Assert.is(div.style.borderRadius, "4px");
+	// Browser normalizes WebkitTransform to transform
+	Assert.is(div.style.transform, "rotate(45deg)");
+});
+
+test("style object numeric values with px conversion", () => {
+	renderer.render(
+		<div
+			style={{width: 100, height: 200, opacity: 0.5, zIndex: 10, fontSize: 16}}
+		/>,
+		document.body,
+	);
+
+	// Check HTML output - numeric values should have px added except for unitless properties
+	const expectedHTML =
+		'<div style="width: 100px; height: 200px; opacity: 0.5; z-index: 10; font-size: 16px;"></div>';
+	Assert.is(document.body.innerHTML, expectedHTML);
+
+	// Check DOM element properties
+	const div = document.body.firstChild as HTMLElement;
+	Assert.is(div.style.width, "100px");
+	Assert.is(div.style.height, "200px");
+	Assert.is(div.style.opacity, "0.5");
+	Assert.is(div.style.zIndex, "10");
+	Assert.is(div.style.fontSize, "16px");
+});
+
 test("uncontrolled props", () => {
 	const input = renderer.render(<input value="hello" />, document.body) as any;
 	Assert.ok(input instanceof HTMLInputElement);

--- a/test/html.tsx
+++ b/test/html.tsx
@@ -83,6 +83,50 @@ test("styles string", () => {
 	);
 });
 
+test("styles camelCase", () => {
+	Assert.is(
+		renderer.render(
+			<div
+				style={{
+					fontSize: "16px",
+					backgroundColor: "red",
+					marginTop: "10px",
+					borderRadius: "4px",
+					WebkitTransform: "rotate(45deg)",
+				}}
+			/>,
+		),
+		'<div style="font-size:16px;background-color:red;margin-top:10px;border-radius:4px;-webkit-transform:rotate(45deg);"></div>',
+	);
+
+	// Test mixed camelCase and kebab-case
+	Assert.is(
+		renderer.render(
+			<div
+				style={{fontSize: "16px", "background-color": "blue", marginTop: "5px"}}
+			/>,
+		),
+		'<div style="font-size:16px;background-color:blue;margin-top:5px;"></div>',
+	);
+});
+
+test("styles numeric values with px conversion", () => {
+	Assert.is(
+		renderer.render(
+			<div
+				style={{
+					width: 100,
+					height: 200,
+					opacity: 0.5,
+					zIndex: 10,
+					fontSize: 16,
+				}}
+			/>,
+		),
+		'<div style="width:100px;height:200px;opacity:0.5;z-index:10;font-size:16px;"></div>',
+	);
+});
+
 test("class and className", () => {
 	Assert.is(
 		renderer.render(


### PR DESCRIPTION
While Claude was working on the documentation for 0.7, it kept making mistakes related to using camelCased style props, and `px`-less units. I asked if we should implement React-style style props for compatibility and it did it while I went to heat up some egg rolls because auto-edit was on.