### PR TITLE
feat: allow spaces in class object syntax keys

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -370,17 +370,21 @@ export const adapter: Partial<RenderAdapter<Node, string, Element>> = {
 							? element.getAttribute("class")
 							: undefined;
 
-						for (const className in {...oldValue, ...value}) {
-							const classValue = value && value[className];
+						for (const classNames in {...oldValue, ...value}) {
+							const classValue = value && value[classNames];
+							// Support space-separated class names like "foo bar baz"
+							const classes = classNames.split(/\s+/).filter(Boolean);
 							if (classValue) {
-								element.classList.add(className);
-								if (hydratingClasses && hydratingClasses.has(className)) {
-									hydratingClasses.delete(className);
-								} else if (isHydrating) {
-									shouldIssueWarning = true;
+								element.classList.add(...classes);
+								for (const className of classes) {
+									if (hydratingClasses && hydratingClasses.has(className)) {
+										hydratingClasses.delete(className);
+									} else if (isHydrating) {
+										shouldIssueWarning = true;
+									}
 								}
 							} else {
-								element.classList.remove(className);
+								element.classList.remove(...classes);
 							}
 						}
 

--- a/src/html.ts
+++ b/src/html.ts
@@ -70,6 +70,18 @@ function printAttrs(props: Record<string, any>): string {
 			}
 
 			attrs.push(`class="${escape(value)}"`);
+		} else if (name === "class") {
+			if (typeof value === "string") {
+				attrs.push(`class="${escape(value)}"`);
+			} else if (typeof value === "object" && value !== null) {
+				// class={{"foo bar": true, "baz": false}} syntax
+				const classes = Object.keys(value)
+					.filter((k) => value[k])
+					.join(" ");
+				if (classes) {
+					attrs.push(`class="${escape(classes)}"`);
+				}
+			}
 		} else {
 			if (name.startsWith("attr:")) {
 				name = name.slice("attr:".length);

--- a/test/dom.tsx
+++ b/test/dom.tsx
@@ -777,6 +777,80 @@ test("object classnames object to string transition", () => {
 	Assert.not.ok(element.classList.contains("another-class"));
 });
 
+test("object classnames with space-separated keys", () => {
+	renderer.render(
+		<div
+			class={{
+				"w-5 h-5 rounded-full flex items-center justify-center": true,
+				"bg-green-500 text-white": true,
+				"bg-gray-200 text-gray-400": false,
+			}}
+		>
+			Test
+		</div>,
+		document.body,
+	);
+
+	const element = document.querySelector("div")!;
+	// All classes from truthy keys should be present
+	Assert.ok(element.classList.contains("w-5"));
+	Assert.ok(element.classList.contains("h-5"));
+	Assert.ok(element.classList.contains("rounded-full"));
+	Assert.ok(element.classList.contains("flex"));
+	Assert.ok(element.classList.contains("items-center"));
+	Assert.ok(element.classList.contains("justify-center"));
+	Assert.ok(element.classList.contains("bg-green-500"));
+	Assert.ok(element.classList.contains("text-white"));
+	// Classes from falsy keys should not be present
+	Assert.not.ok(element.classList.contains("bg-gray-200"));
+	Assert.not.ok(element.classList.contains("text-gray-400"));
+});
+
+test("object classnames with space-separated keys update", () => {
+	renderer.render(
+		<div
+			class={{
+				"base-class shared": true,
+				"variant-a extra-a": true,
+				"variant-b extra-b": false,
+			}}
+		>
+			Test
+		</div>,
+		document.body,
+	);
+
+	let element = document.querySelector("div")!;
+	Assert.ok(element.classList.contains("base-class"));
+	Assert.ok(element.classList.contains("shared"));
+	Assert.ok(element.classList.contains("variant-a"));
+	Assert.ok(element.classList.contains("extra-a"));
+	Assert.not.ok(element.classList.contains("variant-b"));
+	Assert.not.ok(element.classList.contains("extra-b"));
+
+	// Update: swap which variant is active
+	renderer.render(
+		<div
+			class={{
+				"base-class shared": true,
+				"variant-a extra-a": false,
+				"variant-b extra-b": true,
+			}}
+		>
+			Test
+		</div>,
+		document.body,
+	);
+
+	element = document.querySelector("div")!;
+	Assert.ok(element.classList.contains("base-class"));
+	Assert.ok(element.classList.contains("shared"));
+	Assert.not.ok(element.classList.contains("variant-a"));
+	Assert.not.ok(element.classList.contains("extra-a"));
+	Assert.ok(element.classList.contains("variant-b"));
+	Assert.ok(element.classList.contains("extra-b"));
+});
+
 test("relative src should not cause unnecessary updates", () => {
 	// Track how many times src property is set
 	let srcSetCount = 0;

--- a/test/html.tsx
+++ b/test/html.tsx
@@ -147,6 +147,30 @@ test("class and className", () => {
 	);
 });
 
+test("class object syntax", () => {
+	Assert.is(
+		renderer.render(
+			<div class={{active: true, disabled: false, primary: true}} />,
+		),
+		'<div class="active primary"></div>',
+	);
+});
+
+test("class object syntax with space-separated keys", () => {
+	Assert.is(
+		renderer.render(
+			<div
+				class={{
+					"w-5 h-5 rounded-full": true,
+					"bg-green-500 text-white": true,
+					"bg-gray-200 text-gray-400": false,
+				}}
+			/>,
+		),
+		'<div class="w-5 h-5 rounded-full bg-green-500 text-white"></div>',
+	);
+});
+
 test("null", () => {
 	Assert.is(renderer.render(null), "");
 });


### PR DESCRIPTION
## Summary

Support space-separated class names in the class object syntax:

```jsx
<div class={{
  "w-5 h-5 rounded-full": true,
  "bg-green-500 text-white": isActive,
  "bg-gray-200 text-gray-400": !isActive
}} />
```

This is more ergonomic than listing each class separately when using utility-first CSS frameworks like Tailwind.

## Changes

- DOM renderer: split keys on whitespace before `classList.add/remove`
- HTML renderer: add support for class object syntax (was missing)
- Add tests for both renderers

## Test Plan

- [x] All existing tests pass
- [x] New tests for space-separated class keys in DOM renderer
- [x] New tests for class object syntax in HTML renderer
- [x] TypeScript compiles
- [x] ESLint passes

Implements #317

Co-Authored-By: Claude <noreply@anthropic.com>