### PR TITLE
Don't mutate caller's props object in createElement

### DIFF
--- a/src/crank.ts
+++ b/src/crank.ts
@@ -270,9 +270,9 @@ export function createElement<TTag extends Tag>(
 	}
 
 	if (children.length > 1) {
-		(props as TagProps<TTag>).children = children;
+		props = {...props as TagProps<TTag>, children};
 	} else if (children.length === 1) {
-		(props as TagProps<TTag>).children = children[0];
+		props = {...props as TagProps<TTag>, children: children[0]};
 	}
 
 	return new Element(tag, props as TagProps<TTag>);

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -6,7 +6,10 @@ import {createElement} from "./crank.js";
 function jsxAdapter(tag: any, props: Record<string, any>, key: any) {
 	// The new JSX transform extracts the key from props for performance reasons,
 	// but key is not a special property in Crank.
-	props.key = key;
+	if (key != null) {
+		props.key = key;
+	}
+
 	return createElement(tag, props);
 }
 


### PR DESCRIPTION
createElement was mutating the incoming props to assign children, which causes circular references when callers reuse the same props object across calls (e.g. vanity-h's proxy-based hyperscript DSL). Spread into a fresh object instead, only when children are present.

Also guard the key assignment in jsxAdapter behind a null check to avoid unconditionally adding key: undefined to every props object, which causes unnecessary hidden class transitions.

Fixes #356