### PR TITLE
Preserve the break between adjacent text lines in the jsx template (#359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@
   proxy-based hyperscript DSL) no longer causes circular references. The JSX
   automatic runtime also only assigns `key` when it is present.
 
+- **Fix `jsx` template dropping the break between adjacent text lines** (#359)
+  Whitespace between two text runs is now preserved verbatim, so multi-line
+  prose no longer loses the break at its line ends (`jsx\`<p>alpha⏎beta</p>\``
+  yields `alpha⏎beta`, not `alphabeta`). Unlike JSX, which collapses the run to a
+  single space, the template keeps the author’s whitespace (newlines, blank
+  lines, and the indentation between text): it renders as a space in normal flow
+  and as a real line break in a `<pre>`. Whitespace adjacent to an element, an
+  expression, or the template edge is still stripped as layout.
+
 ## [0.7.9] - 2026-03-31
 ### Performance
 - **Make User Timing API profiling opt-in via `setProfiling()`**

--- a/src/jsx-tag.ts
+++ b/src/jsx-tag.ts
@@ -183,6 +183,12 @@ export function parse(spans: ArrayLike<string>): ParseResult {
 									//   jsx` \
 									//   `
 									before = before.slice(0, -1);
+								} else if (before && end < span.length && span[end] !== "<") {
+									// Whitespace between two text runs is preserved verbatim, unlike
+									// JSX, which collapses it to a space. Whitespace touching an
+									// element, expression, or template edge is layout and gets
+									// stripped below, hence the guard: text before, text after.
+									before += newline;
 								} else {
 									before = before.replace(/\s*$/, "");
 								}

--- a/test/jsx-tag.ts
+++ b/test/jsx-tag.ts
@@ -62,6 +62,76 @@ test("newlines and whitespace", () => {
 	);
 });
 
+test("text-text newlines are preserved as a newline (#359)", () => {
+	// A newline between two text runs is preserved as a single newline. Unlike
+	// JSX, which collapses it to a space, the template has no formatter reflowing
+	// it, so the line break is the author's intent: it renders as a space in
+	// normal flow and as a real line break in a `<pre>`.
+	Assert.equal(
+		jsx`<p>alpha
+beta</p>`,
+		createElement("p", null, "alpha\n", "beta"),
+	);
+	// Everything between two text runs is preserved verbatim: the blank line
+	// stays two newlines, and the indentation before `three` is kept.
+	Assert.equal(
+		jsx`<p>one
+two
+
+   three</p>`,
+		createElement("p", null, "one\n", "two\n\n   ", "three"),
+	);
+	// A newline adjacent to an element is still stripped as layout: only the
+	// text-text break is kept.
+	Assert.equal(
+		jsx`<p>alpha
+<b>x</b>
+beta</p>`,
+		createElement("p", null, "alpha", createElement("b", null, "x"), "beta"),
+	);
+});
+
+test("preserves significant whitespace verbatim (diverges from JSX collapse)", () => {
+	// Interior spaces within a line are preserved, not collapsed.
+	Assert.equal(jsx`<p>a   b</p>`, createElement("p", null, "a   b"));
+	// A newline before an expression is stripped as layout — the expression
+	// boundary is structural, like an element.
+	Assert.equal(
+		jsx`<p>a
+${"X"}</p>`,
+		createElement("p", null, "a", "X"),
+	);
+	// Leading whitespace on the first line of a text run is preserved (it is not
+	// indentation following a newline); the break to the next line is kept.
+	Assert.equal(
+		jsx`<p>  Hello
+World</p>`,
+		createElement("p", null, "  Hello\n", "World"),
+	);
+	// Whitespace-only text between elements is preserved on a single line ...
+	Assert.equal(
+		jsx`<p><b>x</b>   <i>y</i></p>`,
+		createElement(
+			"p",
+			null,
+			createElement("b", null, "x"),
+			"   ",
+			createElement("i", null, "y"),
+		),
+	);
+	// ... and removed entirely when it spans a newline.
+	Assert.equal(
+		jsx`<p><b>x</b>
+<i>y</i></p>`,
+		createElement(
+			"p",
+			null,
+			createElement("b", null, "x"),
+			createElement("i", null, "y"),
+		),
+	);
+});
+
 test("string props", () => {
 	Assert.equal(jsx`<p class="foo" />`, createElement("p", {class: "foo"}));
 	Assert.equal(


### PR DESCRIPTION
Fixes #359.

## The bug
The `jsx` tagged template dropped the whitespace **between two text runs** entirely, so a line break in multi-line prose vanished:

```js
jsx`<p>alpha
beta</p>`
// before: "<p>alphabeta</p>"
// after:  "<p>alpha\nbeta</p>"
```

## The fix
Whitespace between two text runs is now **preserved verbatim** — rather than dropped (the bug) or collapsed to a space (standard JSX). In `src/jsx-tag.ts` the children tokenizer, on a newline that follows non-empty text whose next significant character is also text (not `<`, and not the end of a span where an expression follows), appends the whitespace run to the preceding text as-is instead of discarding it. Only whitespace flanked by a non-text boundary — an element, an expression, or the template edge — is stripped.

## Why preserve, and not match JSX?
Standard JSX collapses a text–text newline to a space. That rule exists to make source **safe to reformat**: a formatter (Prettier, tsc) rewraps JSX text to a print width, so the newline you typed can't be significant — otherwise every reflow would change the output.

That rationale doesn't apply here. **Prettier has no embedded formatter for the `jsx` tag** — it leaves the template interior byte-for-byte. Nothing reflows the template, so a line break in it is the author's deliberate whitespace, not disposable layout. Preserving it is both more faithful and more expressive:

- It renders as a space in normal flow (the browser collapses it) and as a **real line break inside `<pre>`**, where collapsing to a space would be wrong. Because the indentation between text is kept too, a `<pre>`'s own formatting now survives without reaching for `${...}`.
- Anything still not expressible literally (e.g. whitespace hugging the `<pre>` tags) stays reachable through `${...}` interpolation, which bypasses whitespace handling entirely — the same escape hatch JSX offers with `{"\n"}`.

So this deliberately **diverges from JSX** for the tagged-template context. (The `html` alias shares this function; note Prettier *does* reflow `` html`` `` templates as HTML — a separate, pre-existing mismatch not addressed here.)

## Whitespace behavior

| source | result |
|---|---|
| `alpha⏎beta` (text–text) | `"alpha\n"`, `"beta"` |
| `alpha⏎⏎   beta` (blank line + indent) | `"alpha\n\n   "`, `"beta"` (verbatim) |
| `a   b` (interior run) | `"a   b"` (preserved) |
| `alpha⏎<b/>` / `<b/>⏎beta` (element-adjacent) | stripped |
| `a⏎${x}` (expression-adjacent) | stripped |
| `<b/>   <i/>` (ws-only, one line) | `"   "` preserved |
| `<b/>⏎<i/>` (ws-only, across a newline) | removed |

The scoping is what keeps this safe: only whitespace flanked by text on both sides is preserved, so it always lives inside a single text run and can never inject a whitespace text node between elements (which would cause inline-element gaps or invalid `<table>`/`<tr>` children). Element-, expression-, and edge-adjacent whitespace is stripped as layout, unchanged.

## Tests
Rewrote the `#359` regression and whitespace blocks in `test/jsx-tag.ts` to assert the preserve behavior. Full suite (598) passes; `tsc --noEmit`, ESLint, and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
