### PR TITLE
website: replace removed Context.flush() with Context.after()

### DIFF
--- a/website/src/utils/virtualizer.ts
+++ b/website/src/utils/virtualizer.ts
@@ -30,10 +30,10 @@ function useVirtualizerBase<
 	const afterUpdate = () => {
 		virtualizer._willUpdate();
 		// TODO: Is this necessary?
-		_this.flush(afterUpdate);
+		_this.after(afterUpdate);
 	};
 
-	_this.flush(afterUpdate);
+	_this.after(afterUpdate);
 
 	return virtualizer;
 }


### PR DESCRIPTION
#366 removed the deprecated `Context.flush()` (renamed to `Context.after()` in 0.7), but `website/src/utils/virtualizer.ts` still calls it:

```ts
_this.after(() => { unmount = virtualizer._didMount(); });   // uses after
...
const afterUpdate = () => {
    virtualizer._willUpdate();
    _this.flush(afterUpdate);   // ...and also uses flush
};
_this.flush(afterUpdate);
```

It calls **both**, treating `flush` and `after` as two different hooks. They were always the same one — `flush` was just the old name.

**This is a live runtime break on main:** `_this.flush is not a function` as soon as the virtualizer runs. CI didn't catch it because the website is bundled with esbuild, which strips types without typechecking them.

Straight rename. The recursive re-registration is just the "run after every render" pattern and works identically with `after`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)