### PR TITLE
ci: build @b9g/crank before the website/crankdown build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,6 +80,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - run: bun install
+      # crankdown imports @b9g/crank/standalone, which resolves through crank's
+      # exports map into ./dist/. Build it before the website/crankdown build.
+      - run: bun run build
       - run: bun install
         working-directory: website
       - name: Install Bikeshed


### PR DESCRIPTION
Fixes the `Deploy Website` failure on main.

## What broke
`Deploy Website` gates on `needs: [lint, ...]`, so it had been **skipped** while main's lint was red. Landing the lint fix unblocked it, and it immediately failed:

```
packages/crankdown/src/index.ts:1:23: ERROR: Could not resolve "@b9g/crank/standalone"
```

crankdown imports `@b9g/crank/standalone`; esbuild resolves that through crank's `exports` map into `./dist/` — and the deploy job never runs a root build, so `dist/` doesn't exist.

## Fix
Add `bun run build` to the deploy job before the website build. The separate `Build` job already runs this and passes, so it's known-good in CI.

## Deeper issue (not fixed here)
libuild's `packages: "external"` externalizes the bare `@b9g/crank` but **not the subpath** `@b9g/crank/standalone`. So esbuild *bundles* Crank into crankdown instead of honoring the `peerDependencies` entry crankdown declares. That likely means published `@b9g/crankdown@0.1.2` has Crank inlined. Worth a libuild fix (`external: [dep, `${dep}/*`]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)