### PR TITLE
Fix URL property comparison for src and href attributes

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -462,7 +462,24 @@ export const adapter: Partial<RenderAdapter<Node, string, Element>> = {
 						) &&
 						isWritableProperty(element, name)
 					) {
-						if ((element as any)[name] !== value || oldValue === undefined) {
+						// For URL properties like src and href, the DOM property returns the
+						// resolved absolute URL. We need to resolve the prop value the same way
+						// to compare correctly.
+						let domValue = (element as any)[name];
+						let propValue = value;
+						if (
+							(name === "src" || name === "href") &&
+							typeof value === "string" &&
+							typeof domValue === "string"
+						) {
+							try {
+								propValue = new URL(value, element.baseURI).href;
+							} catch {
+								// Invalid URL, use original value for comparison
+							}
+						}
+
+						if (propValue !== domValue || oldValue === undefined) {
 							if (
 								isHydrating &&
 								typeof (element as any)[name] === "string" &&


### PR DESCRIPTION
## Summary
- Fix unnecessary DOM updates when using relative URLs for `src` and `href` attributes
- The DOM property returns the resolved absolute URL (e.g., `http://localhost/path`), while the prop value may be relative (`/path`)
- Now we resolve the prop value using `new URL(value, element.baseURI)` before comparing, maintaining the "DOM as source of truth" philosophy

This completes the fix from #181 - the original fix compared `element.src !== value` to avoid unnecessary updates, but didn't account for URL resolution causing `element.src` to return an absolute URL while the prop is relative.

## Test plan
- [x] Added tests for relative `src` on iframe
- [x] Added tests for relative `href` on anchor
- [x] Added tests for absolute URLs
- [x] All 43 DOM tests pass
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)