### PR TITLE
add componentId

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -5,7 +5,6 @@ import {
 	Portal,
 	Renderer,
 	RenderAdapter,
-	RendererOptions,
 } from "./crank.js";
 import {camelToKebabCase, formatStyleValue} from "./_css.js";
 import {REACT_SVG_PROPS} from "./_svg.js";
@@ -834,8 +833,8 @@ export const adapter: Partial<RenderAdapter<Node, string, Node>> = {
 };
 
 export class DOMRenderer extends Renderer<Node, string, Element> {
-	constructor(options?: RendererOptions) {
-		super(adapter, options);
+	constructor() {
+		super(adapter);
 	}
 
 	render(

--- a/src/html.ts
+++ b/src/html.ts
@@ -1,5 +1,5 @@
 import {Portal, Renderer} from "./crank.js";
-import type {ElementValue, RenderAdapter, RendererOptions} from "./crank.js";
+import type {ElementValue, RenderAdapter} from "./crank.js";
 import {camelToKebabCase, formatStyleValue} from "./_css.js";
 import {REACT_SVG_PROPS} from "./_svg.js";
 
@@ -226,8 +226,8 @@ export const impl: Partial<RenderAdapter<TextNode, string, TextNode, string>> =
 	};
 
 export class HTMLRenderer extends Renderer<TextNode, string, any, string> {
-	constructor(options?: RendererOptions) {
-		super(impl, options);
+	constructor() {
+		super(impl);
 	}
 }
 

--- a/test/component-id.tsx
+++ b/test/component-id.tsx
@@ -91,7 +91,7 @@ test("different components from the same HOC get different IDs", () => {
 		return <div />;
 	});
 
-	const ComponentC = Hoc((props, ctx) => {
+	const ComponentC = Hoc((_props: unknown, ctx: Context) => {
 		idC = ctx.componentId;
 		return <div />;
 	});
@@ -106,6 +106,39 @@ test("different components from the same HOC get different IDs", () => {
 	);
 	Assert.ok(idA !== idB);
 	Assert.ok(idA !== idC);
+});
+
+test("different components inside the same HOC get different IDs", () => {
+	let idA: string | undefined;
+	let idB: string | undefined;
+
+	function ComponentAInner(this: Context) {
+		return <div />;
+	}
+
+	function ComponentBInner(this: Context) {
+		return <div />;
+	}
+
+	function Hoc(Component: any) {
+		return function Wrapped(this: Context, props: any) {
+			if (Component === ComponentAInner) idA = this.componentId;
+			if (Component === ComponentBInner) idB = this.componentId;
+			return <Component {...props} />;
+		};
+	}
+
+	const ComponentA = Hoc(ComponentAInner);
+	const ComponentB = Hoc(ComponentBInner);
+
+	renderer.render(
+		<div>
+			<ComponentA />
+			<ComponentB />
+		</div>,
+		document.body,
+	);
+	Assert.ok(idA !== idB);
 });
 
 test("componentId is stable across re-renders in a generator component", () => {
@@ -126,13 +159,13 @@ test("componentId is stable across re-renders in a generator component", () => {
 	Assert.is(ids[1], ids[2]);
 });
 
-test("stable mode produces same ID across separate renderer instances", () => {
+test("same ID across separate renderer instances", () => {
 	function MyComponent(this: Context) {
 		return <div>{this.componentId}</div>;
 	}
 
-	const rendererA = new DOMRenderer({componentIdMode: "stable"});
-	const rendererB = new DOMRenderer({componentIdMode: "stable"});
+	const rendererA = new DOMRenderer();
+	const rendererB = new DOMRenderer();
 
 	const rootA = document.createElement("div");
 	const rootB = document.createElement("div");
@@ -148,7 +181,7 @@ test("stable mode produces same ID across separate renderer instances", () => {
 	rendererB.render(null, rootB);
 });
 
-test("fast mode IDs increment per renderer", () => {
+test("different components in same renderer get different IDs", () => {
 	let idA: string | undefined;
 	let idB: string | undefined;
 


### PR DESCRIPTION
Closes #325 

- Adds  to components
- Adds renderer options with  to control id generation
- adds tests to verify fast and stable mode produce valid identifiers

The reason I think `fast`  is valuable is that hashing the function.toString() can get expensive. It is also a warning in some security analysis tools.  `fast` produces monotonic IDs, which will be internally stable but not stable across renders or instances (order could change which number a component gets). The default mode is `fast`, but I'm not married to this.