### PR TITLE
Replace playwright-test/uvu with the libuild test runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install browser
         run: bunx playwright install --with-deps ${{ matrix.browser }}
       - name: Run core tests
-        run: bunx libuild test "test/*.tsx" "test/*.ts" --platform ${{ matrix.browser }}
+        run: bunx libuild test test/ --platform ${{ matrix.browser }}
       - name: Run eslint plugin tests
         run: bun run test:eslint
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,11 +43,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: oven-sh/setup-bun@v2
       - run: bun install
-      - name: Install WebKit dependencies
-        if: matrix.browser == 'webkit'
-        run: bunx playwright install-deps webkit
+      - name: Install browser
+        run: bunx playwright install --with-deps ${{ matrix.browser }}
       - name: Run core tests
-        run: bun run test:core -- --browser ${{ matrix.browser }}
+        run: bunx libuild test "test/*.tsx" "test/*.ts" --platform ${{ matrix.browser }}
       - name: Run eslint plugin tests
         run: bun run test:eslint
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@b9g/crank",
       "devDependencies": {
-        "@b9g/libuild": "0.2.18",
+        "@b9g/libuild": "^0.2.19",
         "@types/node": "^22.14.0",
         "@types/sinon": "^17.0.4",
         "@typescript-eslint/eslint-plugin": "^8.29.1",
@@ -21,7 +21,7 @@
         "typescript": "^5.8.3",
       },
     },
-    "packages/astro-crank": {
+    "node_modules/.bun/@b9g+crank@root/node_modules/@b9g/crank/packages/astro-crank": {
       "name": "astro-crank",
       "version": "0.3.0",
       "peerDependencies": {
@@ -29,7 +29,7 @@
         "astro": "^4.0.0 || ^5.0.0",
       },
     },
-    "packages/crank-codemods": {
+    "node_modules/.bun/@b9g+crank@root/node_modules/@b9g/crank/packages/crank-codemods": {
       "name": "@b9g/crank-codemods",
       "version": "0.1.0",
       "dependencies": {
@@ -41,7 +41,7 @@
         "typescript": "^5.0.0",
       },
     },
-    "packages/crankdown": {
+    "node_modules/.bun/@b9g+crank@root/node_modules/@b9g/crank/packages/crankdown": {
       "name": "@b9g/crankdown",
       "version": "0.1.3",
       "devDependencies": {
@@ -55,14 +55,14 @@
         "marked": ">=5.0.0",
       },
     },
-    "packages/create-crank": {
+    "node_modules/.bun/@b9g+crank@root/node_modules/@b9g/crank/packages/create-crank": {
       "name": "create-crank",
       "version": "0.1.3",
       "bin": {
         "create-crank": "./bin/create.js",
       },
     },
-    "packages/eslint-plugin-crank": {
+    "node_modules/.bun/@b9g+crank@root/node_modules/@b9g/crank/packages/eslint-plugin-crank": {
       "name": "eslint-plugin-crank",
       "version": "0.2.2",
       "devDependencies": {
@@ -92,11 +92,11 @@
 
     "@b9g/crank": ["@b9g/crank@root:", {}],
 
-    "@b9g/crank-codemods": ["@b9g/crank-codemods@workspace:packages/crank-codemods"],
+    "@b9g/crank-codemods": ["@b9g/crank-codemods@workspace:node_modules/.bun/@b9g+crank@root/node_modules/@b9g/crank/packages/crank-codemods"],
 
-    "@b9g/crankdown": ["@b9g/crankdown@workspace:packages/crankdown"],
+    "@b9g/crankdown": ["@b9g/crankdown@workspace:node_modules/.bun/@b9g+crank@root/node_modules/@b9g/crank/packages/crankdown"],
 
-    "@b9g/libuild": ["@b9g/libuild@0.2.18", "", { "dependencies": { "commander": "^15.0.0", "esbuild": "^0.28.1", "expect": "^30.4.1", "glob": "^13.0.6", "pretty-format": "^30.4.1" }, "peerDependencies": { "playwright": "^1.40.0", "typescript": "^5.0.0" }, "optionalPeers": ["playwright", "typescript"], "bin": { "libuild": "cli.js" } }, "sha512-hp1eJUWAFJgAvm3Ll8ZJY10pWCBToDdXJUtAWgzM+qgvqv3u++Y82SIe7Xums+HNPk4f3dDNLkTFG0ZKdnfhhQ=="],
+    "@b9g/libuild": ["@b9g/libuild@0.2.19", "", { "dependencies": { "commander": "^15.0.0", "esbuild": "^0.28.1", "expect": "^30.4.1", "glob": "^13.0.6", "pretty-format": "^30.4.1" }, "peerDependencies": { "playwright": "^1.40.0", "typescript": "^5.0.0" }, "optionalPeers": ["playwright", "typescript"], "bin": { "libuild": "cli.js" } }, "sha512-pqBEIAO2yIRyIpxM87F3Q5Kmvo0OZq9YVjupZ4+BwiuBHIRF3xs8mJYVpNbjugoC3fy3l5croA2tsJlmN8vlWQ=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -508,7 +508,7 @@
 
     "astro": ["astro@4.16.19", "", { "dependencies": { "@astrojs/compiler": "^2.10.3", "@astrojs/internal-helpers": "0.4.1", "@astrojs/markdown-remark": "5.3.0", "@astrojs/telemetry": "3.1.0", "@babel/core": "^7.26.0", "@babel/plugin-transform-react-jsx": "^7.25.9", "@babel/types": "^7.26.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.1.3", "@types/babel__core": "^7.20.5", "@types/cookie": "^0.6.0", "acorn": "^8.14.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "boxen": "8.0.1", "ci-info": "^4.1.0", "clsx": "^2.1.1", "common-ancestor-path": "^1.0.1", "cookie": "^0.7.2", "cssesc": "^3.0.0", "debug": "^4.3.7", "deterministic-object-hash": "^2.0.2", "devalue": "^5.1.1", "diff": "^5.2.0", "dlv": "^1.1.3", "dset": "^3.1.4", "es-module-lexer": "^1.5.4", "esbuild": "^0.21.5", "estree-walker": "^3.0.3", "fast-glob": "^3.3.2", "flattie": "^1.1.1", "github-slugger": "^2.0.0", "gray-matter": "^4.0.3", "html-escaper": "^3.0.3", "http-cache-semantics": "^4.1.1", "js-yaml": "^4.1.0", "kleur": "^4.1.5", "magic-string": "^0.30.14", "magicast": "^0.3.5", "micromatch": "^4.0.8", "mrmime": "^2.0.0", "neotraverse": "^0.6.18", "ora": "^8.1.1", "p-limit": "^6.1.0", "p-queue": "^8.0.1", "preferred-pm": "^4.0.0", "prompts": "^2.4.2", "rehype": "^13.0.2", "semver": "^7.6.3", "shiki": "^1.23.1", "tinyexec": "^0.3.1", "tsconfck": "^3.1.4", "unist-util-visit": "^5.0.0", "vfile": "^6.0.3", "vite": "^5.4.11", "vitefu": "^1.0.4", "which-pm": "^3.0.0", "xxhash-wasm": "^1.1.0", "yargs-parser": "^21.1.1", "zod": "^3.23.8", "zod-to-json-schema": "^3.23.5", "zod-to-ts": "^1.2.0" }, "optionalDependencies": { "sharp": "^0.33.3" }, "bin": { "astro": "astro.js" } }, "sha512-baeSswPC5ZYvhGDoj25L2FuzKRWMgx105FetOPQVJFMCAp0o08OonYC7AhwsFdhvp7GapqjnC1Fe3lKb2lupYw=="],
 
-    "astro-crank": ["astro-crank@workspace:packages/astro-crank"],
+    "astro-crank": ["astro-crank@workspace:node_modules/.bun/@b9g+crank@root/node_modules/@b9g/crank/packages/astro-crank"],
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
 
@@ -590,7 +590,7 @@
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
-    "create-crank": ["create-crank@workspace:packages/create-crank"],
+    "create-crank": ["create-crank@workspace:node_modules/.bun/@b9g+crank@root/node_modules/@b9g/crank/packages/create-crank"],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -668,7 +668,7 @@
 
     "eslint-config-prettier": ["eslint-config-prettier@9.1.2", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ=="],
 
-    "eslint-plugin-crank": ["eslint-plugin-crank@workspace:packages/eslint-plugin-crank"],
+    "eslint-plugin-crank": ["eslint-plugin-crank@workspace:node_modules/.bun/@b9g+crank@root/node_modules/@b9g/crank/packages/eslint-plugin-crank"],
 
     "eslint-plugin-prettier": ["eslint-plugin-prettier@5.5.5", "", { "dependencies": { "prettier-linter-helpers": "^1.0.1", "synckit": "^0.11.12" }, "peerDependencies": { "@types/eslint": ">=8.0.0", "eslint": ">=8.0.0", "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0", "prettier": ">=3.0.0" }, "optionalPeers": ["@types/eslint", "eslint-config-prettier"] }, "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw=="],
 
@@ -1445,6 +1445,8 @@
     "zod-to-ts": ["zod-to-ts@1.2.0", "", { "peerDependencies": { "typescript": "^4.9.4 || ^5.0.2", "zod": "^3" } }, "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@b9g/crankdown/@b9g/crank": ["@b9g/crank@0.6.1", "", {}, "sha512-NE5uuOMYeNdRLLGSXeM5EpyUvaNjcZmPUEs34ahnXhmlogv9yV3ymoX/RQFf63jTOvTP/wzN+vvNEfkq4sS+2g=="],
 
     "@b9g/crankdown/@b9g/libuild": ["@b9g/libuild@0.1.25", "", { "dependencies": { "commander": "^14.0.2", "esbuild": "^0.19.0", "expect": "^30.2.0", "glob": "^13.0.0" }, "peerDependencies": { "playwright": "^1.40.0", "typescript": "^5.0.0" }, "optionalPeers": ["playwright", "typescript"], "bin": { "libuild": "src/cli.js" } }, "sha512-ibMExggG0YxDdHIUQynAqXTBlv/ka8YpsnJ43LOwyKjD8tsjCwQKBFTQL8EpfuGhl+6gMjTvZPwgQTnUMeGocg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "typescript": "^5.8.3",
       },
     },
-    "node_modules/.bun/@b9g+crank@root/node_modules/@b9g/crank/packages/astro-crank": {
+    "packages/astro-crank": {
       "name": "astro-crank",
       "version": "0.3.0",
       "peerDependencies": {
@@ -29,7 +29,7 @@
         "astro": "^4.0.0 || ^5.0.0",
       },
     },
-    "node_modules/.bun/@b9g+crank@root/node_modules/@b9g/crank/packages/crank-codemods": {
+    "packages/crank-codemods": {
       "name": "@b9g/crank-codemods",
       "version": "0.1.0",
       "dependencies": {
@@ -41,12 +41,12 @@
         "typescript": "^5.0.0",
       },
     },
-    "node_modules/.bun/@b9g+crank@root/node_modules/@b9g/crank/packages/crankdown": {
+    "packages/crankdown": {
       "name": "@b9g/crankdown",
       "version": "0.1.3",
       "devDependencies": {
         "@b9g/crank": "file:../../",
-        "@b9g/libuild": "^0.1.25",
+        "@b9g/libuild": "^0.2.19",
         "marked": "^18.0.0",
         "typescript": "^5.9.3",
       },
@@ -55,17 +55,18 @@
         "marked": ">=5.0.0",
       },
     },
-    "node_modules/.bun/@b9g+crank@root/node_modules/@b9g/crank/packages/create-crank": {
+    "packages/create-crank": {
       "name": "create-crank",
       "version": "0.1.3",
       "bin": {
         "create-crank": "./bin/create.js",
       },
     },
-    "node_modules/.bun/@b9g+crank@root/node_modules/@b9g/crank/packages/eslint-plugin-crank": {
+    "packages/eslint-plugin-crank": {
       "name": "eslint-plugin-crank",
       "version": "0.2.2",
       "devDependencies": {
+        "@b9g/libuild": "^0.2.19",
         "@eslint/js": "^9.37.0",
         "@tsconfig/recommended": "^1.0.10",
         "@types/node": "^20.0.0",
@@ -92,9 +93,9 @@
 
     "@b9g/crank": ["@b9g/crank@root:", {}],
 
-    "@b9g/crank-codemods": ["@b9g/crank-codemods@workspace:node_modules/.bun/@b9g+crank@root/node_modules/@b9g/crank/packages/crank-codemods"],
+    "@b9g/crank-codemods": ["@b9g/crank-codemods@workspace:packages/crank-codemods"],
 
-    "@b9g/crankdown": ["@b9g/crankdown@workspace:node_modules/.bun/@b9g+crank@root/node_modules/@b9g/crank/packages/crankdown"],
+    "@b9g/crankdown": ["@b9g/crankdown@workspace:packages/crankdown"],
 
     "@b9g/libuild": ["@b9g/libuild@0.2.19", "", { "dependencies": { "commander": "^15.0.0", "esbuild": "^0.28.1", "expect": "^30.4.1", "glob": "^13.0.6", "pretty-format": "^30.4.1" }, "peerDependencies": { "playwright": "^1.40.0", "typescript": "^5.0.0" }, "optionalPeers": ["playwright", "typescript"], "bin": { "libuild": "cli.js" } }, "sha512-pqBEIAO2yIRyIpxM87F3Q5Kmvo0OZq9YVjupZ4+BwiuBHIRF3xs8mJYVpNbjugoC3fy3l5croA2tsJlmN8vlWQ=="],
 
@@ -508,7 +509,7 @@
 
     "astro": ["astro@4.16.19", "", { "dependencies": { "@astrojs/compiler": "^2.10.3", "@astrojs/internal-helpers": "0.4.1", "@astrojs/markdown-remark": "5.3.0", "@astrojs/telemetry": "3.1.0", "@babel/core": "^7.26.0", "@babel/plugin-transform-react-jsx": "^7.25.9", "@babel/types": "^7.26.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.1.3", "@types/babel__core": "^7.20.5", "@types/cookie": "^0.6.0", "acorn": "^8.14.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "boxen": "8.0.1", "ci-info": "^4.1.0", "clsx": "^2.1.1", "common-ancestor-path": "^1.0.1", "cookie": "^0.7.2", "cssesc": "^3.0.0", "debug": "^4.3.7", "deterministic-object-hash": "^2.0.2", "devalue": "^5.1.1", "diff": "^5.2.0", "dlv": "^1.1.3", "dset": "^3.1.4", "es-module-lexer": "^1.5.4", "esbuild": "^0.21.5", "estree-walker": "^3.0.3", "fast-glob": "^3.3.2", "flattie": "^1.1.1", "github-slugger": "^2.0.0", "gray-matter": "^4.0.3", "html-escaper": "^3.0.3", "http-cache-semantics": "^4.1.1", "js-yaml": "^4.1.0", "kleur": "^4.1.5", "magic-string": "^0.30.14", "magicast": "^0.3.5", "micromatch": "^4.0.8", "mrmime": "^2.0.0", "neotraverse": "^0.6.18", "ora": "^8.1.1", "p-limit": "^6.1.0", "p-queue": "^8.0.1", "preferred-pm": "^4.0.0", "prompts": "^2.4.2", "rehype": "^13.0.2", "semver": "^7.6.3", "shiki": "^1.23.1", "tinyexec": "^0.3.1", "tsconfck": "^3.1.4", "unist-util-visit": "^5.0.0", "vfile": "^6.0.3", "vite": "^5.4.11", "vitefu": "^1.0.4", "which-pm": "^3.0.0", "xxhash-wasm": "^1.1.0", "yargs-parser": "^21.1.1", "zod": "^3.23.8", "zod-to-json-schema": "^3.23.5", "zod-to-ts": "^1.2.0" }, "optionalDependencies": { "sharp": "^0.33.3" }, "bin": { "astro": "astro.js" } }, "sha512-baeSswPC5ZYvhGDoj25L2FuzKRWMgx105FetOPQVJFMCAp0o08OonYC7AhwsFdhvp7GapqjnC1Fe3lKb2lupYw=="],
 
-    "astro-crank": ["astro-crank@workspace:node_modules/.bun/@b9g+crank@root/node_modules/@b9g/crank/packages/astro-crank"],
+    "astro-crank": ["astro-crank@workspace:packages/astro-crank"],
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
 
@@ -590,7 +591,7 @@
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
-    "create-crank": ["create-crank@workspace:node_modules/.bun/@b9g+crank@root/node_modules/@b9g/crank/packages/create-crank"],
+    "create-crank": ["create-crank@workspace:packages/create-crank"],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -668,7 +669,7 @@
 
     "eslint-config-prettier": ["eslint-config-prettier@9.1.2", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ=="],
 
-    "eslint-plugin-crank": ["eslint-plugin-crank@workspace:node_modules/.bun/@b9g+crank@root/node_modules/@b9g/crank/packages/eslint-plugin-crank"],
+    "eslint-plugin-crank": ["eslint-plugin-crank@workspace:packages/eslint-plugin-crank"],
 
     "eslint-plugin-prettier": ["eslint-plugin-prettier@5.5.5", "", { "dependencies": { "prettier-linter-helpers": "^1.0.1", "synckit": "^0.11.12" }, "peerDependencies": { "@types/eslint": ">=8.0.0", "eslint": ">=8.0.0", "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0", "prettier": ">=3.0.0" }, "optionalPeers": ["@types/eslint", "eslint-config-prettier"] }, "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw=="],
 
@@ -1448,8 +1449,6 @@
 
     "@b9g/crankdown/@b9g/crank": ["@b9g/crank@0.6.1", "", {}, "sha512-NE5uuOMYeNdRLLGSXeM5EpyUvaNjcZmPUEs34ahnXhmlogv9yV3ymoX/RQFf63jTOvTP/wzN+vvNEfkq4sS+2g=="],
 
-    "@b9g/crankdown/@b9g/libuild": ["@b9g/libuild@0.1.25", "", { "dependencies": { "commander": "^14.0.2", "esbuild": "^0.19.0", "expect": "^30.2.0", "glob": "^13.0.0" }, "peerDependencies": { "playwright": "^1.40.0", "typescript": "^5.0.0" }, "optionalPeers": ["playwright", "typescript"], "bin": { "libuild": "src/cli.js" } }, "sha512-ibMExggG0YxDdHIUQynAqXTBlv/ka8YpsnJ43LOwyKjD8tsjCwQKBFTQL8EpfuGhl+6gMjTvZPwgQTnUMeGocg=="],
-
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
@@ -1545,10 +1544,6 @@
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
-    "@b9g/crankdown/@b9g/libuild/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild": ["esbuild@0.19.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.19.12", "@esbuild/android-arm": "0.19.12", "@esbuild/android-arm64": "0.19.12", "@esbuild/android-x64": "0.19.12", "@esbuild/darwin-arm64": "0.19.12", "@esbuild/darwin-x64": "0.19.12", "@esbuild/freebsd-arm64": "0.19.12", "@esbuild/freebsd-x64": "0.19.12", "@esbuild/linux-arm": "0.19.12", "@esbuild/linux-arm64": "0.19.12", "@esbuild/linux-ia32": "0.19.12", "@esbuild/linux-loong64": "0.19.12", "@esbuild/linux-mips64el": "0.19.12", "@esbuild/linux-ppc64": "0.19.12", "@esbuild/linux-riscv64": "0.19.12", "@esbuild/linux-s390x": "0.19.12", "@esbuild/linux-x64": "0.19.12", "@esbuild/netbsd-x64": "0.19.12", "@esbuild/openbsd-x64": "0.19.12", "@esbuild/sunos-x64": "0.19.12", "@esbuild/win32-arm64": "0.19.12", "@esbuild/win32-ia32": "0.19.12", "@esbuild/win32-x64": "0.19.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
@@ -1677,52 +1672,6 @@
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
     "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.19.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.19.12", "", { "os": "android", "cpu": "arm" }, "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.19.12", "", { "os": "android", "cpu": "arm64" }, "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.19.12", "", { "os": "android", "cpu": "x64" }, "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.19.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.19.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.19.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.19.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.19.12", "", { "os": "linux", "cpu": "arm" }, "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.19.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.19.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.19.12", "", { "os": "linux", "cpu": "none" }, "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.19.12", "", { "os": "linux", "cpu": "none" }, "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.19.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.19.12", "", { "os": "linux", "cpu": "none" }, "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.19.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.19.12", "", { "os": "linux", "cpu": "x64" }, "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.19.12", "", { "os": "none", "cpu": "x64" }, "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.19.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.19.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.19.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.19.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.19.12", "", { "os": "win32", "cpu": "x64" }, "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA=="],
 
     "eslint-plugin-crank/eslint/@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@b9g/crank",
       "devDependencies": {
-        "@b9g/libuild": "0.2.17",
+        "@b9g/libuild": "0.2.18",
         "@types/node": "^22.14.0",
         "@types/sinon": "^17.0.4",
         "@typescript-eslint/eslint-plugin": "^8.29.1",
@@ -96,7 +96,7 @@
 
     "@b9g/crankdown": ["@b9g/crankdown@workspace:packages/crankdown"],
 
-    "@b9g/libuild": ["@b9g/libuild@0.2.17", "", { "dependencies": { "commander": "^15.0.0", "esbuild": "^0.28.1", "expect": "^30.4.1", "glob": "^13.0.6", "pretty-format": "^30.4.1" }, "peerDependencies": { "playwright": "^1.40.0", "typescript": "^5.0.0" }, "optionalPeers": ["playwright", "typescript"], "bin": { "libuild": "cli.js" } }, "sha512-7TXKet+ZCwmGqsp4ICWkQUvGWu6tVFFAeRfUF5Y3VlLrsZFMk1NlQLESzbdudvx3GMk2+2wOi3lDRPLtWUT9AA=="],
+    "@b9g/libuild": ["@b9g/libuild@0.2.18", "", { "dependencies": { "commander": "^15.0.0", "esbuild": "^0.28.1", "expect": "^30.4.1", "glob": "^13.0.6", "pretty-format": "^30.4.1" }, "peerDependencies": { "playwright": "^1.40.0", "typescript": "^5.0.0" }, "optionalPeers": ["playwright", "typescript"], "bin": { "libuild": "cli.js" } }, "sha512-hp1eJUWAFJgAvm3Ll8ZJY10pWCBToDdXJUtAWgzM+qgvqv3u++Y82SIe7Xums+HNPk4f3dDNLkTFG0ZKdnfhhQ=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@b9g/crank",
       "devDependencies": {
-        "@b9g/libuild": "^0.2.16",
+        "@b9g/libuild": "0.2.17",
         "@types/node": "^22.14.0",
         "@types/sinon": "^17.0.4",
         "@typescript-eslint/eslint-plugin": "^8.29.1",
@@ -96,7 +96,7 @@
 
     "@b9g/crankdown": ["@b9g/crankdown@workspace:packages/crankdown"],
 
-    "@b9g/libuild": ["@b9g/libuild@0.2.16", "", { "dependencies": { "commander": "^15.0.0", "esbuild": "^0.28.1", "expect": "^30.4.1", "glob": "^13.0.6", "pretty-format": "^30.4.1" }, "peerDependencies": { "playwright": "^1.40.0", "typescript": "^5.0.0" }, "optionalPeers": ["playwright", "typescript"], "bin": { "libuild": "cli.js" } }, "sha512-cSHtyNdAZQgvE/z/CBEXEcavauIi3BDWfcYTrHPUUuCFCs5DJJBemDf7iIvWkeLTncUUL2YHQ5qjxE5J5VyZsw=="],
+    "@b9g/libuild": ["@b9g/libuild@0.2.17", "", { "dependencies": { "commander": "^15.0.0", "esbuild": "^0.28.1", "expect": "^30.4.1", "glob": "^13.0.6", "pretty-format": "^30.4.1" }, "peerDependencies": { "playwright": "^1.40.0", "typescript": "^5.0.0" }, "optionalPeers": ["playwright", "typescript"], "bin": { "libuild": "cli.js" } }, "sha512-7TXKet+ZCwmGqsp4ICWkQUvGWu6tVFFAeRfUF5Y3VlLrsZFMk1NlQLESzbdudvx3GMk2+2wOi3lDRPLtWUT9AA=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@b9g/crank",
       "devDependencies": {
-        "@b9g/libuild": "^0.2.19",
+        "@b9g/libuild": "^0.2.16",
         "@types/node": "^22.14.0",
         "@types/sinon": "^17.0.4",
         "@typescript-eslint/eslint-plugin": "^8.29.1",
@@ -15,11 +15,10 @@
         "eslint-plugin-crank": "workspace:*",
         "eslint-plugin-prettier": "^5.2.6",
         "eslint-plugin-react": "^7.37.5",
-        "playwright-test": "^14.1.9",
+        "playwright": "^1.62.1",
         "prettier": "^3.5.3",
         "sinon": "^17.0.2",
         "typescript": "^5.8.3",
-        "uvu": "^0.5.6",
       },
     },
     "packages/astro-crank": {
@@ -47,7 +46,7 @@
       "version": "0.1.3",
       "devDependencies": {
         "@b9g/crank": "file:../../",
-        "@b9g/libuild": "^0.2.19",
+        "@b9g/libuild": "^0.1.25",
         "marked": "^18.0.0",
         "typescript": "^5.9.3",
       },
@@ -67,7 +66,6 @@
       "name": "eslint-plugin-crank",
       "version": "0.2.2",
       "devDependencies": {
-        "@b9g/libuild": "^0.2.19",
         "@eslint/js": "^9.37.0",
         "@tsconfig/recommended": "^1.0.10",
         "@types/node": "^20.0.0",
@@ -82,8 +80,6 @@
     },
   },
   "packages": {
-    "@arr/every": ["@arr/every@1.0.1", "", {}, "sha512-UQFQ6SgyJ6LX42W8rHCs8KVc0JS0tzVL9ct4XYedJukskYVWTo49tNiMEK9C2HTyarbNiT/RVIRSY82vH+6sTg=="],
-
     "@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
 
     "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.4.1", "", {}, "sha512-bMf9jFihO8YP940uD70SI/RDzIhUHJAolWVcO1v5PUivxGKvfLZTLTVVxEYzGYyPsA3ivdLNqMnL5VgmQySa+g=="],
@@ -100,7 +96,7 @@
 
     "@b9g/crankdown": ["@b9g/crankdown@workspace:packages/crankdown"],
 
-    "@b9g/libuild": ["@b9g/libuild@0.2.19", "", { "dependencies": { "commander": "^15.0.0", "esbuild": "^0.28.1", "expect": "^30.4.1", "glob": "^13.0.6", "pretty-format": "^30.4.1" }, "peerDependencies": { "playwright": "^1.40.0", "typescript": "^5.0.0" }, "optionalPeers": ["playwright", "typescript"], "bin": { "libuild": "cli.js" } }, "sha512-pqBEIAO2yIRyIpxM87F3Q5Kmvo0OZq9YVjupZ4+BwiuBHIRF3xs8mJYVpNbjugoC3fy3l5croA2tsJlmN8vlWQ=="],
+    "@b9g/libuild": ["@b9g/libuild@0.2.16", "", { "dependencies": { "commander": "^15.0.0", "esbuild": "^0.28.1", "expect": "^30.4.1", "glob": "^13.0.6", "pretty-format": "^30.4.1" }, "peerDependencies": { "playwright": "^1.40.0", "typescript": "^5.0.0" }, "optionalPeers": ["playwright", "typescript"], "bin": { "libuild": "cli.js" } }, "sha512-cSHtyNdAZQgvE/z/CBEXEcavauIi3BDWfcYTrHPUUuCFCs5DJJBemDf7iIvWkeLTncUUL2YHQ5qjxE5J5VyZsw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -175,8 +171,6 @@
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
@@ -300,10 +294,6 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
 
-    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
-
-    "@istanbuljs/schema": ["@istanbuljs/schema@0.1.3", "", {}, "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA=="],
-
     "@jest/diff-sequences": ["@jest/diff-sequences@30.4.0", "", {}, "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g=="],
 
     "@jest/expect-utils": ["@jest/expect-utils@30.4.1", "", { "dependencies": { "@jest/get-type": "30.1.0" } }, "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ=="],
@@ -334,11 +324,7 @@
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
-    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
-
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
-
-    "@polka/url": ["@polka/url@0.5.0", "", {}, "sha512-oZLYFEAzUKyi3SKnXvj32ZCEGH6RDnao7COuCVhDydMS9NrCSVXhM79VaKyP5+Zc33m0QXEd2DN3UkU7OsHcfw=="],
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
 
@@ -392,8 +378,6 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.57.1", "", { "os": "win32", "cpu": "x64" }, "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA=="],
 
-    "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
-
     "@shikijs/core": ["@shikijs/core@1.29.2", "", { "dependencies": { "@shikijs/engine-javascript": "1.29.2", "@shikijs/engine-oniguruma": "1.29.2", "@shikijs/types": "1.29.2", "@shikijs/vscode-textmate": "^10.0.1", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.4" } }, "sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ=="],
 
     "@shikijs/engine-javascript": ["@shikijs/engine-javascript@1.29.2", "", { "dependencies": { "@shikijs/types": "1.29.2", "@shikijs/vscode-textmate": "^10.0.1", "oniguruma-to-es": "^2.2.0" } }, "sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A=="],
@@ -409,8 +393,6 @@
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.51", "", {}, "sha512-Nu4sNPT4G3QgAvxmdUCR/NBmsi23F2tEIcbMOZJVHS+qEgk+rmXxQikEeoKFyaX+UEggAoTvHUvIlj8MfYPzXQ=="],
-
-    "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
     "@sinonjs/commons": ["@sinonjs/commons@3.0.1", "", { "dependencies": { "type-detect": "4.0.8" } }, "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ=="],
 
@@ -494,8 +476,6 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
-    "acorn-loose": ["acorn-loose@8.5.2", "", { "dependencies": { "acorn": "^8.15.0" } }, "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A=="],
-
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
     "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
@@ -524,8 +504,6 @@
 
     "arraybuffer.prototype.slice": ["arraybuffer.prototype.slice@1.0.4", "", { "dependencies": { "array-buffer-byte-length": "^1.0.1", "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "is-array-buffer": "^3.0.4" } }, "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ=="],
 
-    "assert": ["assert@2.1.0", "", { "dependencies": { "call-bind": "^1.0.2", "is-nan": "^1.3.2", "object-is": "^1.1.5", "object.assign": "^4.1.4", "util": "^0.12.5" } }, "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw=="],
-
     "ast-types": ["ast-types@0.14.2", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA=="],
 
     "astro": ["astro@4.16.19", "", { "dependencies": { "@astrojs/compiler": "^2.10.3", "@astrojs/internal-helpers": "0.4.1", "@astrojs/markdown-remark": "5.3.0", "@astrojs/telemetry": "3.1.0", "@babel/core": "^7.26.0", "@babel/plugin-transform-react-jsx": "^7.25.9", "@babel/types": "^7.26.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.1.3", "@types/babel__core": "^7.20.5", "@types/cookie": "^0.6.0", "acorn": "^8.14.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "boxen": "8.0.1", "ci-info": "^4.1.0", "clsx": "^2.1.1", "common-ancestor-path": "^1.0.1", "cookie": "^0.7.2", "cssesc": "^3.0.0", "debug": "^4.3.7", "deterministic-object-hash": "^2.0.2", "devalue": "^5.1.1", "diff": "^5.2.0", "dlv": "^1.1.3", "dset": "^3.1.4", "es-module-lexer": "^1.5.4", "esbuild": "^0.21.5", "estree-walker": "^3.0.3", "fast-glob": "^3.3.2", "flattie": "^1.1.1", "github-slugger": "^2.0.0", "gray-matter": "^4.0.3", "html-escaper": "^3.0.3", "http-cache-semantics": "^4.1.1", "js-yaml": "^4.1.0", "kleur": "^4.1.5", "magic-string": "^0.30.14", "magicast": "^0.3.5", "micromatch": "^4.0.8", "mrmime": "^2.0.0", "neotraverse": "^0.6.18", "ora": "^8.1.1", "p-limit": "^6.1.0", "p-queue": "^8.0.1", "preferred-pm": "^4.0.0", "prompts": "^2.4.2", "rehype": "^13.0.2", "semver": "^7.6.3", "shiki": "^1.23.1", "tinyexec": "^0.3.1", "tsconfck": "^3.1.4", "unist-util-visit": "^5.0.0", "vfile": "^6.0.3", "vite": "^5.4.11", "vitefu": "^1.0.4", "which-pm": "^3.0.0", "xxhash-wasm": "^1.1.0", "yargs-parser": "^21.1.1", "zod": "^3.23.8", "zod-to-json-schema": "^3.23.5", "zod-to-ts": "^1.2.0" }, "optionalDependencies": { "sharp": "^0.33.3" }, "bin": { "astro": "astro.js" } }, "sha512-baeSswPC5ZYvhGDoj25L2FuzKRWMgx105FetOPQVJFMCAp0o08OonYC7AhwsFdhvp7GapqjnC1Fe3lKb2lupYw=="],
@@ -544,8 +522,6 @@
 
     "base-64": ["base-64@1.0.0", "", {}, "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="],
 
-    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
-
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.19", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg=="],
 
     "boxen": ["boxen@8.0.1", "", { "dependencies": { "ansi-align": "^3.0.1", "camelcase": "^8.0.0", "chalk": "^5.3.0", "cli-boxes": "^3.0.0", "string-width": "^7.2.0", "type-fest": "^4.21.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0" } }, "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw=="],
@@ -556,11 +532,7 @@
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
-    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
-
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
-
-    "c8": ["c8@10.1.3", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.1", "@istanbuljs/schema": "^0.1.3", "find-up": "^5.0.0", "foreground-child": "^3.1.1", "istanbul-lib-coverage": "^3.2.0", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.1.6", "test-exclude": "^7.0.1", "v8-to-istanbul": "^9.0.0", "yargs": "^17.7.2", "yargs-parser": "^21.1.1" }, "peerDependencies": { "monocart-coverage-reports": "^2" }, "optionalPeers": ["monocart-coverage-reports"], "bin": { "c8": "bin/c8.js" } }, "sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
@@ -584,8 +556,6 @@
 
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
-    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
-
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
     "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
@@ -593,8 +563,6 @@
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
     "cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
-
-    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "clone-deep": ["clone-deep@4.0.1", "", { "dependencies": { "is-plain-object": "^2.0.4", "kind-of": "^6.0.2", "shallow-clone": "^3.0.0" } }, "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ=="],
 
@@ -625,8 +593,6 @@
     "create-crank": ["create-crank@workspace:packages/create-crank"],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
-
-    "crypto-random-string": ["crypto-random-string@4.0.0", "", { "dependencies": { "type-fest": "^1.0.1" } }, "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA=="],
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
@@ -666,8 +632,6 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
-    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
-
     "electron-to-chromium": ["electron-to-chromium@1.5.286", "", {}, "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
@@ -695,8 +659,6 @@
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
 
     "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
-
-    "esbuild-plugin-wasm": ["esbuild-plugin-wasm@1.1.0", "", {}, "sha512-0bQ6+1tUbySSnxzn5jnXHMDvYnT0cN/Wd4Syk8g/sqAIJUg7buTIi22svS3Qz6ssx895NT+TgLPb33xi1OkZig=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -732,12 +694,6 @@
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
-    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
-
-    "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
-
-    "exit-hook": ["exit-hook@4.0.0", "", {}, "sha512-Fqs7ChZm72y40wKjOFXBKg7nJZvQJmewP5/7LtePDdnah/+FH9Hp5sgMujSCMPXlxOAW2//1jrW9pnsY7o20vQ=="],
-
     "expect": ["expect@30.4.1", "", { "dependencies": { "@jest/expect-utils": "30.4.1", "@jest/get-type": "30.1.0", "jest-matcher-utils": "30.4.1", "jest-message-util": "30.4.1", "jest-mock": "30.4.1", "jest-util": "30.4.1" } }, "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
@@ -757,8 +713,6 @@
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
-
-    "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 
     "file-entry-cache": ["file-entry-cache@6.0.1", "", { "dependencies": { "flat-cache": "^3.0.4" } }, "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg=="],
 
@@ -782,11 +736,9 @@
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
-    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
-
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -798,15 +750,11 @@
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
-    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
-
     "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
-
-    "get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
     "get-symbol-description": ["get-symbol-description@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6" } }, "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg=="],
 
@@ -868,10 +816,6 @@
 
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
-    "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
-
-    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
-
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
@@ -885,8 +829,6 @@
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
-
-    "is-arguments": ["is-arguments@1.2.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA=="],
 
     "is-array-buffer": ["is-array-buffer@3.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A=="],
 
@@ -926,8 +868,6 @@
 
     "is-map": ["is-map@2.0.3", "", {}, "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="],
 
-    "is-nan": ["is-nan@1.3.2", "", { "dependencies": { "call-bind": "^1.0.0", "define-properties": "^1.1.3" } }, "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w=="],
-
     "is-negative-zero": ["is-negative-zero@2.0.3", "", {}, "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
@@ -945,8 +885,6 @@
     "is-set": ["is-set@2.0.3", "", {}, "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg=="],
 
     "is-shared-array-buffer": ["is-shared-array-buffer@1.0.4", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A=="],
-
-    "is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
 
     "is-string": ["is-string@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA=="],
 
@@ -970,15 +908,7 @@
 
     "isobject": ["isobject@3.0.1", "", {}, "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="],
 
-    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
-
-    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
-
-    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
-
     "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "^1.1.4", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "get-proto": "^1.0.0", "has-symbols": "^1.1.0", "set-function-name": "^2.0.2" } }, "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g=="],
-
-    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "jest-diff": ["jest-diff@30.4.1", "", { "dependencies": { "@jest/diff-sequences": "30.4.0", "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "pretty-format": "30.4.1" } }, "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA=="],
 
@@ -1020,13 +950,9 @@
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
-    "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
-
     "load-yaml-file": ["load-yaml-file@0.2.0", "", { "dependencies": { "graceful-fs": "^4.1.5", "js-yaml": "^3.13.0", "pify": "^4.0.1", "strip-bom": "^3.0.0" } }, "sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
-
-    "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
@@ -1047,8 +973,6 @@
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
     "marked": ["marked@18.0.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-MrV5puXBfuiy6wl6DLaq3BtIJQAJToAd5zt/ZKhRfGRAuFPALE7/4Y7jnxRQoEgK/pBgurGqLyAuRgZ2xOjr6w=="],
-
-    "matchit": ["matchit@1.1.0", "", { "dependencies": { "@arr/every": "^1.0.0" } }, "sha512-+nGYoOlfHmxe5BW5tE0EMJppXEwdSf8uBA1GTZC7Q77kbT35+VKLYJMzVNWCHSsga1ps1tPYFtFyvxvKzWVmMA=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -1077,8 +1001,6 @@
     "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
 
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
-
-    "merge-options": ["merge-options@3.0.4", "", { "dependencies": { "is-plain-obj": "^2.1.0" } }, "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
@@ -1146,13 +1068,11 @@
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
-    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
-
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@5.1.6", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
@@ -1166,13 +1086,9 @@
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 
-    "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
-
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
-
-    "object-is": ["object-is@1.1.6", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1" } }, "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q=="],
 
     "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
 
@@ -1206,17 +1122,11 @@
 
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
-    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
-
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
     "parse-latin": ["parse-latin@7.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "@types/unist": "^3.0.0", "nlcst-to-string": "^4.0.0", "unist-util-modify-children": "^4.0.0", "unist-util-visit-children": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ=="],
 
-    "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
-
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
-
-    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
@@ -1232,7 +1142,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
 
@@ -1240,11 +1150,9 @@
 
     "pkg-dir": ["pkg-dir@3.0.0", "", { "dependencies": { "find-up": "^3.0.0" } }, "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw=="],
 
-    "playwright-core": ["playwright-core@1.54.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA=="],
+    "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
 
-    "playwright-test": ["playwright-test@14.1.12", "", { "dependencies": { "acorn-loose": "^8.3.0", "assert": "^2.1.0", "buffer": "^6.0.3", "c8": "^10.1.3", "camelcase": "^8.0.0", "chokidar": "^4.0.3", "esbuild": "0.25.8", "esbuild-plugin-wasm": "^1.1.0", "events": "^3.3.0", "execa": "^9.3.0", "exit-hook": "^4.0.0", "kleur": "^4.1.5", "lilconfig": "^3.1.3", "lodash": "^4.17.21", "merge-options": "^3.0.4", "nanoid": "^5.0.9", "ora": "^8.0.1", "p-timeout": "^6.1.4", "path-browserify": "^1.0.1", "playwright-core": "1.54.1", "polka": "^0.5.2", "premove": "^4.0.0", "process": "^0.11.10", "sade": "^1.8.1", "sirv": "^3.0.0", "source-map": "0.6.1", "source-map-support": "^0.5.21", "stream-browserify": "^3.0.0", "tempy": "^3.1.0", "test-exclude": "^7.0.1", "tinyglobby": "^0.2.14", "util": "^0.12.5", "v8-to-istanbul": "^9.3.0" }, "bin": { "playwright-test": "cli.js", "pw-test": "cli.js" } }, "sha512-tEhyXJwIU2f5nK9lNKbKBQ8cuBnux69cfm+tjwGGn3wLQkmMa8IfqCGDV5+s2aVrAPvrxlxSDP1cMr6jX8nhsg=="],
-
-    "polka": ["polka@0.5.2", "", { "dependencies": { "@polka/url": "^0.5.0", "trouter": "^2.0.1" } }, "sha512-FVg3vDmCqP80tOrs+OeNlgXYmFppTXdjD5E7I4ET1NjvtNmQrb1/mJibybKkb/d4NA7YWAr1ojxuhpL3FHqdlw=="],
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -1254,19 +1162,13 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
-    "premove": ["premove@4.0.0", "", { "bin": { "premove": "bin.js" } }, "sha512-zim/Hr4+FVdCIM7zL9b9Z0Wfd5Ya3mnKtiuDv7L5lzYzanSq6cOcVJ7EFcgK4I0pt28l8H0jX/x3nyog380XgQ=="],
-
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "prettier-linter-helpers": ["prettier-linter-helpers@1.0.1", "", { "dependencies": { "fast-diff": "^1.1.2" } }, "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg=="],
 
     "pretty-format": ["pretty-format@30.4.1", "", { "dependencies": { "@jest/schemas": "30.4.1", "ansi-styles": "^5.2.0", "react-is-18": "npm:react-is@^18.3.1", "react-is-19": "npm:react-is@^19.2.5" } }, "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw=="],
 
-    "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
-
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
-
-    "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
@@ -1283,10 +1185,6 @@
     "react-is-18": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "react-is-19": ["react-is@19.2.7", "", {}, "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A=="],
-
-    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
-
-    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "recast": ["recast@0.20.5", "", { "dependencies": { "ast-types": "0.14.2", "esprima": "~4.0.0", "source-map": "~0.6.1", "tslib": "^2.0.1" } }, "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ=="],
 
@@ -1318,8 +1216,6 @@
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
-    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
-
     "resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
@@ -1342,11 +1238,7 @@
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
-    "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
-
     "safe-array-concat": ["safe-array-concat@1.1.3", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q=="],
-
-    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safe-push-apply": ["safe-push-apply@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "isarray": "^2.0.5" } }, "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA=="],
 
@@ -1386,8 +1278,6 @@
 
     "sinon": ["sinon@17.0.2", "", { "dependencies": { "@sinonjs/commons": "^3.0.1", "@sinonjs/fake-timers": "^11.2.2", "@sinonjs/samsam": "^8.0.0", "diff": "^5.2.0", "nise": "^5.1.9", "supports-color": "^7" } }, "sha512-uihLiaB9FhzesElPDFZA7hDcNABzsVHwr3YfmM9sBllVwab3l0ltGlRV1XhpNfIacNDLGD1QRZNLs5nU5+hTuA=="],
 
-    "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
-
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
@@ -1408,11 +1298,7 @@
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
-    "stream-browserify": ["stream-browserify@3.0.0", "", { "dependencies": { "inherits": "~2.0.4", "readable-stream": "^3.5.0" } }, "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA=="],
-
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
-
-    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string.prototype.matchall": ["string.prototype.matchall@4.0.12", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-abstract": "^1.23.6", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "regexp.prototype.flags": "^1.5.3", "set-function-name": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA=="],
 
@@ -1424,19 +1310,13 @@
 
     "string.prototype.trimstart": ["string.prototype.trimstart@1.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg=="],
 
-    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
-
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
     "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
-
-    "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
@@ -1445,12 +1325,6 @@
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
     "synckit": ["synckit@0.11.12", "", { "dependencies": { "@pkgr/core": "^0.2.9" } }, "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ=="],
-
-    "temp-dir": ["temp-dir@3.0.0", "", {}, "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw=="],
-
-    "tempy": ["tempy@3.2.0", "", { "dependencies": { "is-stream": "^3.0.0", "temp-dir": "^3.0.0", "type-fest": "^2.12.2", "unique-string": "^3.0.0" } }, "sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ=="],
-
-    "test-exclude": ["test-exclude@7.0.1", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^10.4.1", "minimatch": "^9.0.4" } }, "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg=="],
 
     "text-table": ["text-table@0.2.0", "", {}, "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="],
 
@@ -1464,13 +1338,9 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
-    "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
-
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
-
-    "trouter": ["trouter@2.0.1", "", { "dependencies": { "matchit": "^1.0.0" } }, "sha512-kr8SKKw94OI+xTGOkfsvwZQ8mWoikZDd2n8XZHjJVZUARZT+4/VV6cacRS6CLsH9bNm+HFIPU1Zx4CnNnb4qlQ=="],
 
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
 
@@ -1500,11 +1370,7 @@
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
-    "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
-
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
-
-    "unique-string": ["unique-string@3.0.0", "", { "dependencies": { "crypto-random-string": "^4.0.0" } }, "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ=="],
 
     "unist-util-find-after": ["unist-util-find-after@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ=="],
 
@@ -1527,14 +1393,6 @@
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
-
-    "util": ["util@0.12.5", "", { "dependencies": { "inherits": "^2.0.3", "is-arguments": "^1.0.4", "is-generator-function": "^1.0.7", "is-typed-array": "^1.1.3", "which-typed-array": "^1.1.2" } }, "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA=="],
-
-    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
-
-    "uvu": ["uvu@0.5.6", "", { "dependencies": { "dequal": "^2.0.0", "diff": "^5.0.0", "kleur": "^4.0.3", "sade": "^1.7.3" }, "bin": { "uvu": "bin.js" } }, "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA=="],
-
-    "v8-to-istanbul": ["v8-to-istanbul@9.3.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.12", "@types/istanbul-lib-coverage": "^2.0.1", "convert-source-map": "^2.0.0" } }, "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
@@ -1568,25 +1426,17 @@
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
-    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "write-file-atomic": ["write-file-atomic@5.0.1", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^4.0.1" } }, "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw=="],
 
     "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
 
-    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
-
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
-
-    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
-
-    "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -1596,17 +1446,15 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@b9g/crankdown/@b9g/libuild": ["@b9g/libuild@0.1.25", "", { "dependencies": { "commander": "^14.0.2", "esbuild": "^0.19.0", "expect": "^30.2.0", "glob": "^13.0.0" }, "peerDependencies": { "playwright": "^1.40.0", "typescript": "^5.0.0" }, "optionalPeers": ["playwright", "typescript"], "bin": { "libuild": "src/cli.js" } }, "sha512-ibMExggG0YxDdHIUQynAqXTBlv/ka8YpsnJ43LOwyKjD8tsjCwQKBFTQL8EpfuGhl+6gMjTvZPwgQTnUMeGocg=="],
+
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
-
-    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
-    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
-
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@rollup/pluginutils/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "@sinonjs/samsam/type-detect": ["type-detect@4.1.0", "", {}, "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw=="],
 
@@ -1630,12 +1478,6 @@
 
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "crypto-random-string/type-fest": ["type-fest@1.4.0", "", {}, "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="],
-
     "eslint/@eslint/js": ["@eslint/js@8.57.1", "", {}, "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q=="],
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
@@ -1648,15 +1490,17 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "fdir/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
     "find-yarn-workspace-root2/pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
     "glob/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "gray-matter/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
-    "istanbul-lib-report/make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
+    "jest-message-util/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
-    "istanbul-reports/html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+    "jest-util/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "jscodeshift/recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
@@ -1670,12 +1514,6 @@
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
-    "merge-options/is-plain-obj": ["is-plain-obj@2.1.0", "", {}, "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="],
-
-    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
-    "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
-
     "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "ora/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
@@ -1684,49 +1522,31 @@
 
     "pkg-dir/find-up": ["find-up@3.0.0", "", { "dependencies": { "locate-path": "^3.0.0" } }, "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg=="],
 
-    "playwright-test/esbuild": ["esbuild@0.25.8", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.8", "@esbuild/android-arm": "0.25.8", "@esbuild/android-arm64": "0.25.8", "@esbuild/android-x64": "0.25.8", "@esbuild/darwin-arm64": "0.25.8", "@esbuild/darwin-x64": "0.25.8", "@esbuild/freebsd-arm64": "0.25.8", "@esbuild/freebsd-x64": "0.25.8", "@esbuild/linux-arm": "0.25.8", "@esbuild/linux-arm64": "0.25.8", "@esbuild/linux-ia32": "0.25.8", "@esbuild/linux-loong64": "0.25.8", "@esbuild/linux-mips64el": "0.25.8", "@esbuild/linux-ppc64": "0.25.8", "@esbuild/linux-riscv64": "0.25.8", "@esbuild/linux-s390x": "0.25.8", "@esbuild/linux-x64": "0.25.8", "@esbuild/netbsd-arm64": "0.25.8", "@esbuild/netbsd-x64": "0.25.8", "@esbuild/openbsd-arm64": "0.25.8", "@esbuild/openbsd-x64": "0.25.8", "@esbuild/openharmony-arm64": "0.25.8", "@esbuild/sunos-x64": "0.25.8", "@esbuild/win32-arm64": "0.25.8", "@esbuild/win32-ia32": "0.25.8", "@esbuild/win32-x64": "0.25.8" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q=="],
-
-    "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
-
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
-    "sharp/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+    "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "sirv/@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
+    "sharp/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
-    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "tempy/is-stream": ["is-stream@3.0.0", "", {}, "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="],
-
-    "tempy/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
-
-    "test-exclude/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
-
-    "test-exclude/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+    "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
-    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "@b9g/crankdown/@b9g/libuild/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
-    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
-
-    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+    "@b9g/crankdown/@b9g/libuild/esbuild": ["esbuild@0.19.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.19.12", "@esbuild/android-arm": "0.19.12", "@esbuild/android-arm64": "0.19.12", "@esbuild/android-x64": "0.19.12", "@esbuild/darwin-arm64": "0.19.12", "@esbuild/darwin-x64": "0.19.12", "@esbuild/freebsd-arm64": "0.19.12", "@esbuild/freebsd-x64": "0.19.12", "@esbuild/linux-arm": "0.19.12", "@esbuild/linux-arm64": "0.19.12", "@esbuild/linux-ia32": "0.19.12", "@esbuild/linux-loong64": "0.19.12", "@esbuild/linux-mips64el": "0.19.12", "@esbuild/linux-ppc64": "0.19.12", "@esbuild/linux-riscv64": "0.19.12", "@esbuild/linux-s390x": "0.19.12", "@esbuild/linux-x64": "0.19.12", "@esbuild/netbsd-x64": "0.19.12", "@esbuild/openbsd-x64": "0.19.12", "@esbuild/sunos-x64": "0.19.12", "@esbuild/win32-arm64": "0.19.12", "@esbuild/win32-ia32": "0.19.12", "@esbuild/win32-x64": "0.19.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
@@ -1778,10 +1598,6 @@
 
     "astro/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
-    "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
     "eslint-plugin-crank/eslint/@eslint/eslintrc": ["@eslint/eslintrc@3.3.3", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ=="],
 
     "eslint-plugin-crank/eslint/eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
@@ -1800,8 +1616,6 @@
 
     "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
-    "istanbul-lib-report/make-dir/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
     "jscodeshift/recast/ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
     "load-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
@@ -1812,65 +1626,7 @@
 
     "pkg-dir/find-up/locate-path": ["locate-path@3.0.0", "", { "dependencies": { "p-locate": "^3.0.0", "path-exists": "^3.0.0" } }, "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A=="],
 
-    "playwright-test/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.8", "", { "os": "aix", "cpu": "ppc64" }, "sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA=="],
-
-    "playwright-test/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.8", "", { "os": "android", "cpu": "arm" }, "sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw=="],
-
-    "playwright-test/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.8", "", { "os": "android", "cpu": "arm64" }, "sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w=="],
-
-    "playwright-test/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.8", "", { "os": "android", "cpu": "x64" }, "sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA=="],
-
-    "playwright-test/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw=="],
-
-    "playwright-test/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg=="],
-
-    "playwright-test/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.8", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA=="],
-
-    "playwright-test/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.8", "", { "os": "freebsd", "cpu": "x64" }, "sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw=="],
-
-    "playwright-test/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.8", "", { "os": "linux", "cpu": "arm" }, "sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg=="],
-
-    "playwright-test/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w=="],
-
-    "playwright-test/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.8", "", { "os": "linux", "cpu": "ia32" }, "sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg=="],
-
-    "playwright-test/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.8", "", { "os": "linux", "cpu": "none" }, "sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ=="],
-
-    "playwright-test/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.8", "", { "os": "linux", "cpu": "none" }, "sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw=="],
-
-    "playwright-test/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.8", "", { "os": "linux", "cpu": "ppc64" }, "sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ=="],
-
-    "playwright-test/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.8", "", { "os": "linux", "cpu": "none" }, "sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg=="],
-
-    "playwright-test/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.8", "", { "os": "linux", "cpu": "s390x" }, "sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg=="],
-
-    "playwright-test/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.8", "", { "os": "linux", "cpu": "x64" }, "sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ=="],
-
-    "playwright-test/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.8", "", { "os": "none", "cpu": "arm64" }, "sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw=="],
-
-    "playwright-test/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.8", "", { "os": "none", "cpu": "x64" }, "sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg=="],
-
-    "playwright-test/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.8", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ=="],
-
-    "playwright-test/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.8", "", { "os": "openbsd", "cpu": "x64" }, "sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ=="],
-
-    "playwright-test/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.8", "", { "os": "none", "cpu": "arm64" }, "sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg=="],
-
-    "playwright-test/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.8", "", { "os": "sunos", "cpu": "x64" }, "sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w=="],
-
-    "playwright-test/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ=="],
-
-    "playwright-test/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.8", "", { "os": "win32", "cpu": "ia32" }, "sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg=="],
-
-    "playwright-test/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.8", "", { "os": "win32", "cpu": "x64" }, "sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw=="],
-
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "test-exclude/glob/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
-
-    "test-exclude/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
-
-    "test-exclude/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
 
@@ -1918,11 +1674,53 @@
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
-    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
     "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
-    "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.19.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.19.12", "", { "os": "android", "cpu": "arm" }, "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.19.12", "", { "os": "android", "cpu": "arm64" }, "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.19.12", "", { "os": "android", "cpu": "x64" }, "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.19.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.19.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.19.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.19.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.19.12", "", { "os": "linux", "cpu": "arm" }, "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.19.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.19.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.19.12", "", { "os": "linux", "cpu": "none" }, "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.19.12", "", { "os": "linux", "cpu": "none" }, "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.19.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.19.12", "", { "os": "linux", "cpu": "none" }, "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.19.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.19.12", "", { "os": "linux", "cpu": "x64" }, "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.19.12", "", { "os": "none", "cpu": "x64" }, "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.19.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.19.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.19.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.19.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ=="],
+
+    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.19.12", "", { "os": "win32", "cpu": "x64" }, "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA=="],
 
     "eslint-plugin-crank/eslint/@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
@@ -1935,8 +1733,6 @@
     "pkg-dir/find-up/locate-path/p-locate": ["p-locate@3.0.0", "", { "dependencies": { "p-limit": "^2.0.0" } }, "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ=="],
 
     "pkg-dir/find-up/locate-path/path-exists": ["path-exists@3.0.0", "", {}, "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="],
-
-    "test-exclude/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "find-yarn-workspace-root2/pkg-dir/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "module": "./dist/crank.js",
   "types": "./dist/crank.d.ts",
   "devDependencies": {
-    "@b9g/libuild": "^0.2.16",
+    "@b9g/libuild": "^0.2.17",
     "@types/node": "^22.14.0",
     "@types/sinon": "^17.0.4",
     "@typescript-eslint/eslint-plugin": "^8.29.1",
@@ -40,7 +40,7 @@
     "publish": "libuild publish",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "test": "npm run test:core && npm run test:eslint && npm run test:crankdown",
-    "test:core": "libuild test \"test/*.tsx\" \"test/*.ts\" --platform chromium",
+    "test:core": "libuild test test/ --platform chromium",
     "test:crankdown": "cd packages/crankdown && npm run typecheck && bun test",
     "test:eslint": "cd packages/eslint-plugin-crank && bun test",
     "typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "module": "./dist/crank.js",
   "types": "./dist/crank.d.ts",
   "devDependencies": {
-    "@b9g/libuild": "^0.2.18",
+    "@b9g/libuild": "^0.2.19",
     "@types/node": "^22.14.0",
     "@types/sinon": "^17.0.4",
     "@typescript-eslint/eslint-plugin": "^8.29.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "module": "./dist/crank.js",
   "types": "./dist/crank.d.ts",
   "devDependencies": {
-    "@b9g/libuild": "^0.2.17",
+    "@b9g/libuild": "^0.2.18",
     "@types/node": "^22.14.0",
     "@types/sinon": "^17.0.4",
     "@typescript-eslint/eslint-plugin": "^8.29.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "module": "./dist/crank.js",
   "types": "./dist/crank.d.ts",
   "devDependencies": {
-    "@b9g/libuild": "^0.2.19",
+    "@b9g/libuild": "^0.2.16",
     "@types/node": "^22.14.0",
     "@types/sinon": "^17.0.4",
     "@typescript-eslint/eslint-plugin": "^8.29.1",
@@ -20,11 +20,10 @@
     "eslint-plugin-crank": "workspace:*",
     "eslint-plugin-prettier": "^5.2.6",
     "eslint-plugin-react": "^7.37.5",
-    "playwright-test": "^14.1.9",
+    "playwright": "^1.62.1",
     "prettier": "^3.5.3",
     "sinon": "^17.0.2",
-    "typescript": "^5.8.3",
-    "uvu": "^0.5.6"
+    "typescript": "^5.8.3"
   },
   "bugs": {
     "url": "https://github.com/bikeshaving/crank/issues"
@@ -41,7 +40,7 @@
     "publish": "libuild publish",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "test": "npm run test:core && npm run test:eslint && npm run test:crankdown",
-    "test:core": "playwright-test --runner uvu",
+    "test:core": "libuild test \"test/*.tsx\" \"test/*.ts\" --platform chromium",
     "test:crankdown": "cd packages/crankdown && npm run typecheck && bun test",
     "test:eslint": "cd packages/eslint-plugin-crank && bun test",
     "typecheck": "tsc --noEmit",

--- a/playwright-test.config.js
+++ b/playwright-test.config.js
@@ -1,3 +1,0 @@
-export default {
-	input: ["test/*.tsx"],
-};

--- a/test/after.tsx
+++ b/test/after.tsx
@@ -1,396 +1,392 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import * as Sinon from "sinon";
 import {createElement, Context, Element} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("after");
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+describe("after", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test("callback called after insertion into the DOM", () => {
-	const fn = Sinon.fake();
-	const callback = (el: HTMLElement) => fn(document.body.contains(el));
-	function Component(this: Context): Element {
-		this.after(callback);
-		return <span>Hello</span>;
-	}
+	test("callback called after insertion into the DOM", () => {
+		const fn = Sinon.fake();
+		const callback = (el: HTMLElement) => fn(document.body.contains(el));
+		function Component(this: Context): Element {
+			this.after(callback);
+			return <span>Hello</span>;
+		}
 
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<span>Hello</span>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], true);
-});
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<span>Hello</span>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(true);
+	});
 
-test("callback called once in a function", () => {
-	let i = 0;
-	const fn = Sinon.fake();
-	function Component(this: Context): Element {
-		if (i === 0) {
+	test("callback called once in a function", () => {
+		let i = 0;
+		const fn = Sinon.fake();
+		function Component(this: Context): Element {
+			if (i === 0) {
+				this.after(fn);
+			}
+
+			return <span>{i++}</span>;
+		}
+
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+	});
+
+	test("callback called every time in a function", () => {
+		let i = 0;
+		const fn = Sinon.fake();
+		function Component(this: Context): Element {
 			this.after(fn);
+			return <span>{i++}</span>;
 		}
 
-		return <span>{i++}</span>;
-	}
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-});
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		expect(fn.callCount).toBe(2);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+	});
 
-test("callback called every time in a function", () => {
-	let i = 0;
-	const fn = Sinon.fake();
-	function Component(this: Context): Element {
-		this.after(fn);
-		return <span>{i++}</span>;
-	}
-
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	Assert.is(fn.callCount, 2);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-});
-
-test("called called once in a generator", () => {
-	const fn = Sinon.fake();
-	function* Component(this: Context): Generator<Element> {
-		let i = 0;
-		this.after(fn);
-		for (const _ of this) {
-			yield <span>{i++}</span>;
-		}
-	}
-
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-});
-
-test("callback called every time in a generator", () => {
-	const fn = Sinon.fake();
-	function* Component(this: Context): Generator<Element> {
-		let i = 0;
-		for (const _ of this) {
+	test("called called once in a generator", () => {
+		const fn = Sinon.fake();
+		function* Component(this: Context): Generator<Element> {
+			let i = 0;
 			this.after(fn);
-			yield <span>{i++}</span>;
+			for (const _ of this) {
+				yield <span>{i++}</span>;
+			}
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	Assert.is(fn.callCount, 2);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-});
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+	});
 
-test("callback called once in an async function", async () => {
-	let i = 0;
-	const fn = Sinon.fake();
-	async function Component(this: Context) {
-		if (i === 0) {
+	test("callback called every time in a generator", () => {
+		const fn = Sinon.fake();
+		function* Component(this: Context): Generator<Element> {
+			let i = 0;
+			for (const _ of this) {
+				this.after(fn);
+				yield <span>{i++}</span>;
+			}
+		}
+
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		expect(fn.callCount).toBe(2);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+	});
+
+	test("callback called once in an async function", async () => {
+		let i = 0;
+		const fn = Sinon.fake();
+		async function Component(this: Context) {
+			if (i === 0) {
+				this.after(fn);
+			}
+
+			return <span>{i++}</span>;
+		}
+
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+	});
+
+	test("callback called every time in an async function", async () => {
+		let i = 0;
+		const fn = Sinon.fake();
+		async function Component(this: Context) {
 			this.after(fn);
+			return <span>{i++}</span>;
 		}
 
-		return <span>{i++}</span>;
-	}
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
 
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-});
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		expect(fn.callCount).toBe(2);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+	});
 
-test("callback called every time in an async function", async () => {
-	let i = 0;
-	const fn = Sinon.fake();
-	async function Component(this: Context) {
-		this.after(fn);
-		return <span>{i++}</span>;
-	}
-
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	Assert.is(fn.callCount, 2);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-});
-
-test("callback called once in an async generator", async () => {
-	const fn = Sinon.fake();
-	async function* Component(this: Context) {
-		let i = 0;
-		this.after(fn);
-		for await (const _ of this) {
-			yield <span>{i++}</span>;
-		}
-	}
-
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-});
-
-test("callback called every time in an async generator", async () => {
-	const fn = Sinon.fake();
-	async function* Component(this: Context) {
-		let i = 0;
-		for await (const _ of this) {
+	test("callback called once in an async generator", async () => {
+		const fn = Sinon.fake();
+		async function* Component(this: Context) {
+			let i = 0;
 			this.after(fn);
-			yield <span>{i++}</span>;
+			for await (const _ of this) {
+				yield <span>{i++}</span>;
+			}
 		}
-	}
 
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
 
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	Assert.is(fn.callCount, 2);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+	});
+
+	test("callback called every time in an async generator", async () => {
+		const fn = Sinon.fake();
+		async function* Component(this: Context) {
+			let i = 0;
+			for await (const _ of this) {
+				this.after(fn);
+				yield <span>{i++}</span>;
+			}
+		}
+
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		expect(fn.callCount).toBe(2);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+	});
+
+	test("callback isn’t called when sibling is refreshed", () => {
+		const fn1 = Sinon.fake();
+		const fn2 = Sinon.fake();
+		let ctx1!: Context;
+		let ctx2!: Context;
+		function* Component(this: Context): Generator<Element> {
+			ctx1 = this;
+			let i = 0;
+			for (const _ of this) {
+				this.after(fn1);
+				yield <span>{i++}</span>;
+			}
+		}
+
+		function* Sibling(this: Context) {
+			let i = 0;
+			ctx2 = this;
+			for (const _ of this) {
+				this.after(fn2);
+				yield <span>sibling {i++}</span>;
+			}
+		}
+
+		renderer.render(
+			<div>
+				<Component />
+				<Sibling />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			"<div><span>0</span><span>sibling 0</span></div>",
+		);
+		expect(fn1.callCount).toBe(1);
+		expect(fn2.callCount).toBe(1);
+		expect(fn1.lastCall.args[0]).toBe(document.body.firstChild!.childNodes[0]);
+		expect(fn2.lastCall.args[0]).toBe(document.body.firstChild!.childNodes[1]);
+		ctx1.after(fn1);
+		ctx2.refresh();
+		expect(document.body.innerHTML).toBe(
+			"<div><span>0</span><span>sibling 1</span></div>",
+		);
+		expect(fn1.callCount).toBe(1);
+		expect(fn2.callCount).toBe(2);
+		expect(fn2.lastCall.args[0]).toBe(document.body.firstChild!.childNodes[1]);
+	});
+
+	test("callback called after insertion with schedule refresh edge case", () => {
+		const fn = Sinon.fake();
+
+		function* Component(this: Context) {
+			this.after((el) => {
+				fn(document.contains(el));
+			});
+
+			this.schedule(() => {
+				this.refresh();
+			});
+
+			let i = 1;
+			for ({} of this) {
+				yield <span>render {i++}</span>;
+			}
+		}
+
+		// Somehow adding an extra div caused an edge case
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>render 2</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.firstCall.args[0]).toBe(true);
+	});
+
+	test("callback called after insertion with async schedule refresh edge case", async () => {
+		const fn = Sinon.fake();
+		async function* Component(this: Context) {
+			this.after((el) => {
+				fn(document.contains(el));
+			});
+			this.schedule(() => this.refresh());
+			let i = 1;
+			for ({} of this) {
+				yield <span>render {i++}</span>;
+			}
+		}
+
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>render 2</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.firstCall.args[0]).toBe(true);
+	});
 });
-
-test("callback isn’t called when sibling is refreshed", () => {
-	const fn1 = Sinon.fake();
-	const fn2 = Sinon.fake();
-	let ctx1!: Context;
-	let ctx2!: Context;
-	function* Component(this: Context): Generator<Element> {
-		ctx1 = this;
-		let i = 0;
-		for (const _ of this) {
-			this.after(fn1);
-			yield <span>{i++}</span>;
-		}
-	}
-
-	function* Sibling(this: Context) {
-		let i = 0;
-		ctx2 = this;
-		for (const _ of this) {
-			this.after(fn2);
-			yield <span>sibling {i++}</span>;
-		}
-	}
-
-	renderer.render(
-		<div>
-			<Component />
-			<Sibling />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>0</span><span>sibling 0</span></div>",
-	);
-	Assert.is(fn1.callCount, 1);
-	Assert.is(fn2.callCount, 1);
-	Assert.is(fn1.lastCall.args[0], document.body.firstChild!.childNodes[0]);
-	Assert.is(fn2.lastCall.args[0], document.body.firstChild!.childNodes[1]);
-	ctx1.after(fn1);
-	ctx2.refresh();
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>0</span><span>sibling 1</span></div>",
-	);
-	Assert.is(fn1.callCount, 1);
-	Assert.is(fn2.callCount, 2);
-	Assert.is(fn2.lastCall.args[0], document.body.firstChild!.childNodes[1]);
-});
-
-test("callback called after insertion with schedule refresh edge case", () => {
-	const fn = Sinon.fake();
-
-	function* Component(this: Context) {
-		this.after((el) => {
-			fn(document.contains(el));
-		});
-
-		this.schedule(() => {
-			this.refresh();
-		});
-
-		let i = 1;
-		for ({} of this) {
-			yield <span>render {i++}</span>;
-		}
-	}
-
-	// Somehow adding an extra div caused an edge case
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>render 2</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.firstCall.args[0], true);
-});
-
-test("callback called after insertion with async schedule refresh edge case", async () => {
-	const fn = Sinon.fake();
-	async function* Component(this: Context) {
-		this.after((el) => {
-			fn(document.contains(el));
-		});
-		this.schedule(() => this.refresh());
-		let i = 1;
-		for ({} of this) {
-			yield <span>render {i++}</span>;
-		}
-	}
-
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>render 2</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.firstCall.args[0], true);
-});
-
-test.run();

--- a/test/async-function.tsx
+++ b/test/async-function.tsx
@@ -1,233 +1,231 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import * as Sinon from "sinon";
 
 import {createElement, Element} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("async functions");
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
-
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
-
-test("basic", async () => {
-	async function Component({message}: {message: string}): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 100));
-		return <span>{message}</span>;
-	}
-
-	const p = renderer.render(
-		<div>
-			<Component message="Hello" />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "");
-	Assert.is(await p, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-});
-
-test("updates enqueue", async () => {
-	const fn = Sinon.fake();
-	async function Component({message}: {message: string}): Promise<Element> {
-		fn();
-		await new Promise((resolve) => setTimeout(resolve, 25));
-		return <span>{message}</span>;
-	}
-
-	const p1 = renderer.render(
-		<div>
-			<Component message="Hello 1" />
-		</div>,
-		document.body,
-	);
-	const p2 = renderer.render(
-		<div>
-			<Component message="Hello 2" />
-		</div>,
-		document.body,
-	);
-	const p3 = renderer.render(
-		<div>
-			<Component message="Hello 3" />
-		</div>,
-		document.body,
-	);
-	const p4 = renderer.render(
-		<div>
-			<Component message="Hello 4" />
-		</div>,
-		document.body,
-	);
-	const p5 = renderer.render(
-		<div>
-			<Component message="Hello 5" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "");
-	Assert.is(await p1, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 1</span></div>");
-	Assert.is(await p2, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 5</span></div>");
-	Assert.is(await p3, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 5</span></div>");
-	Assert.is(await p4, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 5</span></div>");
-	const p6 = renderer.render(
-		<div>
-			<Component message="Hello 6" />
-		</div>,
-		document.body,
-	);
-	const p7 = renderer.render(
-		<div>
-			<Component message="Hello 7" />
-		</div>,
-		document.body,
-	);
-	const p8 = renderer.render(
-		<div>
-			<Component message="Hello 8" />
-		</div>,
-		document.body,
-	);
-	const p9 = renderer.render(
-		<div>
-			<Component message="Hello 9" />
-		</div>,
-		document.body,
-	);
-	const p10 = renderer.render(
-		<div>
-			<Component message="Hello 10" />
-		</div>,
-		document.body,
-	);
-	Assert.is(await p5, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 5</span></div>");
-	Assert.is(await p6, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 6</span></div>");
-	Assert.is(await p7, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 10</span></div>");
-	Assert.is(await p8, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 10</span></div>");
-	Assert.is(await p9, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 10</span></div>");
-	Assert.is(await p10, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 10</span></div>");
-	Assert.is(fn.callCount, 4);
-});
-
-test("update", async () => {
-	const resolves: Array<Function> = [];
-	async function Component({message}: {message: string}): Promise<Element> {
-		await new Promise((resolve) => resolves.push(resolve));
-		return <span>{message}</span>;
-	}
-
-	let p = renderer.render(
-		<div>
-			<Component message="Hello 1" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "");
-	resolves[0]();
-	await p;
-	Assert.is(document.body.innerHTML, "<div><span>Hello 1</span></div>");
-	p = renderer.render(
-		<div>
-			<Component message="Hello 2" />
-		</div>,
-		document.body,
-	);
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(document.body.innerHTML, "<div><span>Hello 1</span></div>");
-	resolves[1]();
-	await p;
-	Assert.is(document.body.innerHTML, "<div><span>Hello 2</span></div>");
-	Assert.is(resolves.length, 2);
-});
-
-test("out of order", async () => {
-	async function Component({
-		message,
-		delay,
-	}: {
-		message: string;
-		delay: number;
-	}): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, delay));
-		return <span>{message}</span>;
-	}
-
-	const p1 = renderer.render(
-		<div>
-			<Component message="Hello 1" delay={100} />
-		</div>,
-		document.body,
-	);
-	const p2 = renderer.render(
-		<div>
-			<Component message="Hello 2" delay={0} />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "");
-	await p1;
-	Assert.is(document.body.innerHTML, "<div><span>Hello 1</span></div>");
-	await p2;
-	Assert.is(document.body.innerHTML, "<div><span>Hello 2</span></div>");
-});
-
-test("async children enqueue", async () => {
-	const Child = Sinon.fake(async function Child({
-		message,
-	}: {
-		message: string;
-	}): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 100));
-		return <div>{message}</div>;
+describe("async functions", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
 	});
 
-	async function Parent({message}: {message: string}): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 50));
-		return <Child message={message} />;
-	}
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-	const p1 = renderer.render(<Parent message="Hello 1" />, document.body);
-	const p2 = renderer.render(<Parent message="Hello 2" />, document.body);
-	const p3 = renderer.render(<Parent message="Hello 3" />, document.body);
-	const p4 = renderer.render(<Parent message="Hello 4" />, document.body);
-	Assert.is(await p1, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>Hello 1</div>");
-	Assert.is(await p2, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>Hello 4</div>");
-	Assert.is(await p3, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>Hello 4</div>");
-	const p5 = renderer.render(<Parent message="Hello 5" />, document.body);
-	const p6 = renderer.render(<Parent message="Hello 6" />, document.body);
-	const p7 = renderer.render(<Parent message="Hello 7" />, document.body);
-	const p8 = renderer.render(<Parent message="Hello 8" />, document.body);
-	Assert.is(await p4, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>Hello 4</div>");
-	Assert.is(await p5, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>Hello 5</div>");
-	Assert.is(await p6, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>Hello 8</div>");
-	Assert.is(await p7, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>Hello 8</div>");
-	Assert.is(await p8, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>Hello 8</div>");
-	Assert.is(Child.callCount, 4);
+	test("basic", async () => {
+		async function Component({message}: {message: string}): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			return <span>{message}</span>;
+		}
+
+		const p = renderer.render(
+			<div>
+				<Component message="Hello" />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("");
+		expect(await p).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+	});
+
+	test("updates enqueue", async () => {
+		const fn = Sinon.fake();
+		async function Component({message}: {message: string}): Promise<Element> {
+			fn();
+			await new Promise((resolve) => setTimeout(resolve, 25));
+			return <span>{message}</span>;
+		}
+
+		const p1 = renderer.render(
+			<div>
+				<Component message="Hello 1" />
+			</div>,
+			document.body,
+		);
+		const p2 = renderer.render(
+			<div>
+				<Component message="Hello 2" />
+			</div>,
+			document.body,
+		);
+		const p3 = renderer.render(
+			<div>
+				<Component message="Hello 3" />
+			</div>,
+			document.body,
+		);
+		const p4 = renderer.render(
+			<div>
+				<Component message="Hello 4" />
+			</div>,
+			document.body,
+		);
+		const p5 = renderer.render(
+			<div>
+				<Component message="Hello 5" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("");
+		expect(await p1).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 1</span></div>");
+		expect(await p2).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 5</span></div>");
+		expect(await p3).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 5</span></div>");
+		expect(await p4).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 5</span></div>");
+		const p6 = renderer.render(
+			<div>
+				<Component message="Hello 6" />
+			</div>,
+			document.body,
+		);
+		const p7 = renderer.render(
+			<div>
+				<Component message="Hello 7" />
+			</div>,
+			document.body,
+		);
+		const p8 = renderer.render(
+			<div>
+				<Component message="Hello 8" />
+			</div>,
+			document.body,
+		);
+		const p9 = renderer.render(
+			<div>
+				<Component message="Hello 9" />
+			</div>,
+			document.body,
+		);
+		const p10 = renderer.render(
+			<div>
+				<Component message="Hello 10" />
+			</div>,
+			document.body,
+		);
+		expect(await p5).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 5</span></div>");
+		expect(await p6).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 6</span></div>");
+		expect(await p7).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 10</span></div>");
+		expect(await p8).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 10</span></div>");
+		expect(await p9).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 10</span></div>");
+		expect(await p10).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 10</span></div>");
+		expect(fn.callCount).toBe(4);
+	});
+
+	test("update", async () => {
+		const resolves: Array<Function> = [];
+		async function Component({message}: {message: string}): Promise<Element> {
+			await new Promise((resolve) => resolves.push(resolve));
+			return <span>{message}</span>;
+		}
+
+		let p = renderer.render(
+			<div>
+				<Component message="Hello 1" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("");
+		resolves[0]();
+		await p;
+		expect(document.body.innerHTML).toBe("<div><span>Hello 1</span></div>");
+		p = renderer.render(
+			<div>
+				<Component message="Hello 2" />
+			</div>,
+			document.body,
+		);
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe("<div><span>Hello 1</span></div>");
+		resolves[1]();
+		await p;
+		expect(document.body.innerHTML).toBe("<div><span>Hello 2</span></div>");
+		expect(resolves.length).toBe(2);
+	});
+
+	test("out of order", async () => {
+		async function Component({
+			message,
+			delay,
+		}: {
+			message: string;
+			delay: number;
+		}): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, delay));
+			return <span>{message}</span>;
+		}
+
+		const p1 = renderer.render(
+			<div>
+				<Component message="Hello 1" delay={100} />
+			</div>,
+			document.body,
+		);
+		const p2 = renderer.render(
+			<div>
+				<Component message="Hello 2" delay={0} />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("");
+		await p1;
+		expect(document.body.innerHTML).toBe("<div><span>Hello 1</span></div>");
+		await p2;
+		expect(document.body.innerHTML).toBe("<div><span>Hello 2</span></div>");
+	});
+
+	test("async children enqueue", async () => {
+		const Child = Sinon.fake(async function Child({
+			message,
+		}: {
+			message: string;
+		}): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			return <div>{message}</div>;
+		});
+
+		async function Parent({message}: {message: string}): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			return <Child message={message} />;
+		}
+
+		const p1 = renderer.render(<Parent message="Hello 1" />, document.body);
+		const p2 = renderer.render(<Parent message="Hello 2" />, document.body);
+		const p3 = renderer.render(<Parent message="Hello 3" />, document.body);
+		const p4 = renderer.render(<Parent message="Hello 4" />, document.body);
+		expect(await p1).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>Hello 1</div>");
+		expect(await p2).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>Hello 4</div>");
+		expect(await p3).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>Hello 4</div>");
+		const p5 = renderer.render(<Parent message="Hello 5" />, document.body);
+		const p6 = renderer.render(<Parent message="Hello 6" />, document.body);
+		const p7 = renderer.render(<Parent message="Hello 7" />, document.body);
+		const p8 = renderer.render(<Parent message="Hello 8" />, document.body);
+		expect(await p4).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>Hello 4</div>");
+		expect(await p5).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>Hello 5</div>");
+		expect(await p6).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>Hello 8</div>");
+		expect(await p7).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>Hello 8</div>");
+		expect(await p8).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>Hello 8</div>");
+		expect(Child.callCount).toBe(4);
+	});
 });
-
-test.run();

--- a/test/async-generator.tsx
+++ b/test/async-generator.tsx
@@ -1,5 +1,4 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import * as Sinon from "sinon";
 
 import {
@@ -12,1182 +11,1190 @@ import {
 } from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("async generator");
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
-
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
-
-test("basic", async () => {
-	const Component = Sinon.fake(async function* Component(
-		this: Context,
-		{message}: {message: string},
-	): AsyncGenerator<Element> {
-		let i = 0;
-		for ({message} of this) {
-			if (++i > 2) {
-				return <span>Final</span>;
-			}
-
-			yield <span>{message}</span>;
-		}
+describe("async generator", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
 	});
 
-	await renderer.render(
-		<div>
-			<Component message="Hello 1" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 1</span></div>");
-	await renderer.render(
-		<div>
-			<Component message="Hello 2" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 2</span></div>");
-	await renderer.render(
-		<div>
-			<Component message="Hello 3" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Final</span></div>");
-	Assert.is(Component.callCount, 1);
-});
-
-test("refresh", async () => {
-	let ctx!: Context;
-	async function* Component(this: Context): AsyncGenerator<Element> {
-		ctx = this;
-		let i = 1;
-		while (true) {
-			yield <span>Hello {i++}</span>;
-		}
-	}
-
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>Hello 1</span></div>");
-	await ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div><span>Hello 2</span></div>");
-	await ctx.refresh();
-	await ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div><span>Hello 4</span></div>");
-});
-
-test("refreshing doesn’t cause siblings to update", async () => {
-	const mock = Sinon.fake();
-	function Sibling(): Element {
-		mock();
-		return <div>Sibling</div>;
-	}
-
-	let ctx!: Context;
-	async function* Component(this: Context): AsyncGenerator<Element> {
-		ctx = this;
-		let i = 0;
-		while (true) {
-			i++;
-			yield <div>Hello {i}</div>;
-		}
-	}
-	await renderer.render(
-		<Fragment>
-			<Component />
-			<Sibling />
-		</Fragment>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div>Hello 1</div><div>Sibling</div>");
-	Assert.is(mock.callCount, 1);
-	await ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div>Hello 2</div><div>Sibling</div>");
-	Assert.is(mock.callCount, 1);
-	await ctx.refresh();
-	await ctx.refresh();
-	await ctx.refresh();
-	await ctx.refresh();
-	await ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div>Hello 7</div><div>Sibling</div>");
-	Assert.is(mock.callCount, 1);
-	await renderer.render(
-		<Fragment>
-			<Component />
-			<Sibling />
-		</Fragment>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div>Hello 8</div><div>Sibling</div>");
-	Assert.is(mock.callCount, 2);
-});
-
-test("while (true) loop", async () => {
-	async function* Timer(this: Context): AsyncGenerator<Element> {
-		let i = 0;
-		while (true) {
-			yield <span>{i++}</span>;
-		}
-	}
-
-	await renderer.render(<Timer />, document.body);
-	Assert.is(document.body.innerHTML, "<span>0</span>");
-	await new Promise((resolve) => setTimeout(resolve, 50));
-	// Should still be paused at first yield!
-	Assert.is(document.body.innerHTML, "<span>0</span>");
-	await renderer.render(<Timer />, document.body);
-	Assert.is(document.body.innerHTML, "<span>1</span>");
-	await renderer.render(<Timer />, document.body);
-	Assert.is(document.body.innerHTML, "<span>2</span>");
-	await new Promise((resolve) => setTimeout(resolve, 50));
-	Assert.is(document.body.innerHTML, "<span>2</span>");
-});
-
-test("for...of yield resumes with elements", async () => {
-	let node: HTMLElement | undefined;
-	async function* Component(this: Context) {
-		let i = 0;
-		for ({} of this) {
-			node = yield <div id={i}>{i}</div>;
-			i++;
-		}
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(node, undefined);
-	await renderer.render(<Component />, document.body);
-	Assert.is(node!.outerHTML, '<div id="1">1</div>');
-	Assert.is(document.body.innerHTML, '<div id="1">1</div>');
-	await renderer.render(<Component />, document.body);
-	Assert.is(node!.outerHTML, '<div id="2">2</div>');
-	Assert.is(document.body.innerHTML, '<div id="2">2</div>');
-});
-
-test("for...of yield resumes with elements with async children", async () => {
-	async function Child({id}: {id: number}) {
-		await new Promise((resolve) => setTimeout(resolve));
-		return <div id={id}>{id}</div>;
-	}
-	let node: HTMLElement | undefined;
-	async function* Component(this: Context) {
-		let i = 0;
-		for ({} of this) {
-			node = yield <Child id={i} />;
-			i++;
-		}
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(node, undefined);
-	await renderer.render(<Component />, document.body);
-	Assert.is(node!.outerHTML, '<div id="1">1</div>');
-	Assert.is(document.body.innerHTML, '<div id="1">1</div>');
-	await renderer.render(<Component />, document.body);
-	Assert.is(node!.outerHTML, '<div id="2">2</div>');
-	Assert.is(document.body.innerHTML, '<div id="2">2</div>');
-});
-
-test("for await...of", async () => {
-	async function* Component(
-		this: Context,
-		{message}: {message: string},
-	): AsyncGenerator<Element> {
-		for await ({message} of this) {
-			yield <span>{message}</span>;
-		}
-	}
-
-	await renderer.render(<Component message="Hello" />, document.body);
-	Assert.is(document.body.innerHTML, "<span>Hello</span>");
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<span>Hello</span>");
-	await renderer.render(<Component message="Hello again" />, document.body);
-	Assert.is(document.body.innerHTML, "<span>Hello again</span>");
-});
-
-test("for await...of nested", async () => {
-	const Component = Sinon.fake(async function* Component(
-		this: Context,
-		{message}: {message: string},
-	): AsyncGenerator<Element> {
-		let i = 0;
-		for await ({message} of this) {
-			if (i >= 2) {
-				return <span>Final</span>;
-			}
-
-			yield <span>{message}</span>;
-			i++;
-		}
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
 	});
 
-	await renderer.render(
-		<div>
-			<Component message="Hello 1" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 1</span></div>");
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<div><span>Hello 1</span></div>");
-	await renderer.render(
-		<div>
-			<Component message="Hello 2" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 2</span></div>");
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<div><span>Hello 2</span></div>");
-	await renderer.render(
-		<div>
-			<Component message="Hello 3" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Final</span></div>");
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<div><span>Final</span></div>");
-	Assert.is(Component.callCount, 1);
-});
+	test("basic", async () => {
+		const Component = Sinon.fake(async function* Component(
+			this: Context,
+			{message}: {message: string},
+		): AsyncGenerator<Element> {
+			let i = 0;
+			for ({message} of this) {
+				if (++i > 2) {
+					return <span>Final</span>;
+				}
 
-test("for await...of multiple yields per update", async () => {
-	let resolve: undefined | Function;
-	async function* Component(
-		this: Context,
-		{message}: {message: string},
-	): AsyncGenerator<Element> {
-		for await ({message} of this) {
-			yield <span>Loading</span>;
-			await new Promise((resolve1) => (resolve = resolve1));
-			yield <span>{message}</span>;
-		}
-	}
+				yield <span>{message}</span>;
+			}
+		});
 
-	await renderer.render(
-		<div>
-			<Component message="Hello" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Loading</span></div>");
-	await new Promise((resolve) => setTimeout(resolve));
-	resolve!();
-	resolve = undefined;
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	await renderer.render(
-		<div>
-			<Component message="Goodbye" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Loading</span></div>");
-	await new Promise((resolve) => setTimeout(resolve));
-	resolve!();
-	resolve = undefined;
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<div><span>Goodbye</span></div>");
-});
-
-test("for await...of multiple yields per update sync", async () => {
-	async function* Component(
-		this: Context,
-		{message}: {message: string},
-	): AsyncGenerator<Element> {
-		for await ({message} of this) {
-			yield <span>{message} 1</span>;
-			yield <span>{message} 2</span>;
-			yield <span>{message} 3</span>;
-		}
-	}
-
-	const result = (await renderer.render(
-		<div>
-			<Component message="Hello" />
-		</div>,
-		document.body,
-	)) as HTMLElement;
-
-	Assert.is(result.outerHTML, "<div><span>Hello 3</span></div>");
-	Assert.is(document.body.innerHTML, "<div><span>Hello 3</span></div>");
-
-	await Promise.resolve();
-	Assert.is(document.body.innerHTML, "<div><span>Hello 3</span></div>");
-});
-
-test("for await...of with Fragment parent", async () => {
-	let resolve!: Function;
-	async function* Component(this: Context) {
-		for await (const _ of this) {
-			yield 1;
-			await new Promise((resolve1) => (resolve = resolve1));
-			yield 2;
-		}
-	}
-
-	await renderer.render(
-		<Fragment>
-			<Component />
-		</Fragment>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "1");
-	await new Promise((resolve) => setTimeout(resolve, 10));
-	Assert.is(document.body.innerHTML, "1");
-	resolve();
-	await new Promise((resolve) => setTimeout(resolve, 0));
-	Assert.is(document.body.innerHTML, "2");
-	await new Promise((resolve) => setTimeout(resolve, 10));
-	Assert.is(document.body.innerHTML, "2");
-});
-
-test("for await...of yield resumes with a promise of an element", async () => {
-	let nodeP: Promise<HTMLElement> | undefined;
-	async function* Component(this: Context) {
-		let i = 0;
-		for await ({} of this) {
-			nodeP = yield <div id={i}>{i}</div>;
-			i++;
-		}
-	}
-
-	await renderer.render(<Component />, document.body);
-	let html = (await nodeP!).outerHTML;
-	Assert.is(html, '<div id="0">0</div>');
-	Assert.is(document.body.innerHTML, '<div id="0">0</div>');
-	await renderer.render(<Component />, document.body);
-	html = (await nodeP!).outerHTML;
-	Assert.is(html, '<div id="1">1</div>');
-	Assert.is(document.body.innerHTML, '<div id="1">1</div>');
-	await renderer.render(<Component />, document.body);
-	html = (await nodeP!).outerHTML;
-	Assert.is(html, '<div id="2">2</div>');
-	Assert.is(document.body.innerHTML, '<div id="2">2</div>');
-});
-
-test("for await...of yield resumes async children", async () => {
-	const t = Date.now();
-	const Async = Sinon.fake(async function Async({
-		id,
-	}: {
-		id: number;
-	}): Promise<Child> {
-		await new Promise((resolve) => setTimeout(resolve, 100));
-		return <div id={id}>{id}</div>;
+		await renderer.render(
+			<div>
+				<Component message="Hello 1" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 1</span></div>");
+		await renderer.render(
+			<div>
+				<Component message="Hello 2" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 2</span></div>");
+		await renderer.render(
+			<div>
+				<Component message="Hello 3" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Final</span></div>");
+		expect(Component.callCount).toBe(1);
 	});
 
-	let html: Promise<string> | undefined;
-	async function* Component(this: Context) {
-		let i = 0;
-		for await (const _ of this) {
-			const node: Promise<HTMLElement> = yield <Async id={i} />;
-			html = node.then((node: HTMLElement) => node.outerHTML);
-			await node;
-			i++;
-		}
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(await html, '<div id="0">0</div>');
-	Assert.is(document.body.innerHTML, '<div id="0">0</div>');
-	// TODO: Find a better way to test the timings
-	Assert.ok(Date.now() - t > 100 - 30 && Date.now() - t < 100 + 30);
-	await renderer.render(<Component />, document.body);
-	Assert.is(await html, '<div id="1">1</div>');
-	Assert.is(document.body.innerHTML, '<div id="1">1</div>');
-	Assert.ok(Date.now() - t > 200 - 30 && Date.now() - t < 200 + 30);
-	await renderer.render(<Component />, document.body);
-	Assert.is(await html, '<div id="2">2</div>');
-	Assert.is(document.body.innerHTML, '<div id="2">2</div>');
-	Assert.ok(Date.now() - t > 300 - 30 && Date.now() - t < 300 + 30);
-	Assert.is(Async.callCount, 3);
-});
-
-test("yield before for await loop", async () => {
-	async function* Component(this: Context) {
-		let i = 0;
-		yield <div>{i++}</div>;
-		for await (const _ of this) {
-			yield <div>{i++}</div>;
-		}
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>0</div>");
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(document.body.innerHTML, "<div>0</div>");
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>1</div>");
-});
-
-test("concurrent unmount", async () => {
-	const mock = Sinon.fake();
-	async function* Component(this: Context): AsyncGenerator<Child> {
-		try {
-			for await ({} of this) {
-				yield "Hello world";
+	test("refresh", async () => {
+		let ctx!: Context;
+		async function* Component(this: Context): AsyncGenerator<Element> {
+			ctx = this;
+			let i = 1;
+			while (true) {
+				yield <span>Hello {i++}</span>;
 			}
-		} finally {
+		}
+
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><span>Hello 1</span></div>");
+		await ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div><span>Hello 2</span></div>");
+		await ctx.refresh();
+		await ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div><span>Hello 4</span></div>");
+	});
+
+	test("refreshing doesn’t cause siblings to update", async () => {
+		const mock = Sinon.fake();
+		function Sibling(): Element {
 			mock();
+			return <div>Sibling</div>;
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	renderer.render(null, document.body);
-	Assert.is(document.body.innerHTML, "");
-	Assert.is(mock.callCount, 0);
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "");
-	Assert.is(mock.callCount, 1);
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(document.body.innerHTML, "");
-	Assert.is(mock.callCount, 1);
-});
-
-test("async generator returns", async () => {
-	const Component = Sinon.fake(async function* Component(
-		this: Context,
-	): AsyncGenerator<Child> {
-		let started = false;
-		for await (const _ of this) {
-			if (started) {
-				return "Goodbye";
-			} else {
-				yield "Hello";
-				started = true;
+		let ctx!: Context;
+		async function* Component(this: Context): AsyncGenerator<Element> {
+			ctx = this;
+			let i = 0;
+			while (true) {
+				i++;
+				yield <div>Hello {i}</div>;
 			}
 		}
+		await renderer.render(
+			<Fragment>
+				<Component />
+				<Sibling />
+			</Fragment>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div>Hello 1</div><div>Sibling</div>",
+		);
+		expect(mock.callCount).toBe(1);
+		await ctx.refresh();
+		expect(document.body.innerHTML).toBe(
+			"<div>Hello 2</div><div>Sibling</div>",
+		);
+		expect(mock.callCount).toBe(1);
+		await ctx.refresh();
+		await ctx.refresh();
+		await ctx.refresh();
+		await ctx.refresh();
+		await ctx.refresh();
+		expect(document.body.innerHTML).toBe(
+			"<div>Hello 7</div><div>Sibling</div>",
+		);
+		expect(mock.callCount).toBe(1);
+		await renderer.render(
+			<Fragment>
+				<Component />
+				<Sibling />
+			</Fragment>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div>Hello 8</div><div>Sibling</div>",
+		);
+		expect(mock.callCount).toBe(2);
 	});
 
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div>Hello</div>");
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div>Goodbye</div>");
-	Assert.is(Component.callCount, 1);
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div>Hello</div>");
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div>Goodbye</div>");
-	Assert.is(Component.callCount, 2);
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div>Hello</div>");
-	Assert.is(Component.callCount, 3);
-});
+	test("while (true) loop", async () => {
+		async function* Timer(this: Context): AsyncGenerator<Element> {
+			let i = 0;
+			while (true) {
+				yield <span>{i++}</span>;
+			}
+		}
 
-test("try/finally", async () => {
-	const mock = Sinon.fake();
-	async function* Component(this: Context): AsyncGenerator<Child> {
-		try {
+		await renderer.render(<Timer />, document.body);
+		expect(document.body.innerHTML).toBe("<span>0</span>");
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		// Should still be paused at first yield!
+		expect(document.body.innerHTML).toBe("<span>0</span>");
+		await renderer.render(<Timer />, document.body);
+		expect(document.body.innerHTML).toBe("<span>1</span>");
+		await renderer.render(<Timer />, document.body);
+		expect(document.body.innerHTML).toBe("<span>2</span>");
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		expect(document.body.innerHTML).toBe("<span>2</span>");
+	});
+
+	test("for...of yield resumes with elements", async () => {
+		let node: HTMLElement | undefined;
+		async function* Component(this: Context) {
+			let i = 0;
+			for ({} of this) {
+				node = yield <div id={i}>{i}</div>;
+				i++;
+			}
+		}
+
+		await renderer.render(<Component />, document.body);
+		expect(node).toBe(undefined);
+		await renderer.render(<Component />, document.body);
+		expect(node!.outerHTML).toBe('<div id="1">1</div>');
+		expect(document.body.innerHTML).toBe('<div id="1">1</div>');
+		await renderer.render(<Component />, document.body);
+		expect(node!.outerHTML).toBe('<div id="2">2</div>');
+		expect(document.body.innerHTML).toBe('<div id="2">2</div>');
+	});
+
+	test("for...of yield resumes with elements with async children", async () => {
+		async function Child({id}: {id: number}) {
+			await new Promise((resolve) => setTimeout(resolve));
+			return <div id={id}>{id}</div>;
+		}
+		let node: HTMLElement | undefined;
+		async function* Component(this: Context) {
+			let i = 0;
+			for ({} of this) {
+				node = yield <Child id={i} />;
+				i++;
+			}
+		}
+
+		await renderer.render(<Component />, document.body);
+		expect(node).toBe(undefined);
+		await renderer.render(<Component />, document.body);
+		expect(node!.outerHTML).toBe('<div id="1">1</div>');
+		expect(document.body.innerHTML).toBe('<div id="1">1</div>');
+		await renderer.render(<Component />, document.body);
+		expect(node!.outerHTML).toBe('<div id="2">2</div>');
+		expect(document.body.innerHTML).toBe('<div id="2">2</div>');
+	});
+
+	test("for await...of", async () => {
+		async function* Component(
+			this: Context,
+			{message}: {message: string},
+		): AsyncGenerator<Element> {
+			for await ({message} of this) {
+				yield <span>{message}</span>;
+			}
+		}
+
+		await renderer.render(<Component message="Hello" />, document.body);
+		expect(document.body.innerHTML).toBe("<span>Hello</span>");
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<span>Hello</span>");
+		await renderer.render(<Component message="Hello again" />, document.body);
+		expect(document.body.innerHTML).toBe("<span>Hello again</span>");
+	});
+
+	test("for await...of nested", async () => {
+		const Component = Sinon.fake(async function* Component(
+			this: Context,
+			{message}: {message: string},
+		): AsyncGenerator<Element> {
+			let i = 0;
+			for await ({message} of this) {
+				if (i >= 2) {
+					return <span>Final</span>;
+				}
+
+				yield <span>{message}</span>;
+				i++;
+			}
+		});
+
+		await renderer.render(
+			<div>
+				<Component message="Hello 1" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 1</span></div>");
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<div><span>Hello 1</span></div>");
+		await renderer.render(
+			<div>
+				<Component message="Hello 2" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 2</span></div>");
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<div><span>Hello 2</span></div>");
+		await renderer.render(
+			<div>
+				<Component message="Hello 3" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Final</span></div>");
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<div><span>Final</span></div>");
+		expect(Component.callCount).toBe(1);
+	});
+
+	test("for await...of multiple yields per update", async () => {
+		let resolve: undefined | Function;
+		async function* Component(
+			this: Context,
+			{message}: {message: string},
+		): AsyncGenerator<Element> {
+			for await ({message} of this) {
+				yield <span>Loading</span>;
+				await new Promise((resolve1) => (resolve = resolve1));
+				yield <span>{message}</span>;
+			}
+		}
+
+		await renderer.render(
+			<div>
+				<Component message="Hello" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Loading</span></div>");
+		await new Promise((resolve) => setTimeout(resolve));
+		resolve!();
+		resolve = undefined;
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		await renderer.render(
+			<div>
+				<Component message="Goodbye" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Loading</span></div>");
+		await new Promise((resolve) => setTimeout(resolve));
+		resolve!();
+		resolve = undefined;
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<div><span>Goodbye</span></div>");
+	});
+
+	test("for await...of multiple yields per update sync", async () => {
+		async function* Component(
+			this: Context,
+			{message}: {message: string},
+		): AsyncGenerator<Element> {
+			for await ({message} of this) {
+				yield <span>{message} 1</span>;
+				yield <span>{message} 2</span>;
+				yield <span>{message} 3</span>;
+			}
+		}
+
+		const result = (await renderer.render(
+			<div>
+				<Component message="Hello" />
+			</div>,
+			document.body,
+		)) as HTMLElement;
+
+		expect(result.outerHTML).toBe("<div><span>Hello 3</span></div>");
+		expect(document.body.innerHTML).toBe("<div><span>Hello 3</span></div>");
+
+		await Promise.resolve();
+		expect(document.body.innerHTML).toBe("<div><span>Hello 3</span></div>");
+	});
+
+	test("for await...of with Fragment parent", async () => {
+		let resolve!: Function;
+		async function* Component(this: Context) {
+			for await (const _ of this) {
+				yield 1;
+				await new Promise((resolve1) => (resolve = resolve1));
+				yield 2;
+			}
+		}
+
+		await renderer.render(
+			<Fragment>
+				<Component />
+			</Fragment>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("1");
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(document.body.innerHTML).toBe("1");
+		resolve();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(document.body.innerHTML).toBe("2");
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(document.body.innerHTML).toBe("2");
+	});
+
+	test("for await...of yield resumes with a promise of an element", async () => {
+		let nodeP: Promise<HTMLElement> | undefined;
+		async function* Component(this: Context) {
+			let i = 0;
+			for await ({} of this) {
+				nodeP = yield <div id={i}>{i}</div>;
+				i++;
+			}
+		}
+
+		await renderer.render(<Component />, document.body);
+		let html = (await nodeP!).outerHTML;
+		expect(html).toBe('<div id="0">0</div>');
+		expect(document.body.innerHTML).toBe('<div id="0">0</div>');
+		await renderer.render(<Component />, document.body);
+		html = (await nodeP!).outerHTML;
+		expect(html).toBe('<div id="1">1</div>');
+		expect(document.body.innerHTML).toBe('<div id="1">1</div>');
+		await renderer.render(<Component />, document.body);
+		html = (await nodeP!).outerHTML;
+		expect(html).toBe('<div id="2">2</div>');
+		expect(document.body.innerHTML).toBe('<div id="2">2</div>');
+	});
+
+	test("for await...of yield resumes async children", async () => {
+		const t = Date.now();
+		const Async = Sinon.fake(async function Async({
+			id,
+		}: {
+			id: number;
+		}): Promise<Child> {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			return <div id={id}>{id}</div>;
+		});
+
+		let html: Promise<string> | undefined;
+		async function* Component(this: Context) {
 			let i = 0;
 			for await (const _ of this) {
+				const node: Promise<HTMLElement> = yield <Async id={i} />;
+				html = node.then((node: HTMLElement) => node.outerHTML);
+				await node;
+				i++;
+			}
+		}
+
+		await renderer.render(<Component />, document.body);
+		expect(await html).toBe('<div id="0">0</div>');
+		expect(document.body.innerHTML).toBe('<div id="0">0</div>');
+		// TODO: Find a better way to test the timings
+		expect(Date.now() - t > 100 - 30 && Date.now() - t < 100 + 30).toBeTruthy();
+		await renderer.render(<Component />, document.body);
+		expect(await html).toBe('<div id="1">1</div>');
+		expect(document.body.innerHTML).toBe('<div id="1">1</div>');
+		expect(Date.now() - t > 200 - 30 && Date.now() - t < 200 + 30).toBeTruthy();
+		await renderer.render(<Component />, document.body);
+		expect(await html).toBe('<div id="2">2</div>');
+		expect(document.body.innerHTML).toBe('<div id="2">2</div>');
+		expect(Date.now() - t > 300 - 30 && Date.now() - t < 300 + 30).toBeTruthy();
+		expect(Async.callCount).toBe(3);
+	});
+
+	test("yield before for await loop", async () => {
+		async function* Component(this: Context) {
+			let i = 0;
+			yield <div>{i++}</div>;
+			for await (const _ of this) {
+				yield <div>{i++}</div>;
+			}
+		}
+
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>0</div>");
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe("<div>0</div>");
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>1</div>");
+	});
+
+	test("concurrent unmount", async () => {
+		const mock = Sinon.fake();
+		async function* Component(this: Context): AsyncGenerator<Child> {
+			try {
+				for await ({} of this) {
+					yield "Hello world";
+				}
+			} finally {
+				mock();
+			}
+		}
+
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		renderer.render(null, document.body);
+		expect(document.body.innerHTML).toBe("");
+		expect(mock.callCount).toBe(0);
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("");
+		expect(mock.callCount).toBe(1);
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe("");
+		expect(mock.callCount).toBe(1);
+	});
+
+	test("async generator returns", async () => {
+		const Component = Sinon.fake(async function* Component(
+			this: Context,
+		): AsyncGenerator<Child> {
+			let started = false;
+			for await (const _ of this) {
+				if (started) {
+					return "Goodbye";
+				} else {
+					yield "Hello";
+					started = true;
+				}
+			}
+		});
+
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div>Hello</div>");
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div>Goodbye</div>");
+		expect(Component.callCount).toBe(1);
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div>Hello</div>");
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div>Goodbye</div>");
+		expect(Component.callCount).toBe(2);
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div>Hello</div>");
+		expect(Component.callCount).toBe(3);
+	});
+
+	test("try/finally", async () => {
+		const mock = Sinon.fake();
+		async function* Component(this: Context): AsyncGenerator<Child> {
+			try {
+				let i = 0;
+				for await (const _ of this) {
+					yield <div>Hello {i++}</div>;
+				}
+			} finally {
+				mock();
+			}
+		}
+
+		await renderer.render(<Component />, document.body);
+		await renderer.render(<Component />, document.body);
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello 2</div>");
+		expect(mock.callCount).toBe(0);
+		renderer.render(<div />, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(mock.callCount).toBe(1);
+	});
+
+	test("for...of", async () => {
+		const beforeYieldFn = Sinon.fake();
+		const afterYieldFn = Sinon.fake();
+		const afterLoopFn = Sinon.fake();
+		async function* Component(this: Context) {
+			let i = 0;
+			for ({} of this) {
+				beforeYieldFn();
+				yield <div>Hello {i++}</div>;
+				afterYieldFn();
+			}
+
+			afterLoopFn();
+		}
+
+		await renderer.render(<Component />, document.body);
+		expect(beforeYieldFn.callCount).toBe(1);
+		expect(afterYieldFn.callCount).toBe(0);
+		expect(document.body.innerHTML).toBe("<div>Hello 0</div>");
+		await renderer.render(<Component />, document.body);
+		expect(beforeYieldFn.callCount).toBe(2);
+		expect(afterYieldFn.callCount).toBe(1);
+		expect(document.body.innerHTML).toBe("<div>Hello 1</div>");
+
+		renderer.render(null, document.body);
+		expect(document.body.innerHTML).toBe("");
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(afterLoopFn.callCount).toBe(1);
+	});
+
+	test("for...of delayed", async () => {
+		const beforeYieldFn = Sinon.fake();
+		const afterYieldFn = Sinon.fake();
+		const afterLoopFn = Sinon.fake();
+		async function* Component(this: Context) {
+			let i = 0;
+			await new Promise((resolve) => setTimeout(resolve));
+			for ({} of this) {
+				beforeYieldFn();
+				yield <div>Hello {i++}</div>;
+				afterYieldFn();
+			}
+
+			afterLoopFn();
+		}
+
+		const p = renderer.render(<Component />, document.body);
+		expect(beforeYieldFn.callCount).toBe(0);
+		expect(afterYieldFn.callCount).toBe(0);
+		await p;
+		expect(beforeYieldFn.callCount).toBe(1);
+		expect(afterYieldFn.callCount).toBe(0);
+		expect(document.body.innerHTML).toBe("<div>Hello 0</div>");
+		await renderer.render(<Component />, document.body);
+		expect(beforeYieldFn.callCount).toBe(2);
+		expect(afterYieldFn.callCount).toBe(1);
+		expect(document.body.innerHTML).toBe("<div>Hello 1</div>");
+
+		renderer.render(null, document.body);
+		expect(document.body.innerHTML).toBe("");
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(afterLoopFn.callCount).toBe(1);
+	});
+
+	test("for await...of", async () => {
+		const beforeYieldFn = Sinon.fake();
+		const afterYieldFn = Sinon.fake();
+		const afterLoopFn = Sinon.fake();
+		async function* Component(this: Context): AsyncGenerator<Child> {
+			let i = 0;
+			for await (const _ of this) {
+				beforeYieldFn();
+				yield <div>Hello {i++}</div>;
+				afterYieldFn();
+			}
+
+			afterLoopFn();
+		}
+
+		await renderer.render(<Component />, document.body);
+		expect(beforeYieldFn.callCount).toBe(1);
+		expect(afterYieldFn.callCount).toBe(1);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(beforeYieldFn.callCount).toBe(1);
+		expect(afterYieldFn.callCount).toBe(1);
+		await renderer.render(<Component />, document.body);
+		expect(beforeYieldFn.callCount).toBe(2);
+		expect(afterYieldFn.callCount).toBe(2);
+		await renderer.render(<Component />, document.body);
+		expect(beforeYieldFn.callCount).toBe(3);
+		expect(afterYieldFn.callCount).toBe(3);
+		expect(document.body.innerHTML).toBe("<div>Hello 2</div>");
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(beforeYieldFn.callCount).toBe(3);
+		expect(afterYieldFn.callCount).toBe(3);
+		expect(afterLoopFn.callCount).toBe(0);
+		renderer.render(null, document.body);
+		expect(document.body.innerHTML).toBe("");
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(afterLoopFn.callCount).toBe(1);
+	});
+
+	test("for await...of with await in loop", async () => {
+		const beforeYieldFn = Sinon.fake();
+		const afterYieldFn = Sinon.fake();
+		const afterLoopFn = Sinon.fake();
+		async function* Component(this: Context): AsyncGenerator<Child> {
+			let i = 0;
+			for await (const _ of this) {
+				await new Promise((r) => setTimeout(r, 10));
+				beforeYieldFn();
+				yield <div>Hello {i++}</div>;
+				afterYieldFn();
+			}
+
+			afterLoopFn();
+		}
+
+		// first render
+		await renderer.render(<Component />, document.body);
+		expect(beforeYieldFn.callCount).toBe(1);
+		expect(afterYieldFn.callCount).toBe(1);
+		expect(document.body.innerHTML).toBe("<div>Hello 0</div>");
+
+		// second render
+		await renderer.render(<Component />, document.body);
+		expect(beforeYieldFn.callCount).toBe(2);
+		expect(afterYieldFn.callCount).toBe(2);
+		expect(document.body.innerHTML).toBe("<div>Hello 1</div>");
+
+		// third render is interrupted by unmount
+		renderer.render(<Component />, document.body);
+		await new Promise((resolve) => setTimeout(resolve));
+		renderer.render(null, document.body);
+		expect(document.body.innerHTML).toBe("");
+		expect(afterLoopFn.callCount).toBe(0);
+		expect(document.body.innerHTML).toBe("");
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(afterLoopFn.callCount).toBe(1);
+	});
+
+	test("for await...of with multiple yields", async () => {
+		const beforeYieldFn = Sinon.fake();
+		const afterYieldFn = Sinon.fake();
+		const afterLoopFn = Sinon.fake();
+		async function* Component(this: Context): AsyncGenerator<Child> {
+			let i = 0;
+			for await ({} of this) {
+				i++;
+				beforeYieldFn();
+				yield <div>Hello {i}</div>;
+				await new Promise((r) => setTimeout(r, 10));
+				yield <div>Goodbye {i}</div>;
+				afterYieldFn();
+			}
+
+			afterLoopFn();
+		}
+
+		// first render
+		await renderer.render(<Component />, document.body);
+		expect(beforeYieldFn.callCount).toBe(1);
+		expect(afterYieldFn.callCount).toBe(0);
+		expect(document.body.innerHTML).toBe("<div>Hello 1</div>");
+		await new Promise((r) => setTimeout(r, 10));
+		expect(beforeYieldFn.callCount).toBe(1);
+		expect(afterYieldFn.callCount).toBe(1);
+		expect(document.body.innerHTML).toBe("<div>Goodbye 1</div>");
+
+		// second render
+		await renderer.render(<Component />, document.body);
+		expect(beforeYieldFn.callCount).toBe(2);
+		expect(afterYieldFn.callCount).toBe(1);
+		expect(document.body.innerHTML).toBe("<div>Hello 2</div>");
+		await new Promise((r) => setTimeout(r, 10));
+		expect(beforeYieldFn.callCount).toBe(2);
+		expect(afterYieldFn.callCount).toBe(2);
+		expect(document.body.innerHTML).toBe("<div>Goodbye 2</div>");
+
+		// third render is interrupted by unmount
+		renderer.render(<Component />, document.body);
+		renderer.render(null, document.body);
+		expect(document.body.innerHTML).toBe("");
+		expect(afterLoopFn.callCount).toBe(0);
+		expect(document.body.innerHTML).toBe("");
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(afterLoopFn.callCount).toBe(1);
+	});
+
+	test("Context iterator returns on unmount", async () => {
+		const mock = Sinon.fake();
+		async function* Component(this: Context): AsyncGenerator<Element> {
+			let i = 0;
+			for await ({} of this) {
 				yield <div>Hello {i++}</div>;
 			}
-		} finally {
+
 			mock();
 		}
-	}
 
-	await renderer.render(<Component />, document.body);
-	await renderer.render(<Component />, document.body);
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello 2</div>");
-	Assert.is(mock.callCount, 0);
-	renderer.render(<div />, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(mock.callCount, 1);
-});
-
-test("for...of", async () => {
-	const beforeYieldFn = Sinon.fake();
-	const afterYieldFn = Sinon.fake();
-	const afterLoopFn = Sinon.fake();
-	async function* Component(this: Context) {
-		let i = 0;
-		for ({} of this) {
-			beforeYieldFn();
-			yield <div>Hello {i++}</div>;
-			afterYieldFn();
-		}
-
-		afterLoopFn();
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(beforeYieldFn.callCount, 1);
-	Assert.is(afterYieldFn.callCount, 0);
-	Assert.is(document.body.innerHTML, "<div>Hello 0</div>");
-	await renderer.render(<Component />, document.body);
-	Assert.is(beforeYieldFn.callCount, 2);
-	Assert.is(afterYieldFn.callCount, 1);
-	Assert.is(document.body.innerHTML, "<div>Hello 1</div>");
-
-	renderer.render(null, document.body);
-	Assert.is(document.body.innerHTML, "");
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(afterLoopFn.callCount, 1);
-});
-
-test("for...of delayed", async () => {
-	const beforeYieldFn = Sinon.fake();
-	const afterYieldFn = Sinon.fake();
-	const afterLoopFn = Sinon.fake();
-	async function* Component(this: Context) {
-		let i = 0;
-		await new Promise((resolve) => setTimeout(resolve));
-		for ({} of this) {
-			beforeYieldFn();
-			yield <div>Hello {i++}</div>;
-			afterYieldFn();
-		}
-
-		afterLoopFn();
-	}
-
-	const p = renderer.render(<Component />, document.body);
-	Assert.is(beforeYieldFn.callCount, 0);
-	Assert.is(afterYieldFn.callCount, 0);
-	await p;
-	Assert.is(beforeYieldFn.callCount, 1);
-	Assert.is(afterYieldFn.callCount, 0);
-	Assert.is(document.body.innerHTML, "<div>Hello 0</div>");
-	await renderer.render(<Component />, document.body);
-	Assert.is(beforeYieldFn.callCount, 2);
-	Assert.is(afterYieldFn.callCount, 1);
-	Assert.is(document.body.innerHTML, "<div>Hello 1</div>");
-
-	renderer.render(null, document.body);
-	Assert.is(document.body.innerHTML, "");
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(afterLoopFn.callCount, 1);
-});
-
-test("for await...of", async () => {
-	const beforeYieldFn = Sinon.fake();
-	const afterYieldFn = Sinon.fake();
-	const afterLoopFn = Sinon.fake();
-	async function* Component(this: Context): AsyncGenerator<Child> {
-		let i = 0;
-		for await (const _ of this) {
-			beforeYieldFn();
-			yield <div>Hello {i++}</div>;
-			afterYieldFn();
-		}
-
-		afterLoopFn();
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(beforeYieldFn.callCount, 1);
-	Assert.is(afterYieldFn.callCount, 1);
-	await new Promise((resolve) => setTimeout(resolve, 10));
-	Assert.is(beforeYieldFn.callCount, 1);
-	Assert.is(afterYieldFn.callCount, 1);
-	await renderer.render(<Component />, document.body);
-	Assert.is(beforeYieldFn.callCount, 2);
-	Assert.is(afterYieldFn.callCount, 2);
-	await renderer.render(<Component />, document.body);
-	Assert.is(beforeYieldFn.callCount, 3);
-	Assert.is(afterYieldFn.callCount, 3);
-	Assert.is(document.body.innerHTML, "<div>Hello 2</div>");
-	await new Promise((resolve) => setTimeout(resolve, 10));
-	Assert.is(beforeYieldFn.callCount, 3);
-	Assert.is(afterYieldFn.callCount, 3);
-	Assert.is(afterLoopFn.callCount, 0);
-	renderer.render(null, document.body);
-	Assert.is(document.body.innerHTML, "");
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(afterLoopFn.callCount, 1);
-});
-
-test("for await...of with await in loop", async () => {
-	const beforeYieldFn = Sinon.fake();
-	const afterYieldFn = Sinon.fake();
-	const afterLoopFn = Sinon.fake();
-	async function* Component(this: Context): AsyncGenerator<Child> {
-		let i = 0;
-		for await (const _ of this) {
-			await new Promise((r) => setTimeout(r, 10));
-			beforeYieldFn();
-			yield <div>Hello {i++}</div>;
-			afterYieldFn();
-		}
-
-		afterLoopFn();
-	}
-
-	// first render
-	await renderer.render(<Component />, document.body);
-	Assert.is(beforeYieldFn.callCount, 1);
-	Assert.is(afterYieldFn.callCount, 1);
-	Assert.is(document.body.innerHTML, "<div>Hello 0</div>");
-
-	// second render
-	await renderer.render(<Component />, document.body);
-	Assert.is(beforeYieldFn.callCount, 2);
-	Assert.is(afterYieldFn.callCount, 2);
-	Assert.is(document.body.innerHTML, "<div>Hello 1</div>");
-
-	// third render is interrupted by unmount
-	renderer.render(<Component />, document.body);
-	await new Promise((resolve) => setTimeout(resolve));
-	renderer.render(null, document.body);
-	Assert.is(document.body.innerHTML, "");
-	Assert.is(afterLoopFn.callCount, 0);
-	Assert.is(document.body.innerHTML, "");
-
-	await new Promise((resolve) => setTimeout(resolve, 10));
-	Assert.is(afterLoopFn.callCount, 1);
-});
-
-test("for await...of with multiple yields", async () => {
-	const beforeYieldFn = Sinon.fake();
-	const afterYieldFn = Sinon.fake();
-	const afterLoopFn = Sinon.fake();
-	async function* Component(this: Context): AsyncGenerator<Child> {
-		let i = 0;
-		for await ({} of this) {
-			i++;
-			beforeYieldFn();
-			yield <div>Hello {i}</div>;
-			await new Promise((r) => setTimeout(r, 10));
-			yield <div>Goodbye {i}</div>;
-			afterYieldFn();
-		}
-
-		afterLoopFn();
-	}
-
-	// first render
-	await renderer.render(<Component />, document.body);
-	Assert.is(beforeYieldFn.callCount, 1);
-	Assert.is(afterYieldFn.callCount, 0);
-	Assert.is(document.body.innerHTML, "<div>Hello 1</div>");
-	await new Promise((r) => setTimeout(r, 10));
-	Assert.is(beforeYieldFn.callCount, 1);
-	Assert.is(afterYieldFn.callCount, 1);
-	Assert.is(document.body.innerHTML, "<div>Goodbye 1</div>");
-
-	// second render
-	await renderer.render(<Component />, document.body);
-	Assert.is(beforeYieldFn.callCount, 2);
-	Assert.is(afterYieldFn.callCount, 1);
-	Assert.is(document.body.innerHTML, "<div>Hello 2</div>");
-	await new Promise((r) => setTimeout(r, 10));
-	Assert.is(beforeYieldFn.callCount, 2);
-	Assert.is(afterYieldFn.callCount, 2);
-	Assert.is(document.body.innerHTML, "<div>Goodbye 2</div>");
-
-	// third render is interrupted by unmount
-	renderer.render(<Component />, document.body);
-	renderer.render(null, document.body);
-	Assert.is(document.body.innerHTML, "");
-	Assert.is(afterLoopFn.callCount, 0);
-	Assert.is(document.body.innerHTML, "");
-
-	await new Promise((resolve) => setTimeout(resolve, 10));
-	Assert.is(afterLoopFn.callCount, 1);
-});
-
-test("Context iterator returns on unmount", async () => {
-	const mock = Sinon.fake();
-	async function* Component(this: Context): AsyncGenerator<Element> {
-		let i = 0;
-		for await ({} of this) {
-			yield <div>Hello {i++}</div>;
-		}
-
-		mock();
-	}
-
-	await renderer.render(<Component />, document.body);
-	await renderer.render(<Component />, document.body);
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello 2</div>");
-	Assert.is(mock.callCount, 0);
-	renderer.render(null, document.body);
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(mock.callCount, 1);
-});
-
-test("return called when component continues to yield", async () => {
-	const mock = Sinon.fake();
-	async function* Component(this: Context) {
-		let i = 0;
-		for await ({} of this) {
-			yield <div>Hello {i++}</div>;
-		}
-
-		mock();
-		yield <div>Exited {i++}</div>;
-		mock();
-		Assert.unreachable();
-	}
-
-	await renderer.render(<Component />, document.body);
-	await renderer.render(<Component />, document.body);
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello 2</div>");
-	Assert.is(mock.callCount, 0);
-	renderer.render(null, document.body);
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(mock.callCount, 1);
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(mock.callCount, 1);
-});
-
-// https://github.com/bikeshaving/crank/pull/121
-test("unmount edge case", async () => {
-	function Switch({children, active}: {children: Children; active: boolean}) {
-		if (!active) {
-			return null;
-		}
-
-		return children;
-	}
-
-	async function* AsyncGen(this: Context) {
-		for await (const _ of this) {
-			yield <span>true</span>;
-		}
-	}
-
-	function* Component() {
-		let toggle = true;
-		while (true) {
-			yield (
-				<div>
-					<Switch active={toggle}>
-						<AsyncGen />
-					</Switch>
-					<Switch active={!toggle}>
-						<span>false</span>
-					</Switch>
-				</div>
-			);
-
-			toggle = !toggle;
-		}
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div><span>true</span></div>");
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div><span>false</span></div>");
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div><span>true</span></div>");
-});
-
-test("multiple iterations without a yield throw", async () => {
-	let i = 0;
-	async function* Component(this: Context) {
-		for await (const _ of this) {
-			// just so the test suite doesn’t enter an infinite loop
-			if (i > 100) {
-				yield;
-				return;
-			}
-
-			i++;
-		}
-	}
-
-	const fn = Sinon.fake();
-
-	try {
 		await renderer.render(<Component />, document.body);
-		Assert.unreachable();
-	} catch (err: any) {
-		Assert.ok(err.message.endsWith("context iterated twice without a yield"));
-		fn();
-	}
+		await renderer.render(<Component />, document.body);
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello 2</div>");
+		expect(mock.callCount).toBe(0);
+		renderer.render(null, document.body);
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(mock.callCount).toBe(1);
+	});
 
-	Assert.is(i, 1);
-	Assert.is(fn.callCount, 1);
-});
+	test("return called when component continues to yield", async () => {
+		const mock = Sinon.fake();
+		async function* Component(this: Context) {
+			let i = 0;
+			for await ({} of this) {
+				yield <div>Hello {i++}</div>;
+			}
 
-test("for...of enqueues", async () => {
-	const fn = Sinon.fake();
-	async function* Component(
-		this: Context<typeof Component>,
-		{message}: {message: string},
-	) {
-		for ({message} of this) {
-			await new Promise((resolve) => setTimeout(resolve));
-			fn();
-			yield <span>{message}</span>;
+			mock();
+			yield <div>Exited {i++}</div>;
+			mock();
+			throw new Error("unreachable");
 		}
-	}
 
-	const p1 = renderer.render(
-		<div>
-			<Component message="Hello 1" />
-		</div>,
-		document.body,
-	);
-	const p2 = renderer.render(
-		<div>
-			<Component message="Hello 2" />
-		</div>,
-		document.body,
-	);
-	const p3 = renderer.render(
-		<div>
-			<Component message="Hello 3" />
-		</div>,
-		document.body,
-	);
-	const p4 = renderer.render(
-		<div>
-			<Component message="Hello 4" />
-		</div>,
-		document.body,
-	);
-	const p5 = renderer.render(
-		<div>
-			<Component message="Hello 5" />
-		</div>,
-		document.body,
-	);
+		await renderer.render(<Component />, document.body);
+		await renderer.render(<Component />, document.body);
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello 2</div>");
+		expect(mock.callCount).toBe(0);
+		renderer.render(null, document.body);
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(mock.callCount).toBe(1);
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(mock.callCount).toBe(1);
+	});
 
-	Assert.is(await p1, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 1</span></div>");
-	Assert.is(await p2, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 5</span></div>");
-	Assert.is(await p3, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 5</span></div>");
-	Assert.is(await p4, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 5</span></div>");
-	const p6 = renderer.render(
-		<div>
-			<Component message="Hello 6" />
-		</div>,
-		document.body,
-	);
-	const p7 = renderer.render(
-		<div>
-			<Component message="Hello 7" />
-		</div>,
-		document.body,
-	);
-	const p8 = renderer.render(
-		<div>
-			<Component message="Hello 8" />
-		</div>,
-		document.body,
-	);
-	const p9 = renderer.render(
-		<div>
-			<Component message="Hello 9" />
-		</div>,
-		document.body,
-	);
-	const p10 = renderer.render(
-		<div>
-			<Component message="Hello 10" />
-		</div>,
-		document.body,
-	);
-	Assert.is(await p5, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 5</span></div>");
-	Assert.is(await p6, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 6</span></div>");
-	Assert.is(await p7, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 10</span></div>");
-	Assert.is(await p8, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 10</span></div>");
-	Assert.is(await p9, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 10</span></div>");
-	Assert.is(await p10, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 10</span></div>");
-	Assert.is(fn.callCount, 4);
-});
+	// https://github.com/bikeshaving/crank/pull/121
+	test("unmount edge case", async () => {
+		function Switch({children, active}: {children: Children; active: boolean}) {
+			if (!active) {
+				return null;
+			}
 
-test("for await...of updates enqueue", async () => {
-	const beforeAwaitFn = Sinon.fake();
-	async function* Component(this: Context, {callIndex}: {callIndex: number}) {
-		let runIndex = 1;
-		for await ({callIndex} of this) {
-			beforeAwaitFn();
-			await new Promise((resolve) => setTimeout(resolve, 25));
-			yield (
-				<div>
-					run {runIndex}, call {callIndex}
-				</div>
-			);
-			runIndex++;
+			return children;
 		}
-	}
 
-	const p1 = renderer.render(<Component callIndex={1} />, document.body);
-	const p2 = renderer.render(<Component callIndex={2} />, document.body);
-	const p3 = renderer.render(<Component callIndex={3} />, document.body);
-	const p4 = renderer.render(<Component callIndex={4} />, document.body);
-	const p5 = renderer.render(<Component callIndex={5} />, document.body);
-
-	Assert.is(await p1, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>run 1, call 1</div>");
-	Assert.is(beforeAwaitFn.callCount, 2);
-	Assert.is(await p2, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>run 2, call 5</div>");
-	Assert.is(await p3, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>run 2, call 5</div>");
-	Assert.is(await p4, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>run 2, call 5</div>");
-
-	const p6 = renderer.render(<Component callIndex={6} />, document.body);
-	const p7 = renderer.render(<Component callIndex={7} />, document.body);
-	const p8 = renderer.render(<Component callIndex={8} />, document.body);
-	const p9 = renderer.render(<Component callIndex={9} />, document.body);
-	const p10 = renderer.render(<Component callIndex={10} />, document.body);
-
-	Assert.is(await p5, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>run 2, call 5</div>");
-	Assert.is(await p6, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>run 3, call 6</div>");
-	Assert.is(await p7, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>run 4, call 10</div>");
-	Assert.is(await p8, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>run 4, call 10</div>");
-	Assert.is(await p9, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>run 4, call 10</div>");
-	Assert.is(await p10, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>run 4, call 10</div>");
-	Assert.is(beforeAwaitFn.callCount, 4);
-});
-
-test("stale renders are skipped", async () => {
-	const characterDatas: Array<string> = [];
-	const mutationObserver = new MutationObserver((records) => {
-		for (const record of records) {
-			if (record.type === "characterData") {
-				characterDatas.push(record.target.textContent!);
+		async function* AsyncGen(this: Context) {
+			for await (const _ of this) {
+				yield <span>true</span>;
 			}
 		}
-	});
 
-	mutationObserver.observe(document.body, {
-		characterData: true,
-		subtree: true,
-	});
-	let resolve: undefined | Function;
-	async function* Component(this: Context, {message}: {message: string}) {
-		for await ({message} of this) {
-			yield <span>{message} before</span>;
-			await new Promise((resolve1) => (resolve = resolve1));
-			yield <span>{message} after</span>;
+		function* Component() {
+			let toggle = true;
+			while (true) {
+				yield (
+					<div>
+						<Switch active={toggle}>
+							<AsyncGen />
+						</Switch>
+						<Switch active={!toggle}>
+							<span>false</span>
+						</Switch>
+					</div>
+				);
+
+				toggle = !toggle;
+			}
 		}
-	}
 
-	try {
-		await renderer.render(<Component message="Hello" />, document.body);
-		Assert.is(document.body.innerHTML, "<span>Hello before</span>");
-		resolve!();
-		await new Promise((resolve) => setTimeout(resolve));
-		Assert.is(document.body.innerHTML, "<span>Hello after</span>");
-		await renderer.render(<Component message="Hello again" />, document.body);
-		Assert.is(document.body.innerHTML, "<span>Hello again before</span>");
-		const resolve1 = resolve;
-		const p = renderer.render(<Component message="Goodbye" />, document.body);
-		resolve1!();
-		await p;
-		Assert.is(document.body.innerHTML, "<span>Goodbye before</span>");
-		Assert.equal(characterDatas, [
-			" after",
-			"Hello again",
-			" before",
-			"Goodbye",
-		]);
-	} finally {
-		mutationObserver.disconnect();
-	}
-});
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div><span>true</span></div>");
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div><span>false</span></div>");
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div><span>true</span></div>");
+	});
 
-test("for...of then for...await of then for...of", async () => {
-	const beforeYieldFn = Sinon.fake();
-	const afterYieldFn = Sinon.fake();
-	const afterLoopFn = Sinon.fake();
-	async function* Component(this: Context) {
+	test("multiple iterations without a yield throw", async () => {
 		let i = 0;
-		for ({} of this) {
-			beforeYieldFn();
-			yield <div>for...of {i++}</div>;
-			afterYieldFn();
-			break;
+		async function* Component(this: Context) {
+			for await (const _ of this) {
+				// just so the test suite doesn’t enter an infinite loop
+				if (i > 100) {
+					yield;
+					return;
+				}
+
+				i++;
+			}
 		}
 
-		afterLoopFn();
-		for await ({} of this) {
-			beforeYieldFn();
-			yield <div>for await...of {i++}</div>;
-			// this code executes immediately because we are in a for await...of loop
-			afterYieldFn();
-			if (i === 4) {
+		const fn = Sinon.fake();
+
+		try {
+			await renderer.render(<Component />, document.body);
+			throw new Error("unreachable");
+		} catch (err: any) {
+			expect(
+				err.message.endsWith("context iterated twice without a yield"),
+			).toBeTruthy();
+			fn();
+		}
+
+		expect(i).toBe(1);
+		expect(fn.callCount).toBe(1);
+	});
+
+	test("for...of enqueues", async () => {
+		const fn = Sinon.fake();
+		async function* Component(
+			this: Context<typeof Component>,
+			{message}: {message: string},
+		) {
+			for ({message} of this) {
+				await new Promise((resolve) => setTimeout(resolve));
+				fn();
+				yield <span>{message}</span>;
+			}
+		}
+
+		const p1 = renderer.render(
+			<div>
+				<Component message="Hello 1" />
+			</div>,
+			document.body,
+		);
+		const p2 = renderer.render(
+			<div>
+				<Component message="Hello 2" />
+			</div>,
+			document.body,
+		);
+		const p3 = renderer.render(
+			<div>
+				<Component message="Hello 3" />
+			</div>,
+			document.body,
+		);
+		const p4 = renderer.render(
+			<div>
+				<Component message="Hello 4" />
+			</div>,
+			document.body,
+		);
+		const p5 = renderer.render(
+			<div>
+				<Component message="Hello 5" />
+			</div>,
+			document.body,
+		);
+
+		expect(await p1).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 1</span></div>");
+		expect(await p2).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 5</span></div>");
+		expect(await p3).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 5</span></div>");
+		expect(await p4).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 5</span></div>");
+		const p6 = renderer.render(
+			<div>
+				<Component message="Hello 6" />
+			</div>,
+			document.body,
+		);
+		const p7 = renderer.render(
+			<div>
+				<Component message="Hello 7" />
+			</div>,
+			document.body,
+		);
+		const p8 = renderer.render(
+			<div>
+				<Component message="Hello 8" />
+			</div>,
+			document.body,
+		);
+		const p9 = renderer.render(
+			<div>
+				<Component message="Hello 9" />
+			</div>,
+			document.body,
+		);
+		const p10 = renderer.render(
+			<div>
+				<Component message="Hello 10" />
+			</div>,
+			document.body,
+		);
+		expect(await p5).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 5</span></div>");
+		expect(await p6).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 6</span></div>");
+		expect(await p7).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 10</span></div>");
+		expect(await p8).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 10</span></div>");
+		expect(await p9).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 10</span></div>");
+		expect(await p10).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 10</span></div>");
+		expect(fn.callCount).toBe(4);
+	});
+
+	test("for await...of updates enqueue", async () => {
+		const beforeAwaitFn = Sinon.fake();
+		async function* Component(this: Context, {callIndex}: {callIndex: number}) {
+			let runIndex = 1;
+			for await ({callIndex} of this) {
+				beforeAwaitFn();
+				await new Promise((resolve) => setTimeout(resolve, 25));
+				yield (
+					<div>
+						run {runIndex}, call {callIndex}
+					</div>
+				);
+				runIndex++;
+			}
+		}
+
+		const p1 = renderer.render(<Component callIndex={1} />, document.body);
+		const p2 = renderer.render(<Component callIndex={2} />, document.body);
+		const p3 = renderer.render(<Component callIndex={3} />, document.body);
+		const p4 = renderer.render(<Component callIndex={4} />, document.body);
+		const p5 = renderer.render(<Component callIndex={5} />, document.body);
+
+		expect(await p1).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>run 1, call 1</div>");
+		expect(beforeAwaitFn.callCount).toBe(2);
+		expect(await p2).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>run 2, call 5</div>");
+		expect(await p3).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>run 2, call 5</div>");
+		expect(await p4).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>run 2, call 5</div>");
+
+		const p6 = renderer.render(<Component callIndex={6} />, document.body);
+		const p7 = renderer.render(<Component callIndex={7} />, document.body);
+		const p8 = renderer.render(<Component callIndex={8} />, document.body);
+		const p9 = renderer.render(<Component callIndex={9} />, document.body);
+		const p10 = renderer.render(<Component callIndex={10} />, document.body);
+
+		expect(await p5).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>run 2, call 5</div>");
+		expect(await p6).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>run 3, call 6</div>");
+		expect(await p7).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>run 4, call 10</div>");
+		expect(await p8).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>run 4, call 10</div>");
+		expect(await p9).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>run 4, call 10</div>");
+		expect(await p10).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>run 4, call 10</div>");
+		expect(beforeAwaitFn.callCount).toBe(4);
+	});
+
+	test("stale renders are skipped", async () => {
+		const characterDatas: Array<string> = [];
+		const mutationObserver = new MutationObserver((records) => {
+			for (const record of records) {
+				if (record.type === "characterData") {
+					characterDatas.push(record.target.textContent!);
+				}
+			}
+		});
+
+		mutationObserver.observe(document.body, {
+			characterData: true,
+			subtree: true,
+		});
+		let resolve: undefined | Function;
+		async function* Component(this: Context, {message}: {message: string}) {
+			for await ({message} of this) {
+				yield <span>{message} before</span>;
+				await new Promise((resolve1) => (resolve = resolve1));
+				yield <span>{message} after</span>;
+			}
+		}
+
+		try {
+			await renderer.render(<Component message="Hello" />, document.body);
+			expect(document.body.innerHTML).toBe("<span>Hello before</span>");
+			resolve!();
+			await new Promise((resolve) => setTimeout(resolve));
+			expect(document.body.innerHTML).toBe("<span>Hello after</span>");
+			await renderer.render(<Component message="Hello again" />, document.body);
+			expect(document.body.innerHTML).toBe("<span>Hello again before</span>");
+			const resolve1 = resolve;
+			const p = renderer.render(<Component message="Goodbye" />, document.body);
+			resolve1!();
+			await p;
+			expect(document.body.innerHTML).toBe("<span>Goodbye before</span>");
+			expect(characterDatas).toEqual([
+				" after",
+				"Hello again",
+				" before",
+				"Goodbye",
+			]);
+		} finally {
+			mutationObserver.disconnect();
+		}
+	});
+
+	test("for...of then for...await of then for...of", async () => {
+		const beforeYieldFn = Sinon.fake();
+		const afterYieldFn = Sinon.fake();
+		const afterLoopFn = Sinon.fake();
+		async function* Component(this: Context) {
+			let i = 0;
+			for ({} of this) {
+				beforeYieldFn();
+				yield <div>for...of {i++}</div>;
+				afterYieldFn();
 				break;
 			}
+
+			afterLoopFn();
+			for await ({} of this) {
+				beforeYieldFn();
+				yield <div>for await...of {i++}</div>;
+				// this code executes immediately because we are in a for await...of loop
+				afterYieldFn();
+				if (i === 4) {
+					break;
+				}
+			}
+
+			afterLoopFn();
+
+			for ({} of this) {
+				beforeYieldFn();
+				yield <div>for...of {i++}</div>;
+				afterYieldFn();
+			}
+
+			afterLoopFn();
 		}
 
-		afterLoopFn();
+		await renderer.render(<Component />, document.body);
+		expect(beforeYieldFn.callCount).toBe(1);
+		expect(afterYieldFn.callCount).toBe(0);
+		expect(document.body.innerHTML).toBe("<div>for...of 0</div>");
 
-		for ({} of this) {
-			beforeYieldFn();
-			yield <div>for...of {i++}</div>;
-			afterYieldFn();
+		await renderer.render(<Component />, document.body);
+		expect(afterLoopFn.callCount).toBe(1);
+		expect(beforeYieldFn.callCount).toBe(2);
+		expect(afterYieldFn.callCount).toBe(2);
+		expect(document.body.innerHTML).toBe("<div>for await...of 1</div>");
+
+		await renderer.render(<Component />, document.body);
+
+		expect(afterLoopFn.callCount).toBe(1);
+		expect(beforeYieldFn.callCount).toBe(3);
+		expect(afterYieldFn.callCount).toBe(3);
+		expect(document.body.innerHTML).toBe("<div>for await...of 2</div>");
+
+		await renderer.render(<Component />, document.body);
+		expect(afterLoopFn.callCount).toBe(2);
+		expect(beforeYieldFn.callCount).toBe(5);
+		expect(afterYieldFn.callCount).toBe(4);
+		expect(document.body.innerHTML).toBe("<div>for...of 4</div>");
+
+		await renderer.render(<Component />, document.body);
+		expect(afterLoopFn.callCount).toBe(2);
+		expect(beforeYieldFn.callCount).toBe(6);
+		expect(afterYieldFn.callCount).toBe(5);
+		expect(document.body.innerHTML).toBe("<div>for...of 5</div>");
+
+		await renderer.render(null, document.body);
+		expect(document.body.innerHTML).toBe("");
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(afterLoopFn.callCount).toBe(3);
+	});
+
+	test("for await...of waits for nephew", async () => {
+		let mock = Sinon.fake();
+		async function* Component(this: Context) {
+			for await ({} of this) {
+				yield <div>Children 1</div>;
+				mock();
+				yield <div>Children 2</div>;
+			}
 		}
 
-		afterLoopFn();
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(beforeYieldFn.callCount, 1);
-	Assert.is(afterYieldFn.callCount, 0);
-	Assert.is(document.body.innerHTML, "<div>for...of 0</div>");
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(afterLoopFn.callCount, 1);
-	Assert.is(beforeYieldFn.callCount, 2);
-	Assert.is(afterYieldFn.callCount, 2);
-	Assert.is(document.body.innerHTML, "<div>for await...of 1</div>");
-
-	await renderer.render(<Component />, document.body);
-
-	Assert.is(afterLoopFn.callCount, 1);
-	Assert.is(beforeYieldFn.callCount, 3);
-	Assert.is(afterYieldFn.callCount, 3);
-	Assert.is(document.body.innerHTML, "<div>for await...of 2</div>");
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(afterLoopFn.callCount, 2);
-	Assert.is(beforeYieldFn.callCount, 5);
-	Assert.is(afterYieldFn.callCount, 4);
-	Assert.is(document.body.innerHTML, "<div>for...of 4</div>");
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(afterLoopFn.callCount, 2);
-	Assert.is(beforeYieldFn.callCount, 6);
-	Assert.is(afterYieldFn.callCount, 5);
-	Assert.is(document.body.innerHTML, "<div>for...of 5</div>");
-
-	await renderer.render(null, document.body);
-	Assert.is(document.body.innerHTML, "");
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(afterLoopFn.callCount, 3);
-});
-
-test("for await...of waits for nephew", async () => {
-	let mock = Sinon.fake();
-	async function* Component(this: Context) {
-		for await ({} of this) {
-			yield <div>Children 1</div>;
-			mock();
-			yield <div>Children 2</div>;
+		let resolveNephew: Function;
+		async function Nephew() {
+			await new Promise((resolve) => (resolveNephew = resolve));
+			return <span>Nephew</span>;
 		}
-	}
 
-	let resolveNephew: Function;
-	async function Nephew() {
-		await new Promise((resolve) => (resolveNephew = resolve));
-		return <span>Nephew</span>;
-	}
+		function Passthrough() {
+			return (
+				<div>
+					<Nephew />
+				</div>
+			);
+		}
 
-	function Passthrough() {
-		return (
+		renderer.render(
 			<div>
-				<Nephew />
-			</div>
+				<div>
+					<Passthrough />
+				</div>
+				<Component />
+			</div>,
+			document.body,
 		);
-	}
 
-	renderer.render(
-		<div>
-			<div>
-				<Passthrough />
-			</div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		expect(document.body.innerHTML).toBe("");
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(document.body.innerHTML).toBe("");
+		expect(mock.callCount).toBe(1);
+		resolveNephew!();
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe(
+			"<div><div><div><span>Nephew</span></div></div><div>Children 2</div></div>",
+		);
+	});
 
-	Assert.is(document.body.innerHTML, "");
-	await new Promise((resolve) => setTimeout(resolve, 10));
-	Assert.is(document.body.innerHTML, "");
-	Assert.is(mock.callCount, 1);
-	resolveNephew!();
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(
-		document.body.innerHTML,
-		"<div><div><div><span>Nephew</span></div></div><div>Children 2</div></div>",
-	);
-});
-
-// https://github.com/bikeshaving/crank/issues/334
-test("refresh before yield does not throw", async () => {
-	async function* Component(this: Context) {
-		await Promise.resolve();
-		this.refresh();
-		this.refresh();
-		for (const {} of this) {
-			yield <span>Hello</span>;
+	// https://github.com/bikeshaving/crank/issues/334
+	test("refresh before yield does not throw", async () => {
+		async function* Component(this: Context) {
+			await Promise.resolve();
+			this.refresh();
+			this.refresh();
+			for (const {} of this) {
+				yield <span>Hello</span>;
+			}
 		}
-	}
 
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+	});
 });
-
-test.run();

--- a/test/cascades.tsx
+++ b/test/cascades.tsx
@@ -1,205 +1,202 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import * as Sinon from "sinon";
 import {createElement, Context} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("cascades");
+describe("cascades", () => {
+	let mock: Sinon.SinonStub;
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+		mock = Sinon.stub(console, "error");
+	});
 
-let mock: Sinon.SinonStub;
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-	mock = Sinon.stub(console, "error");
-});
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+		mock.restore();
+	});
 
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-	mock.restore();
-});
-
-test("sync function calls refresh directly", () => {
-	function Component(this: Context) {
-		this.refresh();
-		return <div>Hello</div>;
-	}
-
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello</div>");
-	Assert.is(mock.callCount, 1);
-});
-
-test("async function calls refresh directly", async () => {
-	async function Component(this: Context) {
-		this.refresh();
-		return <div>Hello</div>;
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello</div>");
-	Assert.is(mock.callCount, 1);
-});
-
-test("sync generator calls refresh directly", () => {
-	function* Component(this: Context) {
-		while (true) {
+	test("sync function calls refresh directly", () => {
+		function Component(this: Context) {
 			this.refresh();
-			yield <div>Hello</div>;
+			return <div>Hello</div>;
 		}
-	}
 
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello</div>");
-	Assert.is(mock.callCount, 1);
-});
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello</div>");
+		expect(mock.callCount).toBe(1);
+	});
 
-test("async generator calls refresh directly", async () => {
-	async function* Component(this: Context) {
-		this.refresh();
-		yield <span>Hello</span>;
-		for await (const _ of this) {
-			yield <span>Hello again</span>;
-		}
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<span>Hello</span>");
-	await new Promise((resolve) => setTimeout(resolve, 0));
-	Assert.is(document.body.innerHTML, "<span>Hello</span>");
-	Assert.is(mock.callCount, 1);
-});
-
-test("sync function parent and sync function child", () => {
-	function Child(this: Context) {
-		this.dispatchEvent(new Event("test", {bubbles: true}));
-		return <span>child</span>;
-	}
-
-	function Parent(this: Context) {
-		this.addEventListener("test", () => {
+	test("async function calls refresh directly", async () => {
+		async function Component(this: Context) {
 			this.refresh();
-		});
+			return <div>Hello</div>;
+		}
 
-		return (
-			<div>
-				<Child />
-			</div>
-		);
-	}
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello</div>");
+		expect(mock.callCount).toBe(1);
+	});
 
-	renderer.render(<Parent />, document.body);
-	Assert.is(document.body.innerHTML, "<div><span>child</span></div>");
-	Assert.is(mock.callCount, 1);
-});
+	test("sync generator calls refresh directly", () => {
+		function* Component(this: Context) {
+			while (true) {
+				this.refresh();
+				yield <div>Hello</div>;
+			}
+		}
 
-test("sync generator parent and sync function child", () => {
-	function Child(this: Context) {
-		this.dispatchEvent(new Event("test", {bubbles: true}));
-		return <span>child</span>;
-	}
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello</div>");
+		expect(mock.callCount).toBe(1);
+	});
 
-	function* Parent(this: Context) {
-		this.addEventListener("test", () => {
+	test("async generator calls refresh directly", async () => {
+		async function* Component(this: Context) {
 			this.refresh();
-		});
-
-		while (true) {
-			yield (
-				<div>
-					<Child />
-				</div>
-			);
-		}
-	}
-
-	renderer.render(<Parent />, document.body);
-	Assert.is(document.body.innerHTML, "<div><span>child</span></div>");
-	Assert.is(mock.callCount, 1);
-});
-
-test("sync generator parent and sync generator child", async () => {
-	function* Child(this: Context) {
-		this.dispatchEvent(new Event("test", {bubbles: true}));
-		while (true) {
-			yield <span>child</span>;
-		}
-	}
-
-	function* Parent(this: Context) {
-		this.addEventListener("test", () => {
-			this.refresh();
-		});
-
-		while (true) {
-			yield (
-				<div>
-					<Child />
-				</div>
-			);
-		}
-	}
-
-	renderer.render(<Parent />, document.body);
-	Assert.is(document.body.innerHTML, "<div><span>child</span></div>");
-	Assert.is(mock.callCount, 1);
-});
-
-test("dispatchEvent in initial schedule callback", () => {
-	function* Child(this: Context) {
-		this.schedule(() => {
-			this.dispatchEvent(new Event("test", {bubbles: true}));
-		});
-
-		while (true) {
-			yield <span>child</span>;
-		}
-	}
-
-	function Parent(this: Context) {
-		this.addEventListener("test", () => {
-			this.refresh();
-		});
-
-		return (
-			<div>
-				<Child />
-			</div>
-		);
-	}
-
-	renderer.render(<Parent />, document.body);
-	Assert.is(document.body.innerHTML, "<div><span>child</span></div>");
-	Assert.is(mock.callCount, 0);
-});
-
-// https://github.com/bikeshaving/crank/issues/336
-test("async generator refresh during await with for...of this", async () => {
-	async function* Component(this: Context) {
-		await Promise.resolve();
-		this.refresh();
-		for (const {} of this) {
 			yield <span>Hello</span>;
+			for await (const _ of this) {
+				yield <span>Hello again</span>;
+			}
 		}
-	}
 
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<span>Hello</span>");
-	Assert.is(mock.callCount, 0);
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<span>Hello</span>");
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(document.body.innerHTML).toBe("<span>Hello</span>");
+		expect(mock.callCount).toBe(1);
+	});
+
+	test("sync function parent and sync function child", () => {
+		function Child(this: Context) {
+			this.dispatchEvent(new Event("test", {bubbles: true}));
+			return <span>child</span>;
+		}
+
+		function Parent(this: Context) {
+			this.addEventListener("test", () => {
+				this.refresh();
+			});
+
+			return (
+				<div>
+					<Child />
+				</div>
+			);
+		}
+
+		renderer.render(<Parent />, document.body);
+		expect(document.body.innerHTML).toBe("<div><span>child</span></div>");
+		expect(mock.callCount).toBe(1);
+	});
+
+	test("sync generator parent and sync function child", () => {
+		function Child(this: Context) {
+			this.dispatchEvent(new Event("test", {bubbles: true}));
+			return <span>child</span>;
+		}
+
+		function* Parent(this: Context) {
+			this.addEventListener("test", () => {
+				this.refresh();
+			});
+
+			while (true) {
+				yield (
+					<div>
+						<Child />
+					</div>
+				);
+			}
+		}
+
+		renderer.render(<Parent />, document.body);
+		expect(document.body.innerHTML).toBe("<div><span>child</span></div>");
+		expect(mock.callCount).toBe(1);
+	});
+
+	test("sync generator parent and sync generator child", async () => {
+		function* Child(this: Context) {
+			this.dispatchEvent(new Event("test", {bubbles: true}));
+			while (true) {
+				yield <span>child</span>;
+			}
+		}
+
+		function* Parent(this: Context) {
+			this.addEventListener("test", () => {
+				this.refresh();
+			});
+
+			while (true) {
+				yield (
+					<div>
+						<Child />
+					</div>
+				);
+			}
+		}
+
+		renderer.render(<Parent />, document.body);
+		expect(document.body.innerHTML).toBe("<div><span>child</span></div>");
+		expect(mock.callCount).toBe(1);
+	});
+
+	test("dispatchEvent in initial schedule callback", () => {
+		function* Child(this: Context) {
+			this.schedule(() => {
+				this.dispatchEvent(new Event("test", {bubbles: true}));
+			});
+
+			while (true) {
+				yield <span>child</span>;
+			}
+		}
+
+		function Parent(this: Context) {
+			this.addEventListener("test", () => {
+				this.refresh();
+			});
+
+			return (
+				<div>
+					<Child />
+				</div>
+			);
+		}
+
+		renderer.render(<Parent />, document.body);
+		expect(document.body.innerHTML).toBe("<div><span>child</span></div>");
+		expect(mock.callCount).toBe(0);
+	});
+
+	// https://github.com/bikeshaving/crank/issues/336
+	test("async generator refresh during await with for...of this", async () => {
+		async function* Component(this: Context) {
+			await Promise.resolve();
+			this.refresh();
+			for (const {} of this) {
+				yield <span>Hello</span>;
+			}
+		}
+
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<span>Hello</span>");
+		expect(mock.callCount).toBe(0);
+	});
+
+	// https://github.com/bikeshaving/crank/issues/336
+	test("async generator refresh during await with direct yield", async () => {
+		async function* Component(this: Context) {
+			await Promise.resolve();
+			this.refresh();
+			yield <span>Hello</span>;
+			yield <span>Goodbye</span>;
+		}
+
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<span>Goodbye</span>");
+		expect(mock.callCount).toBe(0);
+	});
 });
-
-// https://github.com/bikeshaving/crank/issues/336
-test("async generator refresh during await with direct yield", async () => {
-	async function* Component(this: Context) {
-		await Promise.resolve();
-		this.refresh();
-		yield <span>Hello</span>;
-		yield <span>Goodbye</span>;
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<span>Goodbye</span>");
-	Assert.is(mock.callCount, 0);
-});
-
-test.run();

--- a/test/cleanup.tsx
+++ b/test/cleanup.tsx
@@ -1,5 +1,4 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import * as Sinon from "sinon";
 
 import {
@@ -11,1185 +10,1133 @@ import {
 } from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("cleanup");
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+describe("cleanup", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test("function", () => {
-	const fn = Sinon.fake();
-	function Component(this: Context): Element {
-		this.cleanup(fn);
-		return <span>Hello</span>;
-	}
-
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	Assert.is(fn.callCount, 0);
-	const span = document.body.firstChild!.firstChild;
-
-	renderer.render(<div />, document.body);
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], span);
-});
-
-test("generator", () => {
-	const fn = Sinon.fake();
-	function* Component(this: Context): Generator<Element> {
-		this.cleanup(fn);
-		while (true) {
-			yield <span>Hello</span>;
+	test("function", () => {
+		const fn = Sinon.fake();
+		function Component(this: Context): Element {
+			this.cleanup(fn);
+			return <span>Hello</span>;
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	Assert.is(fn.callCount, 0);
-	const span = document.body.firstChild!.firstChild;
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	renderer.render(<div />, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], span);
-});
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		expect(fn.callCount).toBe(0);
+		const span = document.body.firstChild!.firstChild;
 
-test("async function", async () => {
-	const fn = Sinon.fake();
-	async function Component(this: Context): Promise<Element> {
-		this.cleanup(fn);
-		await new Promise((resolve) => setTimeout(resolve, 1));
-		return <span>Hello</span>;
-	}
+		renderer.render(<div />, document.body);
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(span);
+	});
 
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+	test("generator", () => {
+		const fn = Sinon.fake();
+		function* Component(this: Context): Generator<Element> {
+			this.cleanup(fn);
+			while (true) {
+				yield <span>Hello</span>;
+			}
+		}
 
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	Assert.is(fn.callCount, 0);
-	const span = document.body.firstChild!.firstChild;
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		expect(fn.callCount).toBe(0);
+		const span = document.body.firstChild!.firstChild;
 
-	await renderer.render(<div />, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], span);
-});
+		renderer.render(<div />, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(span);
+	});
 
-test("async generator", async () => {
-	const fn = Sinon.fake();
-	async function* Component(this: Context): AsyncGenerator<Element> {
-		this.cleanup(fn);
-		for await (const _ of this) {
+	test("async function", async () => {
+		const fn = Sinon.fake();
+		async function Component(this: Context): Promise<Element> {
+			this.cleanup(fn);
 			await new Promise((resolve) => setTimeout(resolve, 1));
-			yield <span>Hello</span>;
+			return <span>Hello</span>;
 		}
-	}
 
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	Assert.is(fn.callCount, 0);
-	const span = document.body.firstChild!.firstChild;
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		expect(fn.callCount).toBe(0);
+		const span = document.body.firstChild!.firstChild;
 
-	await renderer.render(<div />, document.body);
-	// TODO: why is this setTimeout necessary???
-	await new Promise((resolve) => setTimeout(resolve, 0));
-	Assert.is(document.body.innerHTML, "<div></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], span);
-});
+		await renderer.render(<div />, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(span);
+	});
 
-test("multiple calls, same fn", () => {
-	const fn = Sinon.fake();
-	function* Component(this: Context): Generator<Element> {
-		this.cleanup(fn);
-		while (true) {
-			yield <span>Hello</span>;
+	test("async generator", async () => {
+		const fn = Sinon.fake();
+		async function* Component(this: Context): AsyncGenerator<Element> {
+			this.cleanup(fn);
+			for await (const _ of this) {
+				await new Promise((resolve) => setTimeout(resolve, 1));
+				yield <span>Hello</span>;
+			}
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	Assert.is(fn.callCount, 0);
-	const span = document.body.firstChild!.firstChild;
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		expect(fn.callCount).toBe(0);
+		const span = document.body.firstChild!.firstChild;
 
-	renderer.render(<div />, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], span);
-});
+		await renderer.render(<div />, document.body);
+		// TODO: why is this setTimeout necessary???
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(document.body.innerHTML).toBe("<div></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(span);
+	});
 
-test("multiple calls, different fns", () => {
-	const fn1 = Sinon.fake();
-	const fn2 = Sinon.fake();
-	function* Component(this: Context): Generator<Element> {
-		this.cleanup(fn1);
-		this.cleanup(fn2);
-		while (true) {
-			yield <span>Hello</span>;
+	test("multiple calls, same fn", () => {
+		const fn = Sinon.fake();
+		function* Component(this: Context): Generator<Element> {
+			this.cleanup(fn);
+			while (true) {
+				yield <span>Hello</span>;
+			}
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	Assert.is(fn1.callCount, 0);
-	Assert.is(fn2.callCount, 0);
-	const span = document.body.firstChild!.firstChild;
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		expect(fn.callCount).toBe(0);
+		const span = document.body.firstChild!.firstChild;
 
-	renderer.render(<div />, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	Assert.is(fn1.callCount, 1);
-	Assert.is(fn2.callCount, 1);
-	Assert.is(fn1.lastCall.args[0], span);
-	Assert.is(fn2.lastCall.args[0], span);
-});
+		renderer.render(<div />, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(span);
+	});
 
-test("multiple calls across updates", () => {
-	const fn1 = Sinon.fake();
-	const fn2 = Sinon.fake();
-	function* Component(this: Context): Generator<Element> {
-		let i = 0;
-		while (true) {
+	test("multiple calls, different fns", () => {
+		const fn1 = Sinon.fake();
+		const fn2 = Sinon.fake();
+		function* Component(this: Context): Generator<Element> {
 			this.cleanup(fn1);
 			this.cleanup(fn2);
-			yield <span>{i++}</span>;
+			while (true) {
+				yield <span>Hello</span>;
+			}
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	Assert.is(fn1.callCount, 0);
-	Assert.is(fn2.callCount, 0);
-	const span = document.body.firstChild!.firstChild;
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		expect(fn1.callCount).toBe(0);
+		expect(fn2.callCount).toBe(0);
+		const span = document.body.firstChild!.firstChild;
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		renderer.render(<div />, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		expect(fn1.callCount).toBe(1);
+		expect(fn2.callCount).toBe(1);
+		expect(fn1.lastCall.args[0]).toBe(span);
+		expect(fn2.lastCall.args[0]).toBe(span);
+	});
 
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	Assert.is(fn1.callCount, 0);
-	Assert.is(fn2.callCount, 0);
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>2</span></div>");
-	Assert.is(fn1.callCount, 0);
-	Assert.is(fn2.callCount, 0);
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>3</span></div>");
-	Assert.is(fn1.callCount, 0);
-	Assert.is(fn2.callCount, 0);
-
-	renderer.render(<div />, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	Assert.is(fn1.callCount, 1);
-	Assert.is(fn2.callCount, 1);
-	Assert.is(fn1.lastCall.args[0], span);
-	Assert.is(fn2.lastCall.args[0], span);
-});
-
-test("component child", () => {
-	function Child(): Element {
-		return <span>Hello</span>;
-	}
-
-	const fn = Sinon.fake();
-	function* Component(this: Context): Generator<Element> {
-		this.cleanup(fn);
-		while (true) {
-			yield <Child />;
+	test("multiple calls across updates", () => {
+		const fn1 = Sinon.fake();
+		const fn2 = Sinon.fake();
+		function* Component(this: Context): Generator<Element> {
+			let i = 0;
+			while (true) {
+				this.cleanup(fn1);
+				this.cleanup(fn2);
+				yield <span>{i++}</span>;
+			}
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	Assert.is(fn.callCount, 0);
-	const span = document.body.firstChild!.firstChild;
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	renderer.render(<div />, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], span);
-});
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		expect(fn1.callCount).toBe(0);
+		expect(fn2.callCount).toBe(0);
+		const span = document.body.firstChild!.firstChild;
 
-test("async child", async () => {
-	async function Child(): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 1));
-		return <span>Hello</span>;
-	}
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	const fn = Sinon.fake();
-	function* Component(this: Context): Generator<Element> {
-		this.cleanup(fn);
-		while (true) {
-			yield <Child />;
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		expect(fn1.callCount).toBe(0);
+		expect(fn2.callCount).toBe(0);
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><span>2</span></div>");
+		expect(fn1.callCount).toBe(0);
+		expect(fn2.callCount).toBe(0);
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><span>3</span></div>");
+		expect(fn1.callCount).toBe(0);
+		expect(fn2.callCount).toBe(0);
+
+		renderer.render(<div />, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		expect(fn1.callCount).toBe(1);
+		expect(fn2.callCount).toBe(1);
+		expect(fn1.lastCall.args[0]).toBe(span);
+		expect(fn2.lastCall.args[0]).toBe(span);
+	});
+
+	test("component child", () => {
+		function Child(): Element {
+			return <span>Hello</span>;
 		}
-	}
 
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	Assert.is(fn.callCount, 0);
-	const span = document.body.firstChild!.firstChild;
-
-	renderer.render(<div />, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], span);
-});
-
-test("fragment child", () => {
-	const fn = Sinon.fake();
-	function* Component(this: Context): Generator<Element> {
-		this.cleanup(fn);
-		while (true) {
-			yield (
-				<Fragment>
-					<div>1</div>
-					<div>2</div>
-					<div>3</div>
-				</Fragment>
-			);
+		const fn = Sinon.fake();
+		function* Component(this: Context): Generator<Element> {
+			this.cleanup(fn);
+			while (true) {
+				yield <Child />;
+			}
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><div>1</div><div>2</div><div>3</div></div>",
-	);
-	Assert.is(fn.callCount, 0);
-	const children = Array.from(document.body.firstChild!.childNodes);
-	renderer.render(<div />, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.equal(fn.lastCall.args[0], children);
-});
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		expect(fn.callCount).toBe(0);
+		const span = document.body.firstChild!.firstChild;
 
-test("hanging child", async () => {
-	const fn = Sinon.fake();
-	async function Hanging(): Promise<never> {
-		await new Promise(() => {});
-		throw new Error("This should never be reached");
-	}
+		renderer.render(<div />, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(span);
+	});
 
-	function* Component(this: Context): Generator<Element> {
-		this.cleanup(fn);
-		while (true) {
-			yield <Hanging />;
+	test("async child", async () => {
+		async function Child(): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 1));
+			return <span>Hello</span>;
 		}
-	}
 
-	const p = renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		const fn = Sinon.fake();
+		function* Component(this: Context): Generator<Element> {
+			this.cleanup(fn);
+			while (true) {
+				yield <Child />;
+			}
+		}
 
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(fn.callCount, 0);
-	Assert.is(document.body.innerHTML, "");
-	renderer.render(<div />, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], undefined);
-	await p;
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], undefined);
-});
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		expect(fn.callCount).toBe(0);
+		const span = document.body.firstChild!.firstChild;
 
-test("cleanup is called even if component is prematurely unmounted", async () => {
-	const fn = Sinon.fake();
-	async function* Component(this: Context) {
-		fn();
-		await new Promise((r) => setTimeout(r, 100));
-		this.cleanup(() => {
+		renderer.render(<div />, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(span);
+	});
+
+	test("fragment child", () => {
+		const fn = Sinon.fake();
+		function* Component(this: Context): Generator<Element> {
+			this.cleanup(fn);
+			while (true) {
+				yield (
+					<Fragment>
+						<div>1</div>
+						<div>2</div>
+						<div>3</div>
+					</Fragment>
+				);
+			}
+		}
+
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><div>1</div><div>2</div><div>3</div></div>",
+		);
+		expect(fn.callCount).toBe(0);
+		const children = Array.from(document.body.firstChild!.childNodes);
+		renderer.render(<div />, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toEqual(children);
+	});
+
+	test("hanging child", async () => {
+		const fn = Sinon.fake();
+		async function Hanging(): Promise<never> {
+			await new Promise(() => {});
+			throw new Error("This should never be reached");
+		}
+
+		function* Component(this: Context): Generator<Element> {
+			this.cleanup(fn);
+			while (true) {
+				yield <Hanging />;
+			}
+		}
+
+		const p = renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(fn.callCount).toBe(0);
+		expect(document.body.innerHTML).toBe("");
+		renderer.render(<div />, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(undefined);
+		await p;
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(undefined);
+	});
+
+	test("cleanup is called even if component is prematurely unmounted", async () => {
+		const fn = Sinon.fake();
+		async function* Component(this: Context) {
 			fn();
-		});
-		for ({} of this) {
-			yield null;
-		}
-	}
-
-	renderer.render(<Component />, document.body);
-	renderer.render(null, document.body);
-
-	Assert.is(fn.callCount, 1);
-	await new Promise((r) => setTimeout(r, 200));
-	Assert.is(fn.callCount, 2);
-});
-
-test("components can linger", async () => {
-	let fn = Sinon.fake();
-	let resolve: Function;
-	function* Component(this: Context) {
-		this.cleanup(() => {
-			fn();
-			return new Promise((resolve1) => (resolve = resolve1));
-		});
-		for ({} of this) {
-			yield <span>Hello</span>;
-		}
-	}
-
-	renderer.render(
-		<div>
-			<Component /> <span>World</span>
-		</div>,
-		document.body,
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Hello</span> <span>World</span></div>",
-	);
-
-	renderer.render(<div />, document.body);
-	Assert.is(fn.callCount, 1);
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	resolve!();
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<div></div>");
-});
-
-test("multiple components linger and unmount independently", async () => {
-	let mock1 = Sinon.fake();
-	let mock2 = Sinon.fake();
-	let resolve1!: Function;
-	let resolve2!: Function;
-
-	function* Child1(this: Context) {
-		this.cleanup(() => {
-			mock1();
-			return new Promise((r) => (resolve1 = r));
-		});
-		for ({} of this) yield <span>One</span>;
-	}
-
-	function* Child3(this: Context) {
-		this.cleanup(() => {
-			mock2();
-			return new Promise((r) => (resolve2 = r));
-		});
-		for ({} of this) yield <span>Three</span>;
-	}
-
-	renderer.render(
-		<div>
-			<Child1 />
-			<span>Two</span>
-			<Child3 />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>One</span><span>Two</span><span>Three</span></div>",
-	);
-
-	renderer.render(
-		<div>
-			<span>Two</span>
-		</div>,
-		document.body,
-	);
-
-	Assert.is(mock1.callCount, 1);
-	Assert.is(mock2.callCount, 1);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>One</span><span>Two</span><span>Three</span></div>",
-	);
-
-	resolve1();
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>One</span><span>Two</span><span>Three</span></div>",
-	);
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Two</span><span>Three</span></div>",
-	);
-	resolve2();
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<div><span>Two</span></div>");
-});
-
-test("nested components linger correctly", async () => {
-	let parentCleanup = Sinon.fake();
-	let childCleanup = Sinon.fake();
-	let resolveParent!: Function;
-	let resolveChild!: Function;
-
-	function* Parent(this: Context) {
-		this.cleanup(() => {
-			parentCleanup();
-			return new Promise((r) => (resolveParent = r));
-		});
-		for ({} of this) yield <Child />;
-	}
-
-	function* Child(this: Context) {
-		this.cleanup(() => {
-			childCleanup();
-			return new Promise((r) => (resolveChild = r));
-		});
-		yield <span>Child</span>;
-	}
-
-	renderer.render(
-		<div>
-			<Parent />
-			<span>Sibling</span>
-		</div>,
-		document.body,
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Child</span><span>Sibling</span></div>",
-	);
-
-	// Remove Parent but keep Child lingering
-	renderer.render(
-		<div>
-			<span>Sibling</span>
-		</div>,
-		document.body,
-	);
-
-	Assert.is(parentCleanup.callCount, 1);
-	Assert.is(childCleanup.callCount, 0);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Child</span><span>Sibling</span></div>",
-	);
-
-	resolveParent();
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Child</span><span>Sibling</span></div>",
-	);
-
-	Assert.is(parentCleanup.callCount, 1);
-	Assert.is(childCleanup.callCount, 1);
-
-	resolveChild();
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<div><span>Sibling</span></div>");
-});
-
-test("fragments handle lingering components correctly", async () => {
-	let cleanupA = Sinon.fake();
-	let cleanupB = Sinon.fake();
-	let resolveA!: Function;
-	let resolveB!: Function;
-
-	function* ComponentA(this: Context) {
-		this.cleanup(() => {
-			cleanupA();
-			return new Promise((r) => (resolveA = r));
-		});
-		yield <span>A</span>;
-	}
-
-	function* ComponentB(this: Context) {
-		this.cleanup(() => {
-			cleanupB();
-			return new Promise((r) => (resolveB = r));
-		});
-		yield <span>B</span>;
-	}
-
-	renderer.render(
-		<div>
-			<Fragment>
-				<ComponentA />
-				<ComponentB />
-			</Fragment>
-			<span>Sibling</span>
-		</div>,
-		document.body,
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>A</span><span>B</span><span>Sibling</span></div>",
-	);
-
-	// Remove the fragment, keep lingering components
-	renderer.render(
-		<div>
-			<span>Sibling</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(cleanupA.callCount, 1);
-	Assert.is(cleanupB.callCount, 1);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>A</span><span>Sibling</span><span>B</span></div>",
-	);
-
-	resolveA();
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Sibling</span><span>B</span></div>",
-	);
-
-	resolveB();
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<div><span>Sibling</span></div>");
-});
-
-test("component without children does not linger", async () => {
-	let cleanup = Sinon.fake();
-	let resolve!: Function;
-
-	function* Component(this: Context, {condition}: {condition: boolean}) {
-		this.cleanup(() => {
-			cleanup();
-			return new Promise((r) => (resolve = r));
-		});
-
-		for ({condition} of this) {
-			if (condition) {
-				yield <span>Child</span>;
-			} else {
+			await new Promise((r) => setTimeout(r, 100));
+			this.cleanup(() => {
+				fn();
+			});
+			for ({} of this) {
 				yield null;
 			}
 		}
-	}
 
-	renderer.render(<Component condition={true} />, document.body);
-	Assert.is(document.body.innerHTML, "<span>Child</span>");
+		renderer.render(<Component />, document.body);
+		renderer.render(null, document.body);
 
-	renderer.render(<Component condition={false} />, document.body);
-	Assert.is(cleanup.callCount, 0);
-	Assert.is(document.body.innerHTML, "");
-	renderer.render(<div />, document.body);
-	Assert.is(cleanup.callCount, 1);
-	resolve();
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<div></div>");
-});
+		expect(fn.callCount).toBe(1);
+		await new Promise((r) => setTimeout(r, 200));
+		expect(fn.callCount).toBe(2);
+	});
 
-test("lingering component cleared when parent unmounted", async () => {
-	let cleanup = Sinon.fake();
-
-	function* Child(this: Context) {
-		this.cleanup(() => {
-			cleanup();
-			return new Promise(() => {});
-		});
-		for ({} of this) yield <span>Child</span>;
-	}
-
-	renderer.render(
-		<div>
-			<Child />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Child</span></div>");
-	renderer.render(<div></div>, document.body);
-	Assert.is(cleanup.callCount, 1);
-	renderer.render(<span>No more div</span>, document.body);
-	Assert.is(document.body.innerHTML, "<span>No more div</span>");
-	Assert.is(cleanup.callCount, 1);
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<span>No more div</span>");
-});
-
-test("component wrapping lingering component (no host boundary)", async () => {
-	// AlertModal wraps Modal directly (no intermediate <div>).
-	// Does Modal linger when AlertModal is removed?
-	let cleanup = Sinon.fake();
-	let resolve!: Function;
-
-	function* Modal(this: Context) {
-		this.cleanup(() => {
-			cleanup();
-			return new Promise((r) => (resolve = r));
-		});
-		for ({} of this) {
-			yield <span>Modal</span>;
+	test("components can linger", async () => {
+		let fn = Sinon.fake();
+		let resolve: Function;
+		function* Component(this: Context) {
+			this.cleanup(() => {
+				fn();
+				return new Promise((resolve1) => (resolve = resolve1));
+			});
+			for ({} of this) {
+				yield <span>Hello</span>;
+			}
 		}
-	}
 
-	function AlertModal() {
-		return <Modal />;
-	}
-
-	renderer.render(
-		<div>
-			<AlertModal />
-			<span>Sibling</span>
-		</div>,
-		document.body,
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Modal</span><span>Sibling</span></div>",
-	);
-
-	renderer.render(
-		<div>
-			<span>Sibling</span>
-		</div>,
-		document.body,
-	);
-
-	Assert.is(cleanup.callCount, 1, "cleanup should be called");
-	// Modal lingers because isNested stays false through components
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Modal</span><span>Sibling</span></div>",
-		"Modal should still be visible (lingering)",
-	);
-
-	resolve();
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Sibling</span></div>",
-		"Modal should be removed after cleanup resolves",
-	);
-});
-
-test("component wrapping lingering component with host boundary", async () => {
-	// AlertModal wraps Modal inside a <div class="wrapper">.
-	// Does Modal linger when AlertModal is removed?
-	let cleanup = Sinon.fake();
-	let _resolve!: Function;
-
-	function* Modal(this: Context) {
-		this.cleanup(() => {
-			cleanup();
-			return new Promise((r) => (_resolve = r));
-		});
-		for ({} of this) {
-			yield <span>Modal</span>;
-		}
-	}
-
-	function AlertModal() {
-		return (
-			<div class="wrapper">
-				<Modal />
-			</div>
+		renderer.render(
+			<div>
+				<Component /> <span>World</span>
+			</div>,
+			document.body,
 		);
-	}
 
-	renderer.render(
-		<div>
-			<AlertModal />
-			<span>Sibling</span>
-		</div>,
-		document.body,
-	);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Hello</span> <span>World</span></div>",
+		);
 
-	Assert.is(
-		document.body.innerHTML,
-		'<div><div class="wrapper"><span>Modal</span></div><span>Sibling</span></div>',
-	);
+		renderer.render(<div />, document.body);
+		expect(fn.callCount).toBe(1);
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		resolve!();
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<div></div>");
+	});
 
-	renderer.render(
-		<div>
-			<span>Sibling</span>
-		</div>,
-		document.body,
-	);
+	test("multiple components linger and unmount independently", async () => {
+		let mock1 = Sinon.fake();
+		let mock2 = Sinon.fake();
+		let resolve1!: Function;
+		let resolve2!: Function;
 
-	Assert.is(cleanup.callCount, 1, "cleanup should be called");
-	// Modal cannot linger because <div class="wrapper"> forces isNested=true
-	// So everything is removed immediately
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Sibling</span></div>",
-		"wrapper and Modal should be removed immediately (isNested=true)",
-	);
-});
-
-test("lingering component can refresh during cleanup", async () => {
-	// Modal calls this.refresh() in cleanup to trigger exit animation class.
-	// Does the refresh actually re-render?
-	let resolve!: Function;
-
-	function* Modal(this: Context) {
-		let visible = true;
-		this.cleanup(() => {
-			this.refresh(() => (visible = false));
-			return new Promise((r) => (resolve = r));
-		});
-		for ({} of this) {
-			yield <div class={visible ? "visible" : "hidden"}>Modal</div>;
+		function* Child1(this: Context) {
+			this.cleanup(() => {
+				mock1();
+				return new Promise((r) => (resolve1 = r));
+			});
+			for ({} of this) yield <span>One</span>;
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Modal />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		'<div><div class="visible">Modal</div></div>',
-	);
-
-	renderer.render(<div />, document.body);
-
-	// refresh during cleanup triggers re-render with visible=false
-	Assert.is(
-		document.body.innerHTML,
-		'<div><div class="hidden">Modal</div></div>',
-		"Modal should re-render with hidden class during linger",
-	);
-
-	resolve();
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<div></div>");
-});
-
-test("deeply nested component wrapping (no host boundaries)", async () => {
-	// Three levels of component wrapping: Outer -> Middle -> Modal
-	// No host elements between them. Does Modal linger?
-	let cleanup = Sinon.fake();
-	let resolve!: Function;
-
-	function* Modal(this: Context) {
-		this.cleanup(() => {
-			cleanup();
-			return new Promise((r) => (resolve = r));
-		});
-		for ({} of this) {
-			yield <span>Modal</span>;
+		function* Child3(this: Context) {
+			this.cleanup(() => {
+				mock2();
+				return new Promise((r) => (resolve2 = r));
+			});
+			for ({} of this) yield <span>Three</span>;
 		}
-	}
 
-	function Middle() {
-		return <Modal />;
-	}
+		renderer.render(
+			<div>
+				<Child1 />
+				<span>Two</span>
+				<Child3 />
+			</div>,
+			document.body,
+		);
 
-	function Outer() {
-		return <Middle />;
-	}
+		expect(document.body.innerHTML).toBe(
+			"<div><span>One</span><span>Two</span><span>Three</span></div>",
+		);
 
-	renderer.render(
-		<div>
-			<Outer />
-			<span>Sibling</span>
-		</div>,
-		document.body,
-	);
+		renderer.render(
+			<div>
+				<span>Two</span>
+			</div>,
+			document.body,
+		);
 
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Modal</span><span>Sibling</span></div>",
-	);
+		expect(mock1.callCount).toBe(1);
+		expect(mock2.callCount).toBe(1);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>One</span><span>Two</span><span>Three</span></div>",
+		);
 
-	renderer.render(
-		<div>
-			<span>Sibling</span>
-		</div>,
-		document.body,
-	);
+		resolve1();
+		expect(document.body.innerHTML).toBe(
+			"<div><span>One</span><span>Two</span><span>Three</span></div>",
+		);
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Two</span><span>Three</span></div>",
+		);
+		resolve2();
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<div><span>Two</span></div>");
+	});
 
-	Assert.is(cleanup.callCount, 1, "cleanup should be called");
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Modal</span><span>Sibling</span></div>",
-		"Modal should linger through component wrappers",
-	);
+	test("nested components linger correctly", async () => {
+		let parentCleanup = Sinon.fake();
+		let childCleanup = Sinon.fake();
+		let resolveParent!: Function;
+		let resolveChild!: Function;
 
-	resolve();
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<div><span>Sibling</span></div>");
-});
-
-test("component rendering Portal can linger", async () => {
-	// Modal renders its content via a Portal. Portal content should
-	// stay visible during async cleanup (lingering).
-	let cleanup = Sinon.fake();
-	let resolve!: Function;
-
-	const portalRoot = document.createElement("div");
-	document.body.appendChild(portalRoot);
-
-	function* Modal(this: Context) {
-		this.cleanup(() => {
-			cleanup();
-			return new Promise((r) => (resolve = r));
-		});
-		for ({} of this) {
-			yield (
-				<Portal root={portalRoot}>
-					<div class="modal">Modal Content</div>
-				</Portal>
-			);
+		function* Parent(this: Context) {
+			this.cleanup(() => {
+				parentCleanup();
+				return new Promise((r) => (resolveParent = r));
+			});
+			for ({} of this) yield <Child />;
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Modal />
-			<span>Sibling</span>
-		</div>,
-		document.body,
-	);
-
-	Assert.is(portalRoot.innerHTML, '<div class="modal">Modal Content</div>');
-	Assert.is(document.body.innerHTML.includes("<span>Sibling</span>"), true);
-
-	renderer.render(
-		<div>
-			<span>Sibling</span>
-		</div>,
-		document.body,
-	);
-
-	Assert.is(cleanup.callCount, 1, "cleanup should be called");
-	// Portal content should linger during async cleanup
-	Assert.is(
-		portalRoot.innerHTML,
-		'<div class="modal">Modal Content</div>',
-		"Portal content should stay visible during linger",
-	);
-
-	resolve();
-	await new Promise((resolve) => setTimeout(resolve));
-
-	Assert.is(
-		portalRoot.innerHTML,
-		"",
-		"Portal content should be removed after cleanup resolves",
-	);
-
-	document.body.removeChild(portalRoot);
-});
-
-test("Portal-rendering component can refresh during linger", async () => {
-	// Modal renders via Portal, calls this.refresh() in cleanup to trigger
-	// CSS transition class, then defers with a Promise.
-	let resolve!: Function;
-
-	const portalRoot = document.createElement("div");
-	document.body.appendChild(portalRoot);
-
-	function* Modal(this: Context) {
-		let visible = true;
-		this.cleanup(() => {
-			this.refresh(() => (visible = false));
-			return new Promise((r) => (resolve = r));
-		});
-		for ({} of this) {
-			yield (
-				<Portal root={portalRoot}>
-					<div class={visible ? "visible" : "hidden"}>Modal</div>
-				</Portal>
-			);
+		function* Child(this: Context) {
+			this.cleanup(() => {
+				childCleanup();
+				return new Promise((r) => (resolveChild = r));
+			});
+			yield <span>Child</span>;
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Modal />
-		</div>,
-		document.body,
-	);
+		renderer.render(
+			<div>
+				<Parent />
+				<span>Sibling</span>
+			</div>,
+			document.body,
+		);
 
-	Assert.is(portalRoot.innerHTML, '<div class="visible">Modal</div>');
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Child</span><span>Sibling</span></div>",
+		);
 
-	renderer.render(<div />, document.body);
+		// Remove Parent but keep Child lingering
+		renderer.render(
+			<div>
+				<span>Sibling</span>
+			</div>,
+			document.body,
+		);
 
-	// Modal should re-render with hidden class during linger
-	Assert.is(
-		portalRoot.innerHTML,
-		'<div class="hidden">Modal</div>',
-		"Modal should refresh with hidden class during linger",
-	);
+		expect(parentCleanup.callCount).toBe(1);
+		expect(childCleanup.callCount).toBe(0);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Child</span><span>Sibling</span></div>",
+		);
 
-	resolve();
-	await new Promise((resolve) => setTimeout(resolve));
+		resolveParent();
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Child</span><span>Sibling</span></div>",
+		);
 
-	Assert.is(
-		portalRoot.innerHTML,
-		"",
-		"Portal content should be removed after cleanup resolves",
-	);
+		expect(parentCleanup.callCount).toBe(1);
+		expect(childCleanup.callCount).toBe(1);
 
-	document.body.removeChild(portalRoot);
-});
+		resolveChild();
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<div><span>Sibling</span></div>");
+	});
 
-test("lingering component can refresh multiple times", async () => {
-	// Component plays a multi-step exit animation via repeated refreshes
-	let step = 0;
-	let resolve!: Function;
+	test("fragments handle lingering components correctly", async () => {
+		let cleanupA = Sinon.fake();
+		let cleanupB = Sinon.fake();
+		let resolveA!: Function;
+		let resolveB!: Function;
 
-	function* Animated(this: Context) {
-		this.cleanup(() => {
-			this.refresh(() => (step = 1));
-			return new Promise((r) => (resolve = r));
-		});
-		for ({} of this) {
-			yield <div class={`step-${step}`}>Content</div>;
+		function* ComponentA(this: Context) {
+			this.cleanup(() => {
+				cleanupA();
+				return new Promise((r) => (resolveA = r));
+			});
+			yield <span>A</span>;
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Animated />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		'<div><div class="step-0">Content</div></div>',
-	);
-
-	renderer.render(<div />, document.body);
-	Assert.is(
-		document.body.innerHTML,
-		'<div><div class="step-1">Content</div></div>',
-	);
-
-	resolve();
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<div></div>");
-});
-
-test("lingering component responds to events during linger", async () => {
-	let clickCount = 0;
-	let resolve!: Function;
-
-	function* Counter(this: Context) {
-		this.cleanup(() => {
-			return new Promise((r) => (resolve = r));
-		});
-		this.addEventListener("click", () => {
-			this.refresh(() => clickCount++);
-		});
-		for ({} of this) {
-			yield <button>Clicked {clickCount} times</button>;
+		function* ComponentB(this: Context) {
+			this.cleanup(() => {
+				cleanupB();
+				return new Promise((r) => (resolveB = r));
+			});
+			yield <span>B</span>;
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Counter />
-		</div>,
-		document.body,
-	);
+		renderer.render(
+			<div>
+				<Fragment>
+					<ComponentA />
+					<ComponentB />
+				</Fragment>
+				<span>Sibling</span>
+			</div>,
+			document.body,
+		);
 
-	Assert.is(
-		document.body.innerHTML,
-		"<div><button>Clicked 0 times</button></div>",
-	);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>A</span><span>B</span><span>Sibling</span></div>",
+		);
 
-	// Remove Counter — it should linger
-	renderer.render(<div />, document.body);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><button>Clicked 0 times</button></div>",
-		"Counter should linger",
-	);
+		// Remove the fragment, keep lingering components
+		renderer.render(
+			<div>
+				<span>Sibling</span>
+			</div>,
+			document.body,
+		);
+		expect(cleanupA.callCount).toBe(1);
+		expect(cleanupB.callCount).toBe(1);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>A</span><span>Sibling</span><span>B</span></div>",
+		);
 
-	// Click the button while lingering
-	document.querySelector("button")!.click();
-	Assert.is(
-		document.body.innerHTML,
-		"<div><button>Clicked 1 times</button></div>",
-		"Counter should respond to clicks during linger",
-	);
+		resolveA();
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Sibling</span><span>B</span></div>",
+		);
 
-	document.querySelector("button")!.click();
-	Assert.is(
-		document.body.innerHTML,
-		"<div><button>Clicked 2 times</button></div>",
-		"Counter should respond to multiple clicks during linger",
-	);
+		resolveB();
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<div><span>Sibling</span></div>");
+	});
 
-	resolve();
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<div></div>");
-});
+	test("component without children does not linger", async () => {
+		let cleanup = Sinon.fake();
+		let resolve!: Function;
 
-test("lingering component children update on refresh", async () => {
-	let resolve!: Function;
-	let phase = "active";
+		function* Component(this: Context, {condition}: {condition: boolean}) {
+			this.cleanup(() => {
+				cleanup();
+				return new Promise((r) => (resolve = r));
+			});
 
-	function Badge({label}: {label: string}) {
-		return <span class="badge">{label}</span>;
-	}
+			for ({condition} of this) {
+				if (condition) {
+					yield <span>Child</span>;
+				} else {
+					yield null;
+				}
+			}
+		}
 
-	function* Panel(this: Context) {
-		this.cleanup(() => {
-			this.refresh(() => (phase = "exiting"));
-			return new Promise((r) => (resolve = r));
-		});
-		for ({} of this) {
-			yield (
-				<div>
-					<Badge label={phase} />
+		renderer.render(<Component condition={true} />, document.body);
+		expect(document.body.innerHTML).toBe("<span>Child</span>");
+
+		renderer.render(<Component condition={false} />, document.body);
+		expect(cleanup.callCount).toBe(0);
+		expect(document.body.innerHTML).toBe("");
+		renderer.render(<div />, document.body);
+		expect(cleanup.callCount).toBe(1);
+		resolve();
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<div></div>");
+	});
+
+	test("lingering component cleared when parent unmounted", async () => {
+		let cleanup = Sinon.fake();
+
+		function* Child(this: Context) {
+			this.cleanup(() => {
+				cleanup();
+				return new Promise(() => {});
+			});
+			for ({} of this) yield <span>Child</span>;
+		}
+
+		renderer.render(
+			<div>
+				<Child />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Child</span></div>");
+		renderer.render(<div></div>, document.body);
+		expect(cleanup.callCount).toBe(1);
+		renderer.render(<span>No more div</span>, document.body);
+		expect(document.body.innerHTML).toBe("<span>No more div</span>");
+		expect(cleanup.callCount).toBe(1);
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<span>No more div</span>");
+	});
+
+	test("component wrapping lingering component (no host boundary)", async () => {
+		// AlertModal wraps Modal directly (no intermediate <div>).
+		// Does Modal linger when AlertModal is removed?
+		let cleanup = Sinon.fake();
+		let resolve!: Function;
+
+		function* Modal(this: Context) {
+			this.cleanup(() => {
+				cleanup();
+				return new Promise((r) => (resolve = r));
+			});
+			for ({} of this) {
+				yield <span>Modal</span>;
+			}
+		}
+
+		function AlertModal() {
+			return <Modal />;
+		}
+
+		renderer.render(
+			<div>
+				<AlertModal />
+				<span>Sibling</span>
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Modal</span><span>Sibling</span></div>",
+		);
+
+		renderer.render(
+			<div>
+				<span>Sibling</span>
+			</div>,
+			document.body,
+		);
+
+		expect(cleanup.callCount).toBe(1) /* cleanup should be called */;
+		// Modal lingers because isNested stays false through components
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Modal</span><span>Sibling</span></div>",
+		) /* Modal should still be visible (lingering) */;
+
+		resolve();
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Sibling</span></div>",
+		) /* Modal should be removed after cleanup resolves */;
+	});
+
+	test("component wrapping lingering component with host boundary", async () => {
+		// AlertModal wraps Modal inside a <div class="wrapper">.
+		// Does Modal linger when AlertModal is removed?
+		let cleanup = Sinon.fake();
+		let _resolve!: Function;
+
+		function* Modal(this: Context) {
+			this.cleanup(() => {
+				cleanup();
+				return new Promise((r) => (_resolve = r));
+			});
+			for ({} of this) {
+				yield <span>Modal</span>;
+			}
+		}
+
+		function AlertModal() {
+			return (
+				<div class="wrapper">
+					<Modal />
 				</div>
 			);
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Panel />
-		</div>,
-		document.body,
-	);
+		renderer.render(
+			<div>
+				<AlertModal />
+				<span>Sibling</span>
+			</div>,
+			document.body,
+		);
 
-	Assert.is(
-		document.body.innerHTML,
-		'<div><div><span class="badge">active</span></div></div>',
-	);
+		expect(document.body.innerHTML).toBe(
+			'<div><div class="wrapper"><span>Modal</span></div><span>Sibling</span></div>',
+		);
 
-	renderer.render(<div />, document.body);
+		renderer.render(
+			<div>
+				<span>Sibling</span>
+			</div>,
+			document.body,
+		);
 
-	Assert.is(
-		document.body.innerHTML,
-		'<div><div><span class="badge">exiting</span></div></div>',
-		"Child component should re-render with updated props during linger",
-	);
+		expect(cleanup.callCount).toBe(1) /* cleanup should be called */;
+		// Modal cannot linger because <div class="wrapper"> forces isNested=true
+		// So everything is removed immediately
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Sibling</span></div>",
+		) /* wrapper and Modal should be removed immediately (isNested=true) */;
+	});
 
-	resolve();
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<div></div>");
-});
+	test("lingering component can refresh during cleanup", async () => {
+		// Modal calls this.refresh() in cleanup to trigger exit animation class.
+		// Does the refresh actually re-render?
+		let resolve!: Function;
 
-test("lingering component with async refresh during linger", async () => {
-	// Simulates a real exit animation: cleanup triggers state change,
-	// then a timer fires and resolves the cleanup promise
-	let visible = true;
-	let cleanupResolve!: Function;
-
-	function* Toast(this: Context) {
-		this.cleanup(() => {
-			this.refresh(() => (visible = false));
-			return new Promise((r) => (cleanupResolve = r));
-		});
-		for ({} of this) {
-			yield <div class={visible ? "toast show" : "toast hide"}>Message</div>;
+		function* Modal(this: Context) {
+			let visible = true;
+			this.cleanup(() => {
+				this.refresh(() => (visible = false));
+				return new Promise((r) => (resolve = r));
+			});
+			for ({} of this) {
+				yield <div class={visible ? "visible" : "hidden"}>Modal</div>;
+			}
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Toast />
-		</div>,
-		document.body,
-	);
+		renderer.render(
+			<div>
+				<Modal />
+			</div>,
+			document.body,
+		);
 
-	Assert.is(
-		document.body.innerHTML,
-		'<div><div class="toast show">Message</div></div>',
-	);
+		expect(document.body.innerHTML).toBe(
+			'<div><div class="visible">Modal</div></div>',
+		);
 
-	renderer.render(<div />, document.body);
+		renderer.render(<div />, document.body);
 
-	// Immediately after unmount: class should flip
-	Assert.is(
-		document.body.innerHTML,
-		'<div><div class="toast hide">Message</div></div>',
-		"Toast should show exit state during linger",
-	);
+		// refresh during cleanup triggers re-render with visible=false
+		expect(document.body.innerHTML).toBe(
+			'<div><div class="hidden">Modal</div></div>',
+		) /* Modal should re-render with hidden class during linger */;
 
-	// Resolve after a tick (simulating setTimeout in real code)
-	await new Promise((resolve) => setTimeout(resolve, 50));
+		resolve();
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<div></div>");
+	});
 
-	// Still lingering — hasn't resolved yet
-	Assert.is(
-		document.body.innerHTML,
-		'<div><div class="toast hide">Message</div></div>',
-		"Toast should still be visible while waiting",
-	);
+	test("deeply nested component wrapping (no host boundaries)", async () => {
+		// Three levels of component wrapping: Outer -> Middle -> Modal
+		// No host elements between them. Does Modal linger?
+		let cleanup = Sinon.fake();
+		let resolve!: Function;
 
-	cleanupResolve();
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<div></div>");
+		function* Modal(this: Context) {
+			this.cleanup(() => {
+				cleanup();
+				return new Promise((r) => (resolve = r));
+			});
+			for ({} of this) {
+				yield <span>Modal</span>;
+			}
+		}
+
+		function Middle() {
+			return <Modal />;
+		}
+
+		function Outer() {
+			return <Middle />;
+		}
+
+		renderer.render(
+			<div>
+				<Outer />
+				<span>Sibling</span>
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Modal</span><span>Sibling</span></div>",
+		);
+
+		renderer.render(
+			<div>
+				<span>Sibling</span>
+			</div>,
+			document.body,
+		);
+
+		expect(cleanup.callCount).toBe(1) /* cleanup should be called */;
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Modal</span><span>Sibling</span></div>",
+		) /* Modal should linger through component wrappers */;
+
+		resolve();
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<div><span>Sibling</span></div>");
+	});
+
+	test("component rendering Portal can linger", async () => {
+		// Modal renders its content via a Portal. Portal content should
+		// stay visible during async cleanup (lingering).
+		let cleanup = Sinon.fake();
+		let resolve!: Function;
+
+		const portalRoot = document.createElement("div");
+		document.body.appendChild(portalRoot);
+
+		function* Modal(this: Context) {
+			this.cleanup(() => {
+				cleanup();
+				return new Promise((r) => (resolve = r));
+			});
+			for ({} of this) {
+				yield (
+					<Portal root={portalRoot}>
+						<div class="modal">Modal Content</div>
+					</Portal>
+				);
+			}
+		}
+
+		renderer.render(
+			<div>
+				<Modal />
+				<span>Sibling</span>
+			</div>,
+			document.body,
+		);
+
+		expect(portalRoot.innerHTML).toBe('<div class="modal">Modal Content</div>');
+		expect(document.body.innerHTML.includes("<span>Sibling</span>")).toBe(true);
+
+		renderer.render(
+			<div>
+				<span>Sibling</span>
+			</div>,
+			document.body,
+		);
+
+		expect(cleanup.callCount).toBe(1) /* cleanup should be called */;
+		// Portal content should linger during async cleanup
+		expect(portalRoot.innerHTML).toBe(
+			'<div class="modal">Modal Content</div>',
+		) /* Portal content should stay visible during linger */;
+
+		resolve();
+		await new Promise((resolve) => setTimeout(resolve));
+
+		expect(portalRoot.innerHTML).toBe(
+			"",
+		) /* Portal content should be removed after cleanup resolves */;
+
+		document.body.removeChild(portalRoot);
+	});
+
+	test("Portal-rendering component can refresh during linger", async () => {
+		// Modal renders via Portal, calls this.refresh() in cleanup to trigger
+		// CSS transition class, then defers with a Promise.
+		let resolve!: Function;
+
+		const portalRoot = document.createElement("div");
+		document.body.appendChild(portalRoot);
+
+		function* Modal(this: Context) {
+			let visible = true;
+			this.cleanup(() => {
+				this.refresh(() => (visible = false));
+				return new Promise((r) => (resolve = r));
+			});
+			for ({} of this) {
+				yield (
+					<Portal root={portalRoot}>
+						<div class={visible ? "visible" : "hidden"}>Modal</div>
+					</Portal>
+				);
+			}
+		}
+
+		renderer.render(
+			<div>
+				<Modal />
+			</div>,
+			document.body,
+		);
+
+		expect(portalRoot.innerHTML).toBe('<div class="visible">Modal</div>');
+
+		renderer.render(<div />, document.body);
+
+		// Modal should re-render with hidden class during linger
+		expect(portalRoot.innerHTML).toBe(
+			'<div class="hidden">Modal</div>',
+		) /* Modal should refresh with hidden class during linger */;
+
+		resolve();
+		await new Promise((resolve) => setTimeout(resolve));
+
+		expect(portalRoot.innerHTML).toBe(
+			"",
+		) /* Portal content should be removed after cleanup resolves */;
+
+		document.body.removeChild(portalRoot);
+	});
+
+	test("lingering component can refresh multiple times", async () => {
+		// Component plays a multi-step exit animation via repeated refreshes
+		let step = 0;
+		let resolve!: Function;
+
+		function* Animated(this: Context) {
+			this.cleanup(() => {
+				this.refresh(() => (step = 1));
+				return new Promise((r) => (resolve = r));
+			});
+			for ({} of this) {
+				yield <div class={`step-${step}`}>Content</div>;
+			}
+		}
+
+		renderer.render(
+			<div>
+				<Animated />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			'<div><div class="step-0">Content</div></div>',
+		);
+
+		renderer.render(<div />, document.body);
+		expect(document.body.innerHTML).toBe(
+			'<div><div class="step-1">Content</div></div>',
+		);
+
+		resolve();
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<div></div>");
+	});
+
+	test("lingering component responds to events during linger", async () => {
+		let clickCount = 0;
+		let resolve!: Function;
+
+		function* Counter(this: Context) {
+			this.cleanup(() => {
+				return new Promise((r) => (resolve = r));
+			});
+			this.addEventListener("click", () => {
+				this.refresh(() => clickCount++);
+			});
+			for ({} of this) {
+				yield <button>Clicked {clickCount} times</button>;
+			}
+		}
+
+		renderer.render(
+			<div>
+				<Counter />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			"<div><button>Clicked 0 times</button></div>",
+		);
+
+		// Remove Counter — it should linger
+		renderer.render(<div />, document.body);
+		expect(document.body.innerHTML).toBe(
+			"<div><button>Clicked 0 times</button></div>",
+		) /* Counter should linger */;
+
+		// Click the button while lingering
+		document.querySelector("button")!.click();
+		expect(document.body.innerHTML).toBe(
+			"<div><button>Clicked 1 times</button></div>",
+		) /* Counter should respond to clicks during linger */;
+
+		document.querySelector("button")!.click();
+		expect(document.body.innerHTML).toBe(
+			"<div><button>Clicked 2 times</button></div>",
+		) /* Counter should respond to multiple clicks during linger */;
+
+		resolve();
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<div></div>");
+	});
+
+	test("lingering component children update on refresh", async () => {
+		let resolve!: Function;
+		let phase = "active";
+
+		function Badge({label}: {label: string}) {
+			return <span class="badge">{label}</span>;
+		}
+
+		function* Panel(this: Context) {
+			this.cleanup(() => {
+				this.refresh(() => (phase = "exiting"));
+				return new Promise((r) => (resolve = r));
+			});
+			for ({} of this) {
+				yield (
+					<div>
+						<Badge label={phase} />
+					</div>
+				);
+			}
+		}
+
+		renderer.render(
+			<div>
+				<Panel />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			'<div><div><span class="badge">active</span></div></div>',
+		);
+
+		renderer.render(<div />, document.body);
+
+		expect(document.body.innerHTML).toBe(
+			'<div><div><span class="badge">exiting</span></div></div>',
+		) /* Child component should re-render with updated props during linger */;
+
+		resolve();
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<div></div>");
+	});
+
+	test("lingering component with async refresh during linger", async () => {
+		// Simulates a real exit animation: cleanup triggers state change,
+		// then a timer fires and resolves the cleanup promise
+		let visible = true;
+		let cleanupResolve!: Function;
+
+		function* Toast(this: Context) {
+			this.cleanup(() => {
+				this.refresh(() => (visible = false));
+				return new Promise((r) => (cleanupResolve = r));
+			});
+			for ({} of this) {
+				yield <div class={visible ? "toast show" : "toast hide"}>Message</div>;
+			}
+		}
+
+		renderer.render(
+			<div>
+				<Toast />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			'<div><div class="toast show">Message</div></div>',
+		);
+
+		renderer.render(<div />, document.body);
+
+		// Immediately after unmount: class should flip
+		expect(document.body.innerHTML).toBe(
+			'<div><div class="toast hide">Message</div></div>',
+		) /* Toast should show exit state during linger */;
+
+		// Resolve after a tick (simulating setTimeout in real code)
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		// Still lingering — hasn't resolved yet
+		expect(document.body.innerHTML).toBe(
+			'<div><div class="toast hide">Message</div></div>',
+		) /* Toast should still be visible while waiting */;
+
+		cleanupResolve();
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<div></div>");
+	});
 });
-
-test.run();

--- a/test/copy-el.tsx
+++ b/test/copy-el.tsx
@@ -1,435 +1,435 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import * as Sinon from "sinon";
 
 import {Context, Copy, createElement, Element, Fragment} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("copy-el");
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+describe("copy-el", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test.after.each(() => {
-	document.body.innerHTML = "";
-	renderer.render(null, document.body);
-});
+	afterEach(() => {
+		document.body.innerHTML = "";
+		renderer.render(null, document.body);
+	});
 
-test("copy of nothing", () => {
-	renderer.render(<Copy />, document.body);
-	Assert.is(document.body.innerHTML, "");
-});
+	test("copy of nothing", () => {
+		renderer.render(<Copy />, document.body);
+		expect(document.body.innerHTML).toBe("");
+	});
 
-test("copy of nothing keyed", () => {
-	renderer.render(<Copy key="key" />, document.body);
-	Assert.is(document.body.innerHTML, "");
-});
+	test("copy of nothing keyed", () => {
+		renderer.render(<Copy key="key" />, document.body);
+		expect(document.body.innerHTML).toBe("");
+	});
 
-test("copy of nothing between elements", () => {
-	renderer.render(
-		<div>
-			<span>1</span>
-			<span>2</span>
-		</div>,
-		document.body,
-	);
+	test("copy of nothing between elements", () => {
+		renderer.render(
+			<div>
+				<span>1</span>
+				<span>2</span>
+			</div>,
+			document.body,
+		);
 
-	Assert.is(document.body.innerHTML, "<div><span>1</span><span>2</span></div>");
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span></div>",
+		);
 
-	renderer.render(
-		<div>
-			<span>1</span>
-			<Copy />
-			<span>2</span>
-		</div>,
-		document.body,
-	);
+		renderer.render(
+			<div>
+				<span>1</span>
+				<Copy />
+				<span>2</span>
+			</div>,
+			document.body,
+		);
 
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>2</span></div>",
-	);
-});
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>2</span></div>",
+		);
+	});
 
-test("copy of nothing keyed between elements", () => {
-	renderer.render(
-		<div>
-			<span>1</span>
-			<span>2</span>
-		</div>,
-		document.body,
-	);
+	test("copy of nothing keyed between elements", () => {
+		renderer.render(
+			<div>
+				<span>1</span>
+				<span>2</span>
+			</div>,
+			document.body,
+		);
 
-	Assert.is(document.body.innerHTML, "<div><span>1</span><span>2</span></div>");
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span></div>",
+		);
 
-	renderer.render(
-		<div>
-			<span>1</span>
-			<Copy key="key" />
-			<span>2</span>
-		</div>,
-		document.body,
-	);
+		renderer.render(
+			<div>
+				<span>1</span>
+				<Copy key="key" />
+				<span>2</span>
+			</div>,
+			document.body,
+		);
 
-	Assert.is(document.body.innerHTML, "<div><span>1</span><span>2</span></div>");
-});
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span></div>",
+		);
+	});
 
-test("elements replaced with copies", () => {
-	renderer.render(
-		<div>
-			<span>1</span>
-			<span>2</span>
-			<span>3</span>
-		</div>,
-		document.body,
-	);
+	test("elements replaced with copies", () => {
+		renderer.render(
+			<div>
+				<span>1</span>
+				<span>2</span>
+				<span>3</span>
+			</div>,
+			document.body,
+		);
 
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span></div>",
-	);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span></div>",
+		);
 
-	renderer.render(
-		<div>
-			<Copy />
-			<Copy />
-			<Copy />
-		</div>,
-		document.body,
-	);
+		renderer.render(
+			<div>
+				<Copy />
+				<Copy />
+				<Copy />
+			</div>,
+			document.body,
+		);
 
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span></div>",
-	);
-});
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span></div>",
+		);
+	});
 
-test("elements replaced with keyed copies", () => {
-	renderer.render(
-		<div>
-			<span>1</span>
-			<span>2</span>
-			<span>3</span>
-		</div>,
-		document.body,
-	);
+	test("elements replaced with keyed copies", () => {
+		renderer.render(
+			<div>
+				<span>1</span>
+				<span>2</span>
+				<span>3</span>
+			</div>,
+			document.body,
+		);
 
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span></div>",
-	);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span></div>",
+		);
 
-	renderer.render(
-		<div>
-			<Copy key="1" />
-			<Copy key="2" />
-			<Copy key="3" />
-		</div>,
-		document.body,
-	);
+		renderer.render(
+			<div>
+				<Copy key="1" />
+				<Copy key="2" />
+				<Copy key="3" />
+			</div>,
+			document.body,
+		);
 
-	Assert.is(document.body.innerHTML, "<div></div>");
-});
+		expect(document.body.innerHTML).toBe("<div></div>");
+	});
 
-test("copy intrinsic", () => {
-	renderer.render(<div>Hello</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello</div>");
-	renderer.render(<Copy />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello</div>");
-});
+	test("copy intrinsic", () => {
+		renderer.render(<div>Hello</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello</div>");
+		renderer.render(<Copy />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello</div>");
+	});
 
-test("copy component", () => {
-	function Component({message}: {message: string}): Element {
-		return <span>{message}</span>;
-	}
-
-	renderer.render(
-		<div>
-			<Component message="Hello" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	renderer.render(
-		<div>
-			<Copy />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-});
-
-test("copy array return value", () => {
-	function Component({copy}: {copy?: boolean}) {
-		if (copy) {
-			return <Copy />;
-		} else {
-			return [1, 2, 3];
+	test("copy component", () => {
+		function Component({message}: {message: string}): Element {
+			return <span>{message}</span>;
 		}
-	}
 
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "123");
-	renderer.render(<Component copy={true} />, document.body);
-	Assert.is(document.body.innerHTML, "123");
-});
+		renderer.render(
+			<div>
+				<Component message="Hello" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		renderer.render(
+			<div>
+				<Copy />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+	});
 
-test("copy children", () => {
-	let spans = [
-		<span key="2">2</span>,
-		<span key="3">3</span>,
-		<span key="4">4</span>,
-		<span key="5">5</span>,
-		<span key="6">6</span>,
-	];
-	renderer.render(
-		<div>
-			<span>1</span>
-			{spans}
-			<span>7</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span><span>7</span></div>",
-	);
-	const span1 = document.body.firstChild!.childNodes[0];
-	const span2 = document.body.firstChild!.childNodes[1];
-	const span3 = document.body.firstChild!.childNodes[2];
-	const span4 = document.body.firstChild!.childNodes[3];
-	const span5 = document.body.firstChild!.childNodes[4];
-	const span6 = document.body.firstChild!.childNodes[5];
-	const span7 = document.body.firstChild!.childNodes[6];
-	spans = spans.reverse().map((el) => <Copy key={el.props.key} />);
-	renderer.render(
-		<div>
-			<span>1</span>
-			{spans}
-			<span>7</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>6</span><span>5</span><span>4</span><span>3</span><span>2</span><span>7</span></div>",
-	);
-	renderer.render(
-		<div>
-			<span>1</span>
-			{spans}
-			<span>7</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.firstChild!.childNodes[0], span1);
-	Assert.is(document.body.firstChild!.childNodes[1], span6);
-	Assert.is(document.body.firstChild!.childNodes[2], span5);
-	Assert.is(document.body.firstChild!.childNodes[3], span4);
-	Assert.is(document.body.firstChild!.childNodes[4], span3);
-	Assert.is(document.body.firstChild!.childNodes[5], span2);
-	Assert.is(document.body.firstChild!.childNodes[6], span7);
-	spans = spans.reverse().map((el) => <Copy key={el.props.key} />);
-	renderer.render(
-		<div>
-			<span>1</span>
-			{spans}
-			<span>7</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.firstChild!.childNodes[0], span1);
-	Assert.is(document.body.firstChild!.childNodes[1], span2);
-	Assert.is(document.body.firstChild!.childNodes[2], span3);
-	Assert.is(document.body.firstChild!.childNodes[3], span4);
-	Assert.is(document.body.firstChild!.childNodes[4], span5);
-	Assert.is(document.body.firstChild!.childNodes[5], span6);
-	Assert.is(document.body.firstChild!.childNodes[6], span7);
-});
+	test("copy array return value", () => {
+		function Component({copy}: {copy?: boolean}) {
+			if (copy) {
+				return <Copy />;
+			} else {
+				return [1, 2, 3];
+			}
+		}
 
-test("copy async element", async () => {
-	async function Component() {
-		await new Promise((resolve) => setTimeout(resolve));
-		return <span>Hello</span>;
-	}
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("123");
+		renderer.render(<Component copy={true} />, document.body);
+		expect(document.body.innerHTML).toBe("123");
+	});
 
-	const p1 = renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	const p2 = renderer.render(<Copy />, document.body);
-	Assert.ok(p2 instanceof Promise);
-	Assert.is(await p1, await p2);
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-});
+	test("copy children", () => {
+		let spans = [
+			<span key="2">2</span>,
+			<span key="3">3</span>,
+			<span key="4">4</span>,
+			<span key="5">5</span>,
+			<span key="6">6</span>,
+		];
+		renderer.render(
+			<div>
+				<span>1</span>
+				{spans}
+				<span>7</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span><span>7</span></div>",
+		);
+		const span1 = document.body.firstChild!.childNodes[0];
+		const span2 = document.body.firstChild!.childNodes[1];
+		const span3 = document.body.firstChild!.childNodes[2];
+		const span4 = document.body.firstChild!.childNodes[3];
+		const span5 = document.body.firstChild!.childNodes[4];
+		const span6 = document.body.firstChild!.childNodes[5];
+		const span7 = document.body.firstChild!.childNodes[6];
+		spans = spans.reverse().map((el) => <Copy key={el.props.key} />);
+		renderer.render(
+			<div>
+				<span>1</span>
+				{spans}
+				<span>7</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>6</span><span>5</span><span>4</span><span>3</span><span>2</span><span>7</span></div>",
+		);
+		renderer.render(
+			<div>
+				<span>1</span>
+				{spans}
+				<span>7</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.firstChild!.childNodes[0]).toBe(span1);
+		expect(document.body.firstChild!.childNodes[1]).toBe(span6);
+		expect(document.body.firstChild!.childNodes[2]).toBe(span5);
+		expect(document.body.firstChild!.childNodes[3]).toBe(span4);
+		expect(document.body.firstChild!.childNodes[4]).toBe(span3);
+		expect(document.body.firstChild!.childNodes[5]).toBe(span2);
+		expect(document.body.firstChild!.childNodes[6]).toBe(span7);
+		spans = spans.reverse().map((el) => <Copy key={el.props.key} />);
+		renderer.render(
+			<div>
+				<span>1</span>
+				{spans}
+				<span>7</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.firstChild!.childNodes[0]).toBe(span1);
+		expect(document.body.firstChild!.childNodes[1]).toBe(span2);
+		expect(document.body.firstChild!.childNodes[2]).toBe(span3);
+		expect(document.body.firstChild!.childNodes[3]).toBe(span4);
+		expect(document.body.firstChild!.childNodes[4]).toBe(span5);
+		expect(document.body.firstChild!.childNodes[5]).toBe(span6);
+		expect(document.body.firstChild!.childNodes[6]).toBe(span7);
+	});
 
-test("copy async function", async () => {
-	async function Component() {
-		await new Promise((resolve) => setTimeout(resolve));
-		return <span>Hello</span>;
-	}
-
-	const p1 = renderer.render(<Component />, document.body);
-	const p2 = renderer.render(<Copy />, document.body);
-	Assert.ok(p2 instanceof Promise);
-	Assert.is(await p1, await p2);
-
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(document.body.innerHTML, "<span>Hello</span>");
-});
-
-test("copy async generator", async () => {
-	async function* Component(this: Context) {
-		for await (const _ of this) {
+	test("copy async element", async () => {
+		async function Component() {
 			await new Promise((resolve) => setTimeout(resolve));
-			yield <span>Hello</span>;
+			return <span>Hello</span>;
 		}
-	}
 
-	const p1 = renderer.render(<Component />, document.body);
-	const p2 = renderer.render(<Copy />, document.body);
-	Assert.ok(p2 instanceof Promise);
-	Assert.is(await p1, await p2);
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(document.body.innerHTML, "<span>Hello</span>");
-});
+		const p1 = renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		const p2 = renderer.render(<Copy />, document.body);
+		expect(p2 instanceof Promise).toBeTruthy();
+		expect(await p1).toBe(await p2);
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+	});
 
-test("copy async fragment", async () => {
-	async function Component() {
-		return <span>Hello</span>;
-	}
-
-	const p1 = renderer.render(
-		<Fragment>
-			<Component />
-		</Fragment>,
-		document.body,
-	);
-
-	const p2 = renderer.render(<Copy />, document.body);
-	Assert.ok(p2 instanceof Promise);
-	Assert.is(await p1, await p2);
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(document.body.innerHTML, "<span>Hello</span>");
-});
-
-// https://github.com/bikeshaving/crank/issues/196
-test("copy async generator siblings with refresh", async () => {
-	async function* Component(this: Context) {
-		let i = 0;
-		for await (const _ of this) {
+	test("copy async function", async () => {
+		async function Component() {
 			await new Promise((resolve) => setTimeout(resolve));
-			yield <span>{i}</span>;
-			i++;
+			return <span>Hello</span>;
 		}
-	}
 
-	let ctx!: Context;
-	function* Parent(this: Context) {
-		ctx = this;
-		let i = 1;
-		for (const _ of this) {
-			const children = Array.from({length: i}, (_, j) =>
-				i === j + 1 ? <Component /> : <Copy />,
-			);
+		const p1 = renderer.render(<Component />, document.body);
+		const p2 = renderer.render(<Copy />, document.body);
+		expect(p2 instanceof Promise).toBeTruthy();
+		expect(await p1).toBe(await p2);
 
-			yield <div>{children}</div>;
-			i++;
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe("<span>Hello</span>");
+	});
+
+	test("copy async generator", async () => {
+		async function* Component(this: Context) {
+			for await (const _ of this) {
+				await new Promise((resolve) => setTimeout(resolve));
+				yield <span>Hello</span>;
+			}
 		}
-	}
 
-	await renderer.render(<Parent />, document.body);
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	await ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div><span>0</span><span>0</span></div>");
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(document.body.innerHTML, "<div><span>0</span><span>0</span></div>");
-});
+		const p1 = renderer.render(<Component />, document.body);
+		const p2 = renderer.render(<Copy />, document.body);
+		expect(p2 instanceof Promise).toBeTruthy();
+		expect(await p1).toBe(await p2);
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe("<span>Hello</span>");
+	});
 
-test("identical elements", () => {
-	const fn = Sinon.fake();
-	function Component() {
-		fn();
-		return <span>Hello</span>;
-	}
-	const el = <Component />;
-	renderer.render(el, document.body);
-	Assert.is(document.body.innerHTML, "<span>Hello</span>");
-	renderer.render(el, document.body);
-	Assert.is(document.body.innerHTML, "<span>Hello</span>");
-	Assert.is(fn.callCount, 1);
-});
-
-test("identical elements passed as children", () => {
-	const fn = Sinon.fake();
-	function Child() {
-		fn();
-		return <span>Hello</span>;
-	}
-
-	let ctx!: Context;
-	function* Parent(this: Context, {children}: {children: Element}) {
-		ctx = this;
-		let i = 0;
-		for ({children} of this) {
-			yield (
-				<div>
-					{children}
-					{i}
-				</div>
-			);
-			i++;
+	test("copy async fragment", async () => {
+		async function Component() {
+			return <span>Hello</span>;
 		}
-	}
 
-	renderer.render(
-		<Parent>
-			<Child />
-		</Parent>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span>0</div>");
-	Assert.is(fn.callCount, 1);
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span>1</div>");
-	Assert.is(fn.callCount, 1);
+		const p1 = renderer.render(
+			<Fragment>
+				<Component />
+			</Fragment>,
+			document.body,
+		);
+
+		const p2 = renderer.render(<Copy />, document.body);
+		expect(p2 instanceof Promise).toBeTruthy();
+		expect(await p1).toBe(await p2);
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe("<span>Hello</span>");
+	});
+
+	// https://github.com/bikeshaving/crank/issues/196
+	test("copy async generator siblings with refresh", async () => {
+		async function* Component(this: Context) {
+			let i = 0;
+			for await (const _ of this) {
+				await new Promise((resolve) => setTimeout(resolve));
+				yield <span>{i}</span>;
+				i++;
+			}
+		}
+
+		let ctx!: Context;
+		function* Parent(this: Context) {
+			ctx = this;
+			let i = 1;
+			for (const _ of this) {
+				const children = Array.from({length: i}, (_, j) =>
+					i === j + 1 ? <Component /> : <Copy />,
+				);
+
+				yield <div>{children}</div>;
+				i++;
+			}
+		}
+
+		await renderer.render(<Parent />, document.body);
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		await ctx.refresh();
+		expect(document.body.innerHTML).toBe(
+			"<div><span>0</span><span>0</span></div>",
+		);
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe(
+			"<div><span>0</span><span>0</span></div>",
+		);
+	});
+
+	test("identical elements", () => {
+		const fn = Sinon.fake();
+		function Component() {
+			fn();
+			return <span>Hello</span>;
+		}
+		const el = <Component />;
+		renderer.render(el, document.body);
+		expect(document.body.innerHTML).toBe("<span>Hello</span>");
+		renderer.render(el, document.body);
+		expect(document.body.innerHTML).toBe("<span>Hello</span>");
+		expect(fn.callCount).toBe(1);
+	});
+
+	test("identical elements passed as children", () => {
+		const fn = Sinon.fake();
+		function Child() {
+			fn();
+			return <span>Hello</span>;
+		}
+
+		let ctx!: Context;
+		function* Parent(this: Context, {children}: {children: Element}) {
+			ctx = this;
+			let i = 0;
+			for ({children} of this) {
+				yield (
+					<div>
+						{children}
+						{i}
+					</div>
+				);
+				i++;
+			}
+		}
+
+		renderer.render(
+			<Parent>
+				<Child />
+			</Parent>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span>0</div>");
+		expect(fn.callCount).toBe(1);
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span>1</div>");
+		expect(fn.callCount).toBe(1);
+	});
+
+	test("copied element class name is not modified", () => {
+		const el = renderer.render(
+			<span class="test">Hello</span>,
+			document.body,
+		) as HTMLElement;
+		expect(document.body.innerHTML).toBe('<span class="test">Hello</span>');
+		el.className = "changed";
+		renderer.render(<Copy />, document.body);
+		expect(document.body.innerHTML).toBe('<span class="changed">Hello</span>');
+	});
+
+	test("copied element children are not modified", () => {
+		const el = renderer.render(
+			<span>
+				<span class="test">Hello</span>
+				<span class="test">World</span>
+			</span>,
+			document.body,
+		) as HTMLElement;
+
+		expect(document.body.innerHTML).toBe(
+			'<span><span class="test">Hello</span><span class="test">World</span></span>',
+		);
+
+		el.firstChild!.textContent = "Changed";
+		renderer.render(<Copy />, document.body);
+		expect(document.body.innerHTML).toBe(
+			'<span><span class="test">Changed</span><span class="test">World</span></span>',
+		);
+	});
 });
-
-test("copied element class name is not modified", () => {
-	const el = renderer.render(
-		<span class="test">Hello</span>,
-		document.body,
-	) as HTMLElement;
-	Assert.is(document.body.innerHTML, '<span class="test">Hello</span>');
-	el.className = "changed";
-	renderer.render(<Copy />, document.body);
-	Assert.is(document.body.innerHTML, '<span class="changed">Hello</span>');
-});
-
-test("copied element children are not modified", () => {
-	const el = renderer.render(
-		<span>
-			<span class="test">Hello</span>
-			<span class="test">World</span>
-		</span>,
-		document.body,
-	) as HTMLElement;
-
-	Assert.is(
-		document.body.innerHTML,
-		'<span><span class="test">Hello</span><span class="test">World</span></span>',
-	);
-
-	el.firstChild!.textContent = "Changed";
-	renderer.render(<Copy />, document.body);
-	Assert.is(
-		document.body.innerHTML,
-		'<span><span class="test">Changed</span><span class="test">World</span></span>',
-	);
-});
-
-test.run();

--- a/test/copy-prop.tsx
+++ b/test/copy-prop.tsx
@@ -1,535 +1,528 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import * as Sinon from "sinon";
 
 import {hangs} from "./utils.js";
 import {createElement, Context} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("copy-prop");
+describe("copy-prop", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+	test("host", () => {
+		renderer.render(<div copy={true}>Hello world</div>, document.body);
 
-test("host", () => {
-	renderer.render(<div copy={true}>Hello world</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello world</div>");
 
-	Assert.is(document.body.innerHTML, "<div>Hello world</div>");
+		renderer.render(
+			<div copy={true} style="background-color: red">
+				Hello again
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div>Hello world</div>");
 
-	renderer.render(
-		<div copy={true} style="background-color: red">
-			Hello again
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div>Hello world</div>");
+		renderer.render(
+			<div copy={false} style="background-color: blue">
+				Did you miss me?
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			'<div style="background-color: blue;">Did you miss me?</div>',
+		);
+	});
 
-	renderer.render(
-		<div copy={false} style="background-color: blue">
-			Did you miss me?
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		'<div style="background-color: blue;">Did you miss me?</div>',
-	);
-});
-
-test("component", () => {
-	function Greeting({name}: any) {
-		return <div>Hello {name}</div>;
-	}
-
-	renderer.render(<Greeting copy={true} name="world" />, document.body);
-
-	Assert.is(document.body.innerHTML, "<div>Hello world</div>");
-
-	renderer.render(<Greeting copy={true} name="Alice" />, document.body);
-
-	Assert.is(document.body.innerHTML, "<div>Hello world</div>");
-
-	renderer.render(<Greeting copy={false} name="Bob" />, document.body);
-
-	Assert.is(document.body.innerHTML, "<div>Hello Bob</div>");
-});
-
-test("component refresh", () => {
-	let ctx!: Context;
-	function Greeting(this: Context, {name}: any) {
-		ctx = this;
-		return <div>Hello {name}</div>;
-	}
-
-	renderer.render(<Greeting copy={true} name="world" />, document.body);
-
-	Assert.is(document.body.innerHTML, "<div>Hello world</div>");
-
-	renderer.render(<Greeting copy={true} name="Alice" />, document.body);
-
-	Assert.is(document.body.innerHTML, "<div>Hello world</div>");
-
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div>Hello Alice</div>");
-});
-
-test("async component", async () => {
-	async function Greeting({name}: any) {
-		await new Promise((resolve) => setTimeout(resolve));
-		return <div>Hello {name}</div>;
-	}
-
-	await renderer.render(<Greeting copy={true} name="world" />, document.body);
-
-	Assert.is(document.body.innerHTML, "<div>Hello world</div>");
-	const p1 = renderer.render(
-		<Greeting copy={true} name="Alice" />,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div>Hello world</div>");
-	await p1;
-	Assert.is(document.body.innerHTML, "<div>Hello world</div>");
-
-	const p2 = renderer.render(
-		<Greeting copy={false} name="Bob" />,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div>Hello world</div>");
-	await p2;
-	Assert.is(document.body.innerHTML, "<div>Hello Bob</div>");
-});
-
-test("async component refresh", async () => {
-	let ctx!: Context;
-	async function Greeting(this: Context, {name}: any) {
-		ctx = this;
-		await new Promise((resolve) => setTimeout(resolve));
-		return <div>Hello {name}</div>;
-	}
-
-	await renderer.render(<Greeting copy={true} name="world" />, document.body);
-
-	Assert.is(document.body.innerHTML, "<div>Hello world</div>");
-	const p1 = renderer.render(
-		<Greeting copy={true} name="Alice" />,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div>Hello world</div>");
-	await p1;
-	Assert.is(document.body.innerHTML, "<div>Hello world</div>");
-
-	const p2 = ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div>Hello world</div>");
-	await p2;
-	Assert.is(document.body.innerHTML, "<div>Hello Alice</div>");
-});
-
-test("inflight", async () => {
-	let resolve!: () => void;
-	async function Greeting(this: Context, {name}: any) {
-		await new Promise<void>((resolve1) => (resolve = resolve1));
-		return <div>Hello {name}</div>;
-	}
-
-	const p1 = renderer.render(<Greeting name="world" />, document.body);
-
-	const p2 = renderer.render(
-		<Greeting copy={true} name="Alice" />,
-		document.body,
-	);
-
-	await hangs(p1);
-	await hangs(p2);
-	resolve();
-	Assert.is(await p1, await p2);
-});
-
-test("generator component", async () => {
-	let ctx!: Context;
-	function* Greeting(this: Context, {name}: {name: string}) {
-		ctx = this;
-		let i = 0;
-		for ({name} of this) {
-			yield (
-				<div>
-					Hello {name} {i++}
-				</div>
-			);
+	test("component", () => {
+		function Greeting({name}: any) {
+			return <div>Hello {name}</div>;
 		}
-	}
 
-	renderer.render(<Greeting copy={true} name="world" />, document.body);
+		renderer.render(<Greeting copy={true} name="world" />, document.body);
 
-	Assert.is(document.body.innerHTML, "<div>Hello world 0</div>");
+		expect(document.body.innerHTML).toBe("<div>Hello world</div>");
 
-	renderer.render(<Greeting copy={true} name="Alice" />, document.body);
+		renderer.render(<Greeting copy={true} name="Alice" />, document.body);
 
-	Assert.is(document.body.innerHTML, "<div>Hello world 0</div>");
+		expect(document.body.innerHTML).toBe("<div>Hello world</div>");
 
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div>Hello Alice 1</div>");
-});
+		renderer.render(<Greeting copy={false} name="Bob" />, document.body);
 
-test("isolate higher-order component", () => {
-	function isolate(Component: any) {
-		return function Wrapper(props: any) {
-			return <Component {...props} copy={true} />;
-		};
-	}
+		expect(document.body.innerHTML).toBe("<div>Hello Bob</div>");
+	});
 
-	let ctx!: Context;
-	function* Greeting(this: Context, {name}: any) {
-		ctx = this;
-		let i = 0;
-		for ({name} of this) {
-			yield (
-				<div>
-					Hello {name} {i++}
-				</div>
-			);
+	test("component refresh", () => {
+		let ctx!: Context;
+		function Greeting(this: Context, {name}: any) {
+			ctx = this;
+			return <div>Hello {name}</div>;
 		}
-	}
 
-	const IsolatedGreeting = isolate(Greeting);
+		renderer.render(<Greeting copy={true} name="world" />, document.body);
 
-	renderer.render(<IsolatedGreeting name="world" />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello world 0</div>");
+		expect(document.body.innerHTML).toBe("<div>Hello world</div>");
 
-	renderer.render(<IsolatedGreeting name="Alice" />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello world 0</div>");
+		renderer.render(<Greeting copy={true} name="Alice" />, document.body);
 
-	renderer.render(<IsolatedGreeting name="Bob" />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello world 0</div>");
+		expect(document.body.innerHTML).toBe("<div>Hello world</div>");
 
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div>Hello Bob 1</div>");
-});
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div>Hello Alice</div>");
+	});
 
-test("tag change", () => {
-	renderer.render(<div copy={true}>Hello world</div>, document.body);
-	renderer.render(<span copy={true}>Hello world</span>, document.body);
-	Assert.is(document.body.innerHTML, "<span>Hello world</span>");
-});
-
-test("copy prop can include props", () => {
-	renderer.render(
-		<div
-			copy="style greeting"
-			style="color: red;"
-			class="greeting"
-			data-greeting={true}
-		>
-			Hello world
-		</div>,
-		document.body,
-	);
-
-	const div = document.querySelector("div") as HTMLDivElement;
-	Assert.is(div.className, "greeting");
-	Assert.is(div.style.color, "red");
-	Assert.is(div.dataset.greeting, "");
-	Assert.is(div.innerHTML, "Hello world");
-
-	renderer.render(
-		<div
-			copy="style data-greeting"
-			style="color: blue;"
-			class="second-greeting"
-			data-greeting={false}
-		>
-			Hello again
-		</div>,
-		document.body,
-	);
-
-	Assert.is(div.className, "second-greeting");
-	Assert.is(div.style.color, "red");
-	Assert.is(div.dataset.greeting, "");
-	Assert.is(div.innerHTML, "Hello again");
-
-	renderer.render(
-		<div copy="style children" class="third-greeting" data-greeting={false}>
-			Hello a third time
-		</div>,
-		document.body,
-	);
-
-	Assert.is(div.className, "third-greeting");
-	Assert.is(div.style.color, "red");
-	Assert.is(div.dataset.greeting, undefined);
-	Assert.is(div.innerHTML, "Hello again");
-
-	renderer.render(
-		<div class="fourth-greeting" style="color: yellow;" data-greeting={true}>
-			Hello a fourth time
-		</div>,
-		document.body,
-	);
-
-	Assert.is(div.className, "fourth-greeting");
-	Assert.is(div.style.color, "yellow");
-	Assert.is(div.dataset.greeting, "");
-	Assert.is(div.innerHTML, "Hello a fourth time");
-});
-
-test("copy prop can exclude props", () => {
-	renderer.render(
-		<div
-			copy="style greeting"
-			style="color: red;"
-			class="greeting"
-			data-greeting={true}
-		>
-			Hello world
-		</div>,
-		document.body,
-	);
-
-	const div = document.querySelector("div") as HTMLDivElement;
-	Assert.is(div.className, "greeting");
-	Assert.is(div.dataset.greeting, "");
-	Assert.is(div.style.color, "red");
-	Assert.is(div.innerHTML, "Hello world");
-
-	renderer.render(
-		<div
-			copy="!style !data-greeting"
-			style="color: blue;"
-			class="second-greeting"
-			data-greeting={false}
-		>
-			Hello again
-		</div>,
-		document.body,
-	);
-
-	Assert.is(div.className, "greeting");
-	Assert.is(div.style.color, "blue");
-	Assert.is(div.innerHTML, "Hello world");
-	Assert.is(div.dataset.greeting, undefined);
-	renderer.render(
-		<div
-			copy="!style !data-greeting"
-			class="second-greeting"
-			data-greeting={false}
-		>
-			Hello again
-		</div>,
-		document.body,
-	);
-
-	Assert.is(div.className, "greeting");
-	Assert.is(div.style.cssText, "");
-	Assert.is(div.innerHTML, "Hello world");
-	Assert.is(div.dataset.greeting, undefined);
-});
-
-test("copy can include and exclude props but never both", () => {
-	const consoleError = Sinon.stub(console, "error");
-	renderer.render(
-		<div
-			copy="style data-greeting"
-			style="color: red;"
-			class="greeting"
-			data-greeting={true}
-		>
-			Hello world
-		</div>,
-		document.body,
-	);
-
-	const div = document.querySelector("div") as HTMLDivElement;
-	Assert.is(div.className, "greeting");
-	Assert.is(div.dataset.greeting, "");
-	Assert.is(div.style.color, "red");
-	Assert.is(div.innerHTML, "Hello world");
-
-	renderer.render(
-		<div
-			copy="!style !data-greeting"
-			style="color: blue;"
-			class="second-greeting"
-			data-greeting={false}
-		>
-			Hello again
-		</div>,
-		document.body,
-	);
-
-	Assert.is(div.className, "greeting");
-	Assert.is(div.style.color, "blue");
-	Assert.is(div.innerHTML, "Hello world");
-	Assert.is(div.dataset.greeting, undefined);
-
-	renderer.render(
-		<div copy="!children" class="third-greeting" data-greeting={true}>
-			Hello a third time
-		</div>,
-		document.body,
-	);
-
-	Assert.is(div.className, "greeting");
-	Assert.is(div.style.color, "blue");
-	Assert.is(div.innerHTML, "Hello a third time");
-	Assert.is(div.dataset.greeting, undefined);
-
-	renderer.render(
-		<div
-			copy="!style data-greeting"
-			class="fourth-greeting"
-			data-greeting={false}
-		>
-			Hello a fourth time
-		</div>,
-		document.body,
-	);
-
-	Assert.is(consoleError.callCount, 1);
-	Assert.equal(
-		consoleError.firstCall.args[0],
-		'Invalid copy prop "!style data-greeting".\nUse prop or !prop but not both.',
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		'<div class="fourth-greeting">Hello a fourth time</div>',
-	);
-
-	consoleError.restore();
-});
-
-test("initial render with copy children", () => {
-	renderer.render(
-		<div copy="children" class="greeting">
-			Hello world
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, '<div class="greeting">Hello world</div>');
-
-	renderer.render(
-		<div copy="children" class="second-greeting">
-			Hello again
-		</div>,
-		document.body,
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		'<div class="second-greeting">Hello world</div>',
-	);
-
-	renderer.render(
-		<div copy={false} class="third-greeting">
-			Hello a third time
-		</div>,
-		document.body,
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		'<div class="third-greeting">Hello a third time</div>',
-	);
-});
-
-test("initial render with children excluded", () => {
-	renderer.render(
-		<div copy="!class" class="greeting">
-			Hello world
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, '<div class="greeting">Hello world</div>');
-
-	renderer.render(
-		<div copy="!class !children" class="second-greeting">
-			Hello again
-		</div>,
-		document.body,
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		'<div class="second-greeting">Hello again</div>',
-	);
-
-	renderer.render(
-		<div copy="class children" class="third-greeting">
-			Hello a third time
-		</div>,
-		document.body,
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		'<div class="second-greeting">Hello again</div>',
-	);
-});
-
-test("copy prop can be used for uncontrolled input values", () => {
-	const spy = Sinon.spy();
-	function* Component(this: Context<typeof Component>, {}: {}) {
-		let force = false;
-		let value = "Hello";
-		for ({} of this) {
-			yield (
-				<div>
-					<input
-						type="text"
-						copy={force ? false : "value"}
-						value={value}
-						oninput={(ev: InputEvent) => {
-							spy(ev);
-							value = (ev.target as HTMLInputElement).value;
-							this.refresh();
-						}}
-					/>
-					<button
-						onclick={() => {
-							force = true;
-							this.refresh();
-						}}
-					>
-						Click me
-					</button>
-				</div>
-			);
-
-			force = false;
+	test("async component", async () => {
+		async function Greeting({name}: any) {
+			await new Promise((resolve) => setTimeout(resolve));
+			return <div>Hello {name}</div>;
 		}
-	}
 
-	renderer.render(<Component />, document.body);
-	// The value attr is never set, so HTML won't reflect the value.
-	Assert.is(
-		document.body.innerHTML,
-		'<div><input type="text"><button>Click me</button></div>',
-	);
-	const input = document.querySelector("input") as HTMLInputElement;
-	Assert.is(input.value, "Hello");
+		await renderer.render(<Greeting copy={true} name="world" />, document.body);
 
-	// simulate input event
-	const toAdd = " world";
-	for (let i = 0; i < toAdd.length; i++) {
-		input.value = input.value + toAdd[i];
-		input.dispatchEvent(new Event("input"));
-		Assert.is(spy.callCount, i + 1);
-	}
+		expect(document.body.innerHTML).toBe("<div>Hello world</div>");
+		const p1 = renderer.render(
+			<Greeting copy={true} name="Alice" />,
+			document.body,
+		);
 
-	Assert.is(input.value, "Hello world");
-	Assert.is(spy.callCount, toAdd.length);
+		expect(document.body.innerHTML).toBe("<div>Hello world</div>");
+		await p1;
+		expect(document.body.innerHTML).toBe("<div>Hello world</div>");
+
+		const p2 = renderer.render(
+			<Greeting copy={false} name="Bob" />,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div>Hello world</div>");
+		await p2;
+		expect(document.body.innerHTML).toBe("<div>Hello Bob</div>");
+	});
+
+	test("async component refresh", async () => {
+		let ctx!: Context;
+		async function Greeting(this: Context, {name}: any) {
+			ctx = this;
+			await new Promise((resolve) => setTimeout(resolve));
+			return <div>Hello {name}</div>;
+		}
+
+		await renderer.render(<Greeting copy={true} name="world" />, document.body);
+
+		expect(document.body.innerHTML).toBe("<div>Hello world</div>");
+		const p1 = renderer.render(
+			<Greeting copy={true} name="Alice" />,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div>Hello world</div>");
+		await p1;
+		expect(document.body.innerHTML).toBe("<div>Hello world</div>");
+
+		const p2 = ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div>Hello world</div>");
+		await p2;
+		expect(document.body.innerHTML).toBe("<div>Hello Alice</div>");
+	});
+
+	test("inflight", async () => {
+		let resolve!: () => void;
+		async function Greeting(this: Context, {name}: any) {
+			await new Promise<void>((resolve1) => (resolve = resolve1));
+			return <div>Hello {name}</div>;
+		}
+
+		const p1 = renderer.render(<Greeting name="world" />, document.body);
+
+		const p2 = renderer.render(
+			<Greeting copy={true} name="Alice" />,
+			document.body,
+		);
+
+		await hangs(p1);
+		await hangs(p2);
+		resolve();
+		expect(await p1).toBe(await p2);
+	});
+
+	test("generator component", async () => {
+		let ctx!: Context;
+		function* Greeting(this: Context, {name}: {name: string}) {
+			ctx = this;
+			let i = 0;
+			for ({name} of this) {
+				yield (
+					<div>
+						Hello {name} {i++}
+					</div>
+				);
+			}
+		}
+
+		renderer.render(<Greeting copy={true} name="world" />, document.body);
+
+		expect(document.body.innerHTML).toBe("<div>Hello world 0</div>");
+
+		renderer.render(<Greeting copy={true} name="Alice" />, document.body);
+
+		expect(document.body.innerHTML).toBe("<div>Hello world 0</div>");
+
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div>Hello Alice 1</div>");
+	});
+
+	test("isolate higher-order component", () => {
+		function isolate(Component: any) {
+			return function Wrapper(props: any) {
+				return <Component {...props} copy={true} />;
+			};
+		}
+
+		let ctx!: Context;
+		function* Greeting(this: Context, {name}: any) {
+			ctx = this;
+			let i = 0;
+			for ({name} of this) {
+				yield (
+					<div>
+						Hello {name} {i++}
+					</div>
+				);
+			}
+		}
+
+		const IsolatedGreeting = isolate(Greeting);
+
+		renderer.render(<IsolatedGreeting name="world" />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello world 0</div>");
+
+		renderer.render(<IsolatedGreeting name="Alice" />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello world 0</div>");
+
+		renderer.render(<IsolatedGreeting name="Bob" />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello world 0</div>");
+
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div>Hello Bob 1</div>");
+	});
+
+	test("tag change", () => {
+		renderer.render(<div copy={true}>Hello world</div>, document.body);
+		renderer.render(<span copy={true}>Hello world</span>, document.body);
+		expect(document.body.innerHTML).toBe("<span>Hello world</span>");
+	});
+
+	test("copy prop can include props", () => {
+		renderer.render(
+			<div
+				copy="style greeting"
+				style="color: red;"
+				class="greeting"
+				data-greeting={true}
+			>
+				Hello world
+			</div>,
+			document.body,
+		);
+
+		const div = document.querySelector("div") as HTMLDivElement;
+		expect(div.className).toBe("greeting");
+		expect(div.style.color).toBe("red");
+		expect(div.dataset.greeting).toBe("");
+		expect(div.innerHTML).toBe("Hello world");
+
+		renderer.render(
+			<div
+				copy="style data-greeting"
+				style="color: blue;"
+				class="second-greeting"
+				data-greeting={false}
+			>
+				Hello again
+			</div>,
+			document.body,
+		);
+
+		expect(div.className).toBe("second-greeting");
+		expect(div.style.color).toBe("red");
+		expect(div.dataset.greeting).toBe("");
+		expect(div.innerHTML).toBe("Hello again");
+
+		renderer.render(
+			<div copy="style children" class="third-greeting" data-greeting={false}>
+				Hello a third time
+			</div>,
+			document.body,
+		);
+
+		expect(div.className).toBe("third-greeting");
+		expect(div.style.color).toBe("red");
+		expect(div.dataset.greeting).toBe(undefined);
+		expect(div.innerHTML).toBe("Hello again");
+
+		renderer.render(
+			<div class="fourth-greeting" style="color: yellow;" data-greeting={true}>
+				Hello a fourth time
+			</div>,
+			document.body,
+		);
+
+		expect(div.className).toBe("fourth-greeting");
+		expect(div.style.color).toBe("yellow");
+		expect(div.dataset.greeting).toBe("");
+		expect(div.innerHTML).toBe("Hello a fourth time");
+	});
+
+	test("copy prop can exclude props", () => {
+		renderer.render(
+			<div
+				copy="style greeting"
+				style="color: red;"
+				class="greeting"
+				data-greeting={true}
+			>
+				Hello world
+			</div>,
+			document.body,
+		);
+
+		const div = document.querySelector("div") as HTMLDivElement;
+		expect(div.className).toBe("greeting");
+		expect(div.dataset.greeting).toBe("");
+		expect(div.style.color).toBe("red");
+		expect(div.innerHTML).toBe("Hello world");
+
+		renderer.render(
+			<div
+				copy="!style !data-greeting"
+				style="color: blue;"
+				class="second-greeting"
+				data-greeting={false}
+			>
+				Hello again
+			</div>,
+			document.body,
+		);
+
+		expect(div.className).toBe("greeting");
+		expect(div.style.color).toBe("blue");
+		expect(div.innerHTML).toBe("Hello world");
+		expect(div.dataset.greeting).toBe(undefined);
+		renderer.render(
+			<div
+				copy="!style !data-greeting"
+				class="second-greeting"
+				data-greeting={false}
+			>
+				Hello again
+			</div>,
+			document.body,
+		);
+
+		expect(div.className).toBe("greeting");
+		expect(div.style.cssText).toBe("");
+		expect(div.innerHTML).toBe("Hello world");
+		expect(div.dataset.greeting).toBe(undefined);
+	});
+
+	test("copy can include and exclude props but never both", () => {
+		const consoleError = Sinon.stub(console, "error");
+		renderer.render(
+			<div
+				copy="style data-greeting"
+				style="color: red;"
+				class="greeting"
+				data-greeting={true}
+			>
+				Hello world
+			</div>,
+			document.body,
+		);
+
+		const div = document.querySelector("div") as HTMLDivElement;
+		expect(div.className).toBe("greeting");
+		expect(div.dataset.greeting).toBe("");
+		expect(div.style.color).toBe("red");
+		expect(div.innerHTML).toBe("Hello world");
+
+		renderer.render(
+			<div
+				copy="!style !data-greeting"
+				style="color: blue;"
+				class="second-greeting"
+				data-greeting={false}
+			>
+				Hello again
+			</div>,
+			document.body,
+		);
+
+		expect(div.className).toBe("greeting");
+		expect(div.style.color).toBe("blue");
+		expect(div.innerHTML).toBe("Hello world");
+		expect(div.dataset.greeting).toBe(undefined);
+
+		renderer.render(
+			<div copy="!children" class="third-greeting" data-greeting={true}>
+				Hello a third time
+			</div>,
+			document.body,
+		);
+
+		expect(div.className).toBe("greeting");
+		expect(div.style.color).toBe("blue");
+		expect(div.innerHTML).toBe("Hello a third time");
+		expect(div.dataset.greeting).toBe(undefined);
+
+		renderer.render(
+			<div
+				copy="!style data-greeting"
+				class="fourth-greeting"
+				data-greeting={false}
+			>
+				Hello a fourth time
+			</div>,
+			document.body,
+		);
+
+		expect(consoleError.callCount).toBe(1);
+		expect(consoleError.firstCall.args[0]).toEqual(
+			'Invalid copy prop "!style data-greeting".\nUse prop or !prop but not both.',
+		);
+
+		expect(document.body.innerHTML).toBe(
+			'<div class="fourth-greeting">Hello a fourth time</div>',
+		);
+
+		consoleError.restore();
+	});
+
+	test("initial render with copy children", () => {
+		renderer.render(
+			<div copy="children" class="greeting">
+				Hello world
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			'<div class="greeting">Hello world</div>',
+		);
+
+		renderer.render(
+			<div copy="children" class="second-greeting">
+				Hello again
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			'<div class="second-greeting">Hello world</div>',
+		);
+
+		renderer.render(
+			<div copy={false} class="third-greeting">
+				Hello a third time
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			'<div class="third-greeting">Hello a third time</div>',
+		);
+	});
+
+	test("initial render with children excluded", () => {
+		renderer.render(
+			<div copy="!class" class="greeting">
+				Hello world
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			'<div class="greeting">Hello world</div>',
+		);
+
+		renderer.render(
+			<div copy="!class !children" class="second-greeting">
+				Hello again
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			'<div class="second-greeting">Hello again</div>',
+		);
+
+		renderer.render(
+			<div copy="class children" class="third-greeting">
+				Hello a third time
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			'<div class="second-greeting">Hello again</div>',
+		);
+	});
+
+	test("copy prop can be used for uncontrolled input values", () => {
+		const spy = Sinon.spy();
+		function* Component(this: Context<typeof Component>, {}: {}) {
+			let force = false;
+			let value = "Hello";
+			for ({} of this) {
+				yield (
+					<div>
+						<input
+							type="text"
+							copy={force ? false : "value"}
+							value={value}
+							oninput={(ev: InputEvent) => {
+								spy(ev);
+								value = (ev.target as HTMLInputElement).value;
+								this.refresh();
+							}}
+						/>
+						<button
+							onclick={() => {
+								force = true;
+								this.refresh();
+							}}
+						>
+							Click me
+						</button>
+					</div>
+				);
+
+				force = false;
+			}
+		}
+
+		renderer.render(<Component />, document.body);
+		// The value attr is never set, so HTML won't reflect the value.
+		expect(document.body.innerHTML).toBe(
+			'<div><input type="text"><button>Click me</button></div>',
+		);
+		const input = document.querySelector("input") as HTMLInputElement;
+		expect(input.value).toBe("Hello");
+
+		// simulate input event
+		const toAdd = " world";
+		for (let i = 0; i < toAdd.length; i++) {
+			input.value = input.value + toAdd[i];
+			input.dispatchEvent(new Event("input"));
+			expect(spy.callCount).toBe(i + 1);
+		}
+
+		expect(input.value).toBe("Hello world");
+		expect(spy.callCount).toBe(toAdd.length);
+	});
 });
-
-test.run();

--- a/test/create-element.tsx
+++ b/test/create-element.tsx
@@ -1,37 +1,34 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, expect} from "@b9g/libuild/test";
 import {createElement} from "../src/crank.js";
 
-const test = suite("createElement");
+describe("createElement", () => {
+	test("does not mutate the caller's props when adding a child", () => {
+		const props = {id: "x"};
+		const el = createElement("div", props, "child");
+		expect(props).toEqual({id: "x"});
+		expect("children" in props).toBe(false);
+		expect((el.props as any).children).toBe("child");
+	});
 
-test("does not mutate the caller's props when adding a child", () => {
-	const props = {id: "x"};
-	const el = createElement("div", props, "child");
-	Assert.equal(props, {id: "x"});
-	Assert.is("children" in props, false);
-	Assert.is((el.props as any).children, "child");
+	test("does not mutate the caller's props with multiple children", () => {
+		const props = {id: "x"};
+		const el = createElement("div", props, "a", "b");
+		expect(props).toEqual({id: "x"});
+		expect((el.props as any).children).toEqual(["a", "b"]);
+	});
+
+	test("a reused props object yields independent elements (#356)", () => {
+		const props = {class: "shared"};
+		const a = createElement("div", props, "a");
+		const b = createElement("div", props, "b");
+		expect((a.props as any).children).toBe("a");
+		expect((b.props as any).children).toBe("b");
+		expect("children" in props).toBe(false);
+	});
+
+	test("passes props through when there are no children", () => {
+		const props = {id: "x"};
+		const el = createElement("div", props);
+		expect(el.props).toEqual({id: "x"});
+	});
 });
-
-test("does not mutate the caller's props with multiple children", () => {
-	const props = {id: "x"};
-	const el = createElement("div", props, "a", "b");
-	Assert.equal(props, {id: "x"});
-	Assert.equal((el.props as any).children, ["a", "b"]);
-});
-
-test("a reused props object yields independent elements (#356)", () => {
-	const props = {class: "shared"};
-	const a = createElement("div", props, "a");
-	const b = createElement("div", props, "b");
-	Assert.is((a.props as any).children, "a");
-	Assert.is((b.props as any).children, "b");
-	Assert.is("children" in props, false);
-});
-
-test("passes props through when there are no children", () => {
-	const props = {id: "x"};
-	const el = createElement("div", props);
-	Assert.equal(el.props, {id: "x"});
-});
-
-test.run();

--- a/test/dom.tsx
+++ b/test/dom.tsx
@@ -1,1726 +1,1412 @@
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 /// <ref lib="dom" />
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
 import {Copy, createElement, Fragment, Raw} from "../src/crank.js";
 import type {Context} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("dom");
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
-
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
-
-test("simple", () => {
-	renderer.render(<h1>Hello world</h1>, document.body);
-	Assert.is(document.body.innerHTML, "<h1>Hello world</h1>");
-});
-
-test("multiple children", () => {
-	renderer.render(
-		<div>
-			<span>1</span>
-			<span>2</span>
-			<span>3</span>
-			<span>4</span>
-		</div>,
-		document.body,
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span></div>",
-	);
-});
-
-test("nested children", () => {
-	renderer.render(
-		<div id="1">
-			<div id="2">
-				<div id="3">Hi</div>
-			</div>
-		</div>,
-		document.body,
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		'<div id="1"><div id="2"><div id="3">Hi</div></div></div>',
-	);
-
-	const div1 = document.getElementById("1")!;
-	renderer.render(<div id="1" />, document.body);
-	Assert.is(document.body.innerHTML, '<div id="1"></div>');
-	Assert.is(document.body.firstChild, div1);
-});
-
-test("boolean replaces nested children", () => {
-	renderer.render(
-		<div id="1">
-			<div id="2">
-				<div id="3">Hi</div>
-			</div>
-		</div>,
-		document.body,
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		'<div id="1"><div id="2"><div id="3">Hi</div></div></div>',
-	);
-
-	const div1 = document.getElementById("1")!;
-	const div2 = document.getElementById("2")!;
-	renderer.render(
-		<div id="1">
-			<div id="2">{true}</div>
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, '<div id="1"><div id="2"></div></div>');
-	Assert.is(document.body.firstChild, div1);
-	Assert.is(document.body.firstChild!.firstChild, div2);
-});
-
-test("attrs", () => {
-	renderer.render(
-		<Fragment>
-			<input id="toggle" type="checkbox" checked={true} data-checked={true} />
-			<label for="toggle" />
-		</Fragment>,
-		document.body,
-	);
-	// this expectation is based on non-standard jsdom innerHTML behavior jsdom doesn‘t seem to reflect checked property
-	Assert.is(
-		document.body.innerHTML,
-		'<input id="toggle" type="checkbox" data-checked=""><label for="toggle"></label>',
-	);
-	Assert.is((document.body.firstChild! as any).checked, true);
-	renderer.render(
-		<Fragment>
-			<input id="toggle" type="checkbox" checked={false} data-checked={false} />
-			<label for="toggle" class="inactive" />
-		</Fragment>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		'<input id="toggle" type="checkbox"><label for="toggle" class="inactive"></label>',
-	);
-	Assert.is((document.body.firstChild! as any).checked, false);
-});
-
-test("doesn’t blow away user-created html when it doesn’t have to", () => {
-	renderer.render(<div id="mount" />, document.body);
-	Assert.is(document.body.innerHTML, '<div id="mount"></div>');
-	document.getElementById("mount")!.innerHTML = "<span>Hello world</span>";
-	Assert.is(
-		document.body.innerHTML,
-		'<div id="mount"><span>Hello world</span></div>',
-	);
-	renderer.render(<div id="mount" />, document.body);
-	Assert.is(
-		document.body.innerHTML,
-		'<div id="mount"><span>Hello world</span></div>',
-	);
-});
-
-test("rerender text", () => {
-	renderer.render(<h1>Hello world 1</h1>, document.body);
-	Assert.is(document.body.innerHTML, "<h1>Hello world 1</h1>");
-	const h1 = document.body.firstChild!;
-	Assert.is(h1.childNodes.length, 1);
-	const text = h1.firstChild!;
-	renderer.render(<h1>Hello {"world"} 2</h1>, document.body);
-	Assert.is(document.body.innerHTML, "<h1>Hello world 2</h1>");
-	Assert.is(document.body.firstChild!, h1);
-	Assert.is(h1.childNodes.length, 3);
-	Assert.is(document.body.firstChild!.childNodes[0] as Text, text);
-	Assert.is((document.body.firstChild!.childNodes[0] as Text).data, "Hello ");
-	Assert.is((document.body.firstChild!.childNodes[1] as Text).data, "world");
-	Assert.is((document.body.firstChild!.childNodes[2] as Text).data, " 2");
-	const text1 = document.body.firstChild!.childNodes[1] as Text;
-	const text2 = document.body.firstChild!.childNodes[2] as Text;
-	renderer.render(<h1>Hello world {3}</h1>, document.body);
-	Assert.is(document.body.innerHTML, "<h1>Hello world 3</h1>");
-	Assert.is(document.body.firstChild!, h1);
-	Assert.is(h1.childNodes.length, 2);
-	Assert.is(document.body.firstChild!.childNodes[0] as Text, text);
-	Assert.is(document.body.firstChild!.childNodes[1] as Text, text1);
-	Assert.is(text2.parentNode, null);
-});
-
-test("rerender different child", () => {
-	renderer.render(
-		<div>
-			<h1>Hello world</h1>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><h1>Hello world</h1></div>");
-	const div = document.body.firstChild!;
-	renderer.render(
-		<div>
-			<h2>Hello world</h2>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><h2>Hello world</h2></div>");
-	Assert.is(document.body.firstChild!, div);
-});
-
-test("rerender text with children", () => {
-	renderer.render(<div>Hello world</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello world</div>");
-	const div = document.body.firstChild!;
-	renderer.render(
-		<div>
-			<span>1</span>
-			<span>2</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>1</span><span>2</span></div>");
-	Assert.is(document.body.firstChild!, div);
-});
-
-test("rerender children with text", () => {
-	renderer.render(
-		<div>
-			<span>1</span>
-			<span>2</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>1</span><span>2</span></div>");
-	const div = document.body.firstChild!;
-	renderer.render(<div>Hello world</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello world</div>");
-	Assert.is(document.body.firstChild!, div);
-});
-
-test("rerender more children", () => {
-	renderer.render(
-		<div>
-			<span>1</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	const div = document.body.firstChild!;
-	const span = div.firstChild!;
-	renderer.render(
-		<div>
-			<span>1</span>
-			<span>2</span>
-			<span>3</span>
-			<span>4</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span></div>",
-	);
-	Assert.is(document.body.firstChild!, div);
-	Assert.is(document.body.firstChild!.firstChild, span);
-});
-
-test("rerender fewer children", () => {
-	renderer.render(
-		<div>
-			<span>1</span>
-			<span>2</span>
-			<span>3</span>
-			<span>4</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span></div>",
-	);
-	const div = document.body.firstChild!;
-	const span = div.firstChild!;
-	renderer.render(
-		<div>
-			<span>1</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	Assert.is(document.body.firstChild!, div);
-	Assert.is(document.body.firstChild!.firstChild, span);
-});
-
-test("null and undefined", () => {
-	renderer.render(<h1>Hello world</h1>, document.body);
-	Assert.is(document.body.innerHTML, "<h1>Hello world</h1>");
-	renderer.render(null, document.body);
-	Assert.is(document.body.innerHTML, "");
-	renderer.render(<h1>Hello again</h1>, document.body);
-	Assert.is(document.body.innerHTML, "<h1>Hello again</h1>");
-	renderer.render(undefined, document.body);
-	Assert.is(document.body.innerHTML, "");
-});
-
-test("fragment", () => {
-	renderer.render(
-		<Fragment>
-			<span>1</span>
-			<span>2</span>
-		</Fragment>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<span>1</span><span>2</span>");
-	const span1 = document.body.childNodes[0];
-	const span2 = document.body.childNodes[1];
-	renderer.render(
-		<Fragment>
-			<span>1</span>
-			<span>2</span>
-			<span>3</span>
-		</Fragment>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<span>1</span><span>2</span><span>3</span>",
-	);
-	Assert.is(document.body.childNodes[0], span1);
-	Assert.is(document.body.childNodes[1], span2);
-});
-
-test("fragment with null and undefined", () => {
-	renderer.render(
-		<Fragment>
-			{null}
-			{undefined}
-		</Fragment>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "");
-	renderer.render(
-		<Fragment>
-			<span>1</span>
-			<span>2</span>
-		</Fragment>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<span>1</span><span>2</span>");
-});
-
-test("iterable", () => {
-	renderer.render(["1", 2, <div>3</div>], document.body);
-	Assert.is(document.body.innerHTML, "12<div>3</div>");
-	renderer.render(null, document.body);
-	Assert.is(document.body.innerHTML, "");
-});
-
-test("array", () => {
-	renderer.render(
-		<div>
-			<span>1</span>
-			{[<span>2</span>, <span>3</span>]}
-			<span>4</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span></div>",
-	);
-	const span1 = document.body.firstChild!.childNodes[0];
-	const span4 = document.body.firstChild!.childNodes[3];
-	renderer.render(
-		<div>
-			<span>1</span>
-			{[]}
-			<span>4</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>1</span><span>4</span></div>");
-	Assert.is(document.body.firstChild!.childNodes[0], span1);
-	Assert.is(document.body.firstChild!.childNodes[1], span4);
-});
-
-test("nested arrays", () => {
-	renderer.render(
-		<div>
-			<span>1</span>
-			{[<span>2</span>, [<span>3</span>, <span>4</span>], <span>5</span>]}
-			<span>6</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></div>",
-	);
-	const span1 = document.body.firstChild!.childNodes[0];
-	const span2 = document.body.firstChild!.childNodes[1];
-	const span3 = document.body.firstChild!.childNodes[2];
-	const span6 = document.body.firstChild!.childNodes[5];
-	renderer.render(
-		<div>
-			<span>1</span>
-			{[<span>2</span>, [<span>4</span>]]}
-			<span>6</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>4</span><span>6</span></div>",
-	);
-	Assert.is(document.body.firstChild!.childNodes[0], span1);
-	Assert.is(document.body.firstChild!.childNodes[1], span2);
-	Assert.is(document.body.firstChild!.childNodes[2], span3);
-	Assert.is(document.body.firstChild!.childNodes[3], span6);
-});
-
-test("raw html", () => {
-	const html = '<span id="raw">Hi</span>';
-	renderer.render(
-		<div>
-			Raw: <Raw value={html} />
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		'<div>Raw: <span id="raw">Hi</span></div>',
-	);
-	Assert.ok(document.getElementById("raw"));
-});
-
-test("raw svg", () => {
-	const html = '<circle cx="5" cy="5" r="5" />';
-	renderer.render(
-		<svg>
-			Raw: <Raw value={html} />
-		</svg>,
-		document.body,
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		'<svg>Raw: <circle cx="5" cy="5" r="5"></circle></svg>',
-	);
-
-	Assert.ok(
-		document.body.firstChild!.childNodes[1] instanceof SVGCircleElement,
-	);
-});
-
-test("raw node", () => {
-	var template = document.createElement("template");
-	template.innerHTML = '<span id="raw">Hi</span>';
-	const span = template.content.firstChild!;
-	renderer.render(
-		<div>
-			Raw: <Raw value={span} />
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		'<div>Raw: <span id="raw">Hi</span></div>',
-	);
-	Assert.ok(document.getElementById("raw"));
-});
-
-test("raw changes", () => {
-	let html = '<span id="raw">Hi</span>';
-	renderer.render(
-		<div>
-			Raw: <Raw value={html} />
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		'<div>Raw: <span id="raw">Hi</span></div>',
-	);
-
-	html = "RAWRAWRAW<div>Raw</div>RAWRAWRAW";
-	renderer.render(
-		<div>
-			Raw: <Raw value={html} />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		"<div>Raw: RAWRAWRAW<div>Raw</div>RAWRAWRAW</div>",
-	);
-});
-
-test("style text", () => {
-	renderer.render(<div style="display: none" />, document.body);
-	Assert.is(document.body.innerHTML, '<div style="display: none;"></div>');
-	Assert.is((document.body.firstChild as HTMLElement).style.display, "none");
-});
-
-test("style object", () => {
-	renderer.render(
-		<div style={{display: "none", "margin-top": "30px"}} />,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		'<div style="display: none; margin-top: 30px;"></div>',
-	);
-	Assert.is((document.body.firstChild as HTMLElement).style.display, "none");
-	Assert.is((document.body.firstChild as HTMLElement).style.marginTop, "30px");
-});
-
-test("style text to object", () => {
-	renderer.render(<div style="font-weight: bold" />, document.body);
-
-	Assert.is(document.body.innerHTML, '<div style="font-weight: bold;"></div>');
-
-	renderer.render(<div style={{color: "goldenrod"}} />, document.body);
-
-	Assert.is(document.body.innerHTML, '<div style="color: goldenrod;"></div>');
-});
-
-test("outside DOM mutations", () => {
-	renderer.render(<div />, document.body);
-
-	const div = document.body.firstChild as HTMLDivElement;
-	div.innerHTML = "<span>child</span>";
-	renderer.render(<div />, document.body);
-
-	Assert.is(document.body.innerHTML, "<div><span>child</span></div>");
-	renderer.render(<div>{[]}</div>, document.body);
-
-	Assert.is(document.body.innerHTML, "<div><span>child</span></div>");
-	div.innerHTML = "<span>child</span>";
-	renderer.render(<div>{null}</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div><span>child</span></div>");
-});
-
-test("unknown attribute", () => {
-	renderer.render(
-		<div
-			unknown="value"
-			unknown-attribute="value"
-			data-unknown-attribute="value"
-		/>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		'<div unknown="value" unknown-attribute="value" data-unknown-attribute="value"></div>',
-	);
-
-	const div = document.body.firstChild as HTMLDivElement;
-	Assert.is(div.getAttribute("unknown"), "value");
-	Assert.is(div.getAttribute("unknown-attribute"), "value");
-	Assert.is(div.getAttribute("data-unknown-attribute"), "value");
-});
-
-test("removing props", () => {
-	const input = renderer.render(
-		<input dir="rtl" autofocus={true} value="hello" />,
-		document.body,
-	) as any;
-
-	Assert.is(input.dir, "rtl");
-	Assert.is(input.autofocus, true);
-	renderer.render(<input />, document.body);
-	Assert.is(input.dir, "");
-	Assert.is(input.autofocus, false);
-});
-
-test("removing styles", () => {
-	const div = renderer.render(
-		<div style={{color: "red", "background-color": "blue"}} />,
-		document.body,
-	) as any;
-
-	Assert.is(div.style.color, "red");
-	Assert.is(div.style.backgroundColor, "blue");
-	renderer.render(<div style={{color: "red"}} />, document.body) as any;
-	Assert.is(div.style.color, "red");
-	Assert.is(div.style.backgroundColor, "");
-});
-
-test("style object camelCase", () => {
-	renderer.render(
-		<div
-			style={{
-				fontSize: "16px",
-				backgroundColor: "red",
-				marginTop: "10px",
-				borderRadius: "4px",
-				WebkitTransform: "rotate(45deg)",
-			}}
-		/>,
-		document.body,
-	);
-
-	// Check HTML output has kebab-case properties
-	// Note: Browser normalizes -webkit-transform to transform in innerHTML
-	const expectedHTML =
-		'<div style="font-size: 16px; background-color: red; margin-top: 10px; border-radius: 4px; transform: rotate(45deg);"></div>';
-	Assert.is(document.body.innerHTML, expectedHTML);
-
-	// Check DOM element properties are accessible via camelCase
-	const div = document.body.firstChild as HTMLElement;
-	Assert.is(div.style.fontSize, "16px");
-	Assert.is(div.style.backgroundColor, "red");
-	Assert.is(div.style.marginTop, "10px");
-	Assert.is(div.style.borderRadius, "4px");
-	// Browser normalizes WebkitTransform to transform
-	Assert.is(div.style.transform, "rotate(45deg)");
-});
-
-test("style object numeric values with px conversion", () => {
-	renderer.render(
-		<div
-			style={{width: 100, height: 200, opacity: 0.5, zIndex: 10, fontSize: 16}}
-		/>,
-		document.body,
-	);
-
-	// Check HTML output - numeric values should have px added except for unitless properties
-	const expectedHTML =
-		'<div style="width: 100px; height: 200px; opacity: 0.5; z-index: 10; font-size: 16px;"></div>';
-	Assert.is(document.body.innerHTML, expectedHTML);
-
-	// Check DOM element properties
-	const div = document.body.firstChild as HTMLElement;
-	Assert.is(div.style.width, "100px");
-	Assert.is(div.style.height, "200px");
-	Assert.is(div.style.opacity, "0.5");
-	Assert.is(div.style.zIndex, "10");
-	Assert.is(div.style.fontSize, "16px");
-});
-
-test("uncontrolled props", () => {
-	const input = renderer.render(<input value="hello" />, document.body) as any;
-	Assert.ok(input instanceof HTMLInputElement);
-	Assert.is(input.value, "hello");
-	input.value = "world";
-	Assert.is(input.value, "world");
-	renderer.render(<input value={Copy} />, document.body);
-});
-
-test("default props", () => {
-	renderer.render(
-		<Fragment>
-			<input />
-			<input type="text" />
-		</Fragment>,
-		document.body,
-	);
-	Assert.equal(document.querySelectorAll("input").length, 2);
-	Assert.equal(document.querySelectorAll('input[type="text"]').length, 1);
-});
-
-test("set/unset default props", () => {
-	// Attribute should be set on initial render.
-	renderer.render(<input type="text" />, document.body);
-	Assert.equal(document.querySelectorAll('input[type="text"]').length, 1);
-
-	// Remove attribute.
-	renderer.render(<input />, document.body);
-	Assert.equal(document.querySelectorAll('input[type="text"]').length, 0);
-
-	// Attribute should also be set on subsequent renders if it was previously missing.
-	renderer.render(<input type="text" />, document.body);
-	Assert.equal(document.querySelectorAll('input[type="text"]').length, 1);
-});
-
-test("prop: prefix forces prop", () => {
-	let el: any;
-	renderer.render(
-		<custom-el prop:prop="value" ref={(el1: any) => (el = el1)} />,
-		document.body,
-	);
-	Assert.is(el.prop, "value");
-});
-
-test("attr: prefix forces attribute", () => {
-	let el: any;
-	renderer.render(<custom-el ref={(el1: any) => (el = el1)} />, document.body);
-	el.attr = "value";
-	renderer.render(<custom-el attr:attr="other" />, document.body);
-	Assert.is(el.getAttribute("attr"), "other");
-	Assert.is(el.attr, "value");
-});
-
-test("attr: prefix removes attribute when null", () => {
-	renderer.render(<div attr:data-x="hello" />, document.body);
-	const div = document.body.firstChild as HTMLElement;
-	Assert.is(div.getAttribute("data-x"), "hello");
-
-	renderer.render(<div attr:data-x={null} />, document.body);
-	Assert.is(div.getAttribute("data-x"), null);
-});
-
-test("attr: prefix removes attribute when false", () => {
-	renderer.render(<div attr:data-x="hello" />, document.body);
-	const div = document.body.firstChild as HTMLElement;
-	Assert.is(div.getAttribute("data-x"), "hello");
-
-	renderer.render(<div attr:data-x={false} />, document.body);
-	Assert.is(div.getAttribute("data-x"), null);
-});
-
-test("attr: prefix sets empty string when true", () => {
-	renderer.render(<div attr:data-x={true} />, document.body);
-	const div = document.body.firstChild as HTMLElement;
-	Assert.is(div.getAttribute("data-x"), "");
-});
-
-test("object classnames basic", () => {
-	renderer.render(
-		<div
-			class={{
-				active: true,
-				disabled: false,
-				primary: true,
-			}}
-		>
-			Test
-		</div>,
-		document.body,
-	);
-
-	const element = document.querySelector("div")!;
-	Assert.ok(element.classList.contains("active"));
-	Assert.not.ok(element.classList.contains("disabled"));
-	Assert.ok(element.classList.contains("primary"));
-});
-
-test("object classnames update", () => {
-	renderer.render(
-		<div
-			class={{
-				active: true,
-				disabled: false,
-				primary: true,
-			}}
-		>
-			Test
-		</div>,
-		document.body,
-	);
-
-	let element = document.querySelector("div")!;
-	Assert.ok(element.classList.contains("active"));
-	Assert.ok(element.classList.contains("primary"));
-	Assert.not.ok(element.classList.contains("disabled"));
-	Assert.not.ok(element.classList.contains("warning"));
-
-	// Update classnames
-	renderer.render(
-		<div
-			class={{
-				active: false,
-				disabled: true,
-				primary: true,
-				warning: true,
-			}}
-		>
-			Test
-		</div>,
-		document.body,
-	);
-
-	element = document.querySelector("div")!;
-	Assert.not.ok(element.classList.contains("active"));
-	Assert.ok(element.classList.contains("disabled"));
-	Assert.ok(element.classList.contains("primary"));
-	Assert.ok(element.classList.contains("warning"));
-});
-
-test("object classnames string to object transition", () => {
-	// Start with string classnames
-	renderer.render(<div class="string-class other">Test</div>, document.body);
-
-	let element = document.querySelector("div")!;
-	Assert.ok(element.classList.contains("string-class"));
-	Assert.ok(element.classList.contains("other"));
-
-	// Switch to object classnames (should clear old string classes)
-	renderer.render(
-		<div
-			class={{
-				"object-class": true,
-				"new-class": true,
-			}}
-		>
-			Test
-		</div>,
-		document.body,
-	);
-
-	element = document.querySelector("div")!;
-	Assert.not.ok(element.classList.contains("string-class"));
-	Assert.not.ok(element.classList.contains("other"));
-	Assert.ok(element.classList.contains("object-class"));
-	Assert.ok(element.classList.contains("new-class"));
-});
-
-test("object classnames object to string transition", () => {
-	// Start with object classnames
-	renderer.render(
-		<div
-			class={{
-				"object-class": true,
-				"another-class": true,
-			}}
-		>
-			Test
-		</div>,
-		document.body,
-	);
-
-	let element = document.querySelector("div")!;
-	Assert.ok(element.classList.contains("object-class"));
-	Assert.ok(element.classList.contains("another-class"));
-
-	// Switch to string classnames (completely replaces class attribute)
-	renderer.render(<div class="string-class final">Test</div>, document.body);
-
-	element = document.querySelector("div")!;
-	Assert.ok(element.classList.contains("string-class"));
-	Assert.ok(element.classList.contains("final"));
-	Assert.not.ok(element.classList.contains("object-class"));
-	Assert.not.ok(element.classList.contains("another-class"));
-});
-
-test("object classnames with space-separated keys", () => {
-	renderer.render(
-		<div
-			class={{
-				"w-5 h-5 rounded-full flex items-center justify-center": true,
-				"bg-green-500 text-white": true,
-				"bg-gray-200 text-gray-400": false,
-			}}
-		>
-			Test
-		</div>,
-		document.body,
-	);
-
-	const element = document.querySelector("div")!;
-	// All classes from truthy keys should be present
-	Assert.ok(element.classList.contains("w-5"));
-	Assert.ok(element.classList.contains("h-5"));
-	Assert.ok(element.classList.contains("rounded-full"));
-	Assert.ok(element.classList.contains("flex"));
-	Assert.ok(element.classList.contains("items-center"));
-	Assert.ok(element.classList.contains("justify-center"));
-	Assert.ok(element.classList.contains("bg-green-500"));
-	Assert.ok(element.classList.contains("text-white"));
-	// Classes from falsy keys should not be present
-	Assert.not.ok(element.classList.contains("bg-gray-200"));
-	Assert.not.ok(element.classList.contains("text-gray-400"));
-});
-
-test("object classnames with space-separated keys update", () => {
-	renderer.render(
-		<div
-			class={{
-				"base-class shared": true,
-				"variant-a extra-a": true,
-				"variant-b extra-b": false,
-			}}
-		>
-			Test
-		</div>,
-		document.body,
-	);
-
-	let element = document.querySelector("div")!;
-	Assert.ok(element.classList.contains("base-class"));
-	Assert.ok(element.classList.contains("shared"));
-	Assert.ok(element.classList.contains("variant-a"));
-	Assert.ok(element.classList.contains("extra-a"));
-	Assert.not.ok(element.classList.contains("variant-b"));
-	Assert.not.ok(element.classList.contains("extra-b"));
-
-	// Update: swap which variant is active
-	renderer.render(
-		<div
-			class={{
-				"base-class shared": true,
-				"variant-a extra-a": false,
-				"variant-b extra-b": true,
-			}}
-		>
-			Test
-		</div>,
-		document.body,
-	);
-
-	element = document.querySelector("div")!;
-	Assert.ok(element.classList.contains("base-class"));
-	Assert.ok(element.classList.contains("shared"));
-	Assert.not.ok(element.classList.contains("variant-a"));
-	Assert.not.ok(element.classList.contains("extra-a"));
-	Assert.ok(element.classList.contains("variant-b"));
-	Assert.ok(element.classList.contains("extra-b"));
-});
-
-test("object classnames with overlapping space-separated keys", () => {
-	// When two keys share a class, toggling one shouldn't remove the shared class
-	renderer.render(
-		<div
-			class={{
-				"a b": true,
-				"b c": true,
-			}}
-		>
-			Test
-		</div>,
-		document.body,
-	);
-
-	let element = document.querySelector("div")!;
-	Assert.ok(element.classList.contains("a"));
-	Assert.ok(element.classList.contains("b"));
-	Assert.ok(element.classList.contains("c"));
-
-	// Toggle first key off - "b" should remain because "b c" is still true
-	renderer.render(
-		<div
-			class={{
-				"a b": false,
-				"b c": true,
-			}}
-		>
-			Test
-		</div>,
-		document.body,
-	);
-
-	element = document.querySelector("div")!;
-	Assert.not.ok(element.classList.contains("a"));
-	Assert.ok(element.classList.contains("b")); // Still present from "b c"
-	Assert.ok(element.classList.contains("c"));
-
-	// Toggle both off
-	renderer.render(
-		<div
-			class={{
-				"a b": false,
-				"b c": false,
-			}}
-		>
-			Test
-		</div>,
-		document.body,
-	);
-
-	element = document.querySelector("div")!;
-	Assert.not.ok(element.classList.contains("a"));
-	Assert.not.ok(element.classList.contains("b"));
-	Assert.not.ok(element.classList.contains("c"));
-});
-
-test("relative src should not cause unnecessary updates", () => {
-	// Track how many times src property is set
-	let srcSetCount = 0;
-	const originalDescriptor = Object.getOwnPropertyDescriptor(
-		HTMLIFrameElement.prototype,
-		"src",
-	)!;
-	Object.defineProperty(HTMLIFrameElement.prototype, "src", {
-		get: originalDescriptor.get,
-		set(value) {
-			srcSetCount++;
-			originalDescriptor.set!.call(this, value);
-		},
-		configurable: true,
+describe("dom", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
 	});
 
-	try {
-		// Initial render
-		renderer.render(<iframe src="/test-path" />, document.body);
-		Assert.is(srcSetCount, 1, "src should be set once on initial render");
-
-		// Re-render with same src
-		renderer.render(<iframe src="/test-path" />, document.body);
-		Assert.is(srcSetCount, 1, "src should not be set again when unchanged");
-
-		// Re-render with different src
-		renderer.render(<iframe src="/different-path" />, document.body);
-		Assert.is(srcSetCount, 2, "src should be set when changed");
-	} finally {
-		// Restore original property
-		Object.defineProperty(
-			HTMLIFrameElement.prototype,
-			"src",
-			originalDescriptor,
-		);
-	}
-});
-
-test("relative href should not cause unnecessary updates", () => {
-	// Track how many times href property is set
-	let hrefSetCount = 0;
-	const originalDescriptor = Object.getOwnPropertyDescriptor(
-		HTMLAnchorElement.prototype,
-		"href",
-	)!;
-	Object.defineProperty(HTMLAnchorElement.prototype, "href", {
-		get: originalDescriptor.get,
-		set(value) {
-			hrefSetCount++;
-			originalDescriptor.set!.call(this, value);
-		},
-		configurable: true,
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
 	});
 
-	try {
-		// Initial render
-		renderer.render(<a href="/test-link">Link</a>, document.body);
-		Assert.is(hrefSetCount, 1, "href should be set once on initial render");
-
-		// Re-render with same href
-		renderer.render(<a href="/test-link">Link</a>, document.body);
-		Assert.is(hrefSetCount, 1, "href should not be set again when unchanged");
-
-		// Re-render with different href
-		renderer.render(<a href="/different-link">Link</a>, document.body);
-		Assert.is(hrefSetCount, 2, "href should be set when changed");
-	} finally {
-		// Restore original property
-		Object.defineProperty(
-			HTMLAnchorElement.prototype,
-			"href",
-			originalDescriptor,
-		);
-	}
-});
-
-test("absolute URLs should work correctly for src", () => {
-	let srcSetCount = 0;
-	const originalDescriptor = Object.getOwnPropertyDescriptor(
-		HTMLIFrameElement.prototype,
-		"src",
-	)!;
-	Object.defineProperty(HTMLIFrameElement.prototype, "src", {
-		get: originalDescriptor.get,
-		set(value) {
-			srcSetCount++;
-			originalDescriptor.set!.call(this, value);
-		},
-		configurable: true,
+	test("simple", () => {
+		renderer.render(<h1>Hello world</h1>, document.body);
+		expect(document.body.innerHTML).toBe("<h1>Hello world</h1>");
 	});
 
-	try {
-		// Initial render with absolute URL
-		renderer.render(<iframe src="https://example.com/page" />, document.body);
-		Assert.is(srcSetCount, 1);
-
-		// Re-render with same absolute URL
-		renderer.render(<iframe src="https://example.com/page" />, document.body);
-		Assert.is(
-			srcSetCount,
-			1,
-			"absolute src should not be set again when unchanged",
-		);
-	} finally {
-		Object.defineProperty(
-			HTMLIFrameElement.prototype,
-			"src",
-			originalDescriptor,
-		);
-	}
-});
-
-// Prop patching: two-loop iteration (removals then updates)
-test("simultaneous prop add, remove, and update", () => {
-	const div = renderer.render(
-		<div id="old" data-a="1" data-b="2" />,
-		document.body,
-	) as HTMLElement;
-	Assert.is(div.id, "old");
-	Assert.is(div.getAttribute("data-a"), "1");
-	Assert.is(div.getAttribute("data-b"), "2");
-
-	renderer.render(<div id="new" data-b="changed" data-c="3" />, document.body);
-	Assert.is(div.id, "new"); // updated
-	Assert.is(div.getAttribute("data-a"), null); // removed
-	Assert.is(div.getAttribute("data-b"), "changed"); // updated
-	Assert.is(div.getAttribute("data-c"), "3"); // added
-});
-
-test("remove all props", () => {
-	const div = renderer.render(
-		<div dir="rtl" data-a="1" data-b="2" />,
-		document.body,
-	) as HTMLElement;
-	Assert.is(div.dir, "rtl");
-	Assert.is(div.getAttribute("data-a"), "1");
-
-	renderer.render(<div />, document.body);
-	Assert.is(div.dir, "");
-	Assert.is(div.getAttribute("data-a"), null);
-	Assert.is(div.getAttribute("data-b"), null);
-});
-
-test("add props to element that had none", () => {
-	const div = renderer.render(<div />, document.body) as HTMLElement;
-	Assert.is(div.id, "");
-
-	renderer.render(<div id="added" data-x="y" />, document.body);
-	Assert.is(div.id, "added");
-	Assert.is(div.getAttribute("data-x"), "y");
-});
-
-test("event handler swap across renders", () => {
-	const calls: string[] = [];
-	renderer.render(<button onclick={() => calls.push("a")} />, document.body);
-	const button = document.body.firstChild as HTMLButtonElement;
-	button.click();
-	Assert.equal(calls, ["a"]);
-
-	renderer.render(<button onclick={() => calls.push("b")} />, document.body);
-	button.click();
-	Assert.equal(calls, ["a", "b"]);
-});
-
-test("event handler removal", () => {
-	const calls: string[] = [];
-	renderer.render(
-		<button onclick={() => calls.push("clicked")} />,
-		document.body,
-	);
-	const button = document.body.firstChild as HTMLButtonElement;
-	button.click();
-	Assert.equal(calls, ["clicked"]);
-
-	renderer.render(<button />, document.body);
-	button.click();
-	Assert.equal(calls, ["clicked"]); // no new call after removal
-});
-
-test("event handler add and remove different events simultaneously", () => {
-	const calls: string[] = [];
-	renderer.render(<div onclick={() => calls.push("click")} />, document.body);
-	const div = document.body.firstChild as HTMLDivElement;
-	div.click();
-	Assert.equal(calls, ["click"]);
-
-	// Remove onclick, add onmouseenter
-	renderer.render(
-		<div onmouseenter={() => calls.push("mouseenter")} />,
-		document.body,
-	);
-	div.click();
-	Assert.equal(calls, ["click"]); // onclick removed
-	div.dispatchEvent(new MouseEvent("mouseenter"));
-	Assert.equal(calls, ["click", "mouseenter"]); // onmouseenter added
-});
-
-// Style object two-loop: partial overlap
-test("style object partial overlap across renders", () => {
-	const div = renderer.render(
-		<div style={{color: "red", fontSize: "12px", margin: "5px"}} />,
-		document.body,
-	) as HTMLElement;
-	Assert.is(div.style.color, "red");
-	Assert.is(div.style.fontSize, "12px");
-	Assert.is(div.style.margin, "5px");
-
-	// color removed, fontSize updated, padding added, margin removed
-	renderer.render(
-		<div style={{fontSize: "14px", padding: "10px"}} />,
-		document.body,
-	);
-	Assert.is(div.style.color, ""); // removed
-	Assert.is(div.style.fontSize, "14px"); // updated
-	Assert.is(div.style.margin, ""); // removed
-	Assert.is(div.style.padding, "10px"); // added
-});
-
-test("style object with explicit null values", () => {
-	const div = renderer.render(
-		<div style={{color: "red", fontSize: "12px", margin: "5px"}} />,
-		document.body,
-	) as HTMLElement;
-	Assert.is(div.style.color, "red");
-	Assert.is(div.style.fontSize, "12px");
-	Assert.is(div.style.margin, "5px");
-
-	// Explicitly null out color, keep fontSize, update margin
-	renderer.render(
-		<div style={{color: null, fontSize: "12px", margin: "10px"}} />,
-		document.body,
-	);
-	Assert.is(div.style.color, ""); // explicitly removed
-	Assert.is(div.style.fontSize, "12px"); // unchanged
-	Assert.is(div.style.margin, "10px"); // updated
-});
-
-test("style object to empty object clears all styles", () => {
-	const div = renderer.render(
-		<div style={{color: "red", fontSize: "12px"}} />,
-		document.body,
-	) as HTMLElement;
-	Assert.is(div.style.color, "red");
-	Assert.is(div.style.fontSize, "12px");
-
-	renderer.render(<div style={{}} />, document.body);
-	Assert.is(div.style.color, ""); // removed
-	Assert.is(div.style.fontSize, ""); // removed
-});
-
-test("style object completely disjoint sets across renders", () => {
-	const div = renderer.render(
-		<div style={{color: "red", margin: "5px"}} />,
-		document.body,
-	) as HTMLElement;
-	Assert.is(div.style.color, "red");
-	Assert.is(div.style.margin, "5px");
-
-	// Completely different properties
-	renderer.render(
-		<div style={{padding: "10px", border: "1px solid black"}} />,
-		document.body,
-	);
-	Assert.is(div.style.color, ""); // removed
-	Assert.is(div.style.margin, ""); // removed
-	Assert.is(div.style.padding, "10px"); // added
-	Assert.is(div.style.border, "1px solid black"); // added
-});
-
-// Class object two-loop: partial overlap
-test("class object partial overlap across renders", () => {
-	renderer.render(
-		<div class={{active: true, highlight: true, large: true}}>Test</div>,
-		document.body,
-	);
-	let div = document.querySelector("div")!;
-	Assert.ok(div.classList.contains("active"));
-	Assert.ok(div.classList.contains("highlight"));
-	Assert.ok(div.classList.contains("large"));
-
-	// active removed, highlight kept, small added, large removed
-	renderer.render(
-		<div class={{active: false, highlight: true, small: true}}>Test</div>,
-		document.body,
-	);
-	Assert.not.ok(div.classList.contains("active")); // removed
-	Assert.ok(div.classList.contains("highlight")); // kept
-	Assert.not.ok(div.classList.contains("large")); // removed (not in new)
-	Assert.ok(div.classList.contains("small")); // added
-});
-
-test("class object all classes removed", () => {
-	renderer.render(
-		<div class={{a: true, b: true, c: true}}>Test</div>,
-		document.body,
-	);
-	let div = document.querySelector("div")!;
-	Assert.ok(div.classList.contains("a"));
-	Assert.ok(div.classList.contains("b"));
-	Assert.ok(div.classList.contains("c"));
-
-	renderer.render(
-		<div class={{a: false, b: false, c: false}}>Test</div>,
-		document.body,
-	);
-	Assert.not.ok(div.classList.contains("a"));
-	Assert.not.ok(div.classList.contains("b"));
-	Assert.not.ok(div.classList.contains("c"));
-});
-
-test("class object to empty object clears classes", () => {
-	renderer.render(<div class={{x: true, y: true}}>Test</div>, document.body);
-	let div = document.querySelector("div")!;
-	Assert.ok(div.classList.contains("x"));
-	Assert.ok(div.classList.contains("y"));
-
-	renderer.render(<div class={{}}>Test</div>, document.body);
-	Assert.not.ok(div.classList.contains("x"));
-	Assert.not.ok(div.classList.contains("y"));
-});
-
-// Mixed prop types changing simultaneously
-test("style, class, and attributes all change in single render", () => {
-	renderer.render(
-		<div id="old" style={{color: "red"}} class={{active: true}} data-x="1">
-			Test
-		</div>,
-		document.body,
-	);
-	let div = document.querySelector("div")!;
-	Assert.is(div.id, "old");
-	Assert.is(div.style.color, "red");
-	Assert.ok(div.classList.contains("active"));
-	Assert.is(div.getAttribute("data-x"), "1");
-
-	renderer.render(
-		<div
-			id="new"
-			style={{fontSize: "14px"}}
-			class={{highlight: true}}
-			data-y="2"
-		>
-			Test
-		</div>,
-		document.body,
-	);
-	Assert.is(div.id, "new"); // updated
-	Assert.is(div.style.color, ""); // removed
-	Assert.is(div.style.fontSize, "14px"); // added
-	Assert.not.ok(div.classList.contains("active")); // removed
-	Assert.ok(div.classList.contains("highlight")); // added
-	Assert.is(div.getAttribute("data-x"), null); // removed
-	Assert.is(div.getAttribute("data-y"), "2"); // added
-});
-
-test("htmlFor sets for attribute", () => {
-	renderer.render(<label htmlFor="email">Email</label>, document.body);
-	const label = document.body.firstChild as HTMLLabelElement;
-	Assert.is(label.getAttribute("for"), "email");
-});
-
-test("htmlFor removes for attribute when null", () => {
-	renderer.render(<label htmlFor="email">Email</label>, document.body);
-	renderer.render(<label htmlFor={null}>Email</label>, document.body);
-	const label = document.body.firstChild as HTMLLabelElement;
-	Assert.is(label.getAttribute("for"), null);
-});
-
-test("htmlFor skipped when for is also present", () => {
-	renderer.render(
-		<label for="email" htmlFor="other">
-			Email
-		</label>,
-		document.body,
-	);
-	const label = document.body.firstChild as HTMLLabelElement;
-	Assert.is(label.getAttribute("for"), "email");
-});
-
-test("className skipped when class is also present", () => {
-	renderer.render(<div class="real" className="ignored" />, document.body);
-	const div = document.body.firstChild as HTMLDivElement;
-	Assert.is(div.getAttribute("class"), "real");
-});
-
-test("dangerouslySetInnerHTML sets innerHTML", () => {
-	renderer.render(
-		<div dangerouslySetInnerHTML={{__html: "<b>bold</b>"}} />,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><b>bold</b></div>");
-});
-
-test("dangerouslySetInnerHTML does not insert children", () => {
-	renderer.render(
-		<div dangerouslySetInnerHTML={{__html: "<b>bold</b>"}} />,
-		document.body,
-	);
-	const div = document.body.firstChild as HTMLElement;
-	Assert.is(div.innerHTML, "<b>bold</b>");
-	Assert.is(div.childNodes.length, 1);
-});
-
-test("dangerouslySetInnerHTML updates", () => {
-	renderer.render(
-		<div dangerouslySetInnerHTML={{__html: "<b>first</b>"}} />,
-		document.body,
-	);
-	renderer.render(
-		<div dangerouslySetInnerHTML={{__html: "<i>second</i>"}} />,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><i>second</i></div>");
-});
-
-// Child cardinality transitions — exercises the diffChild/diffChildren boundary
-test("zero to one child", () => {
-	renderer.render(<div />, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	renderer.render(
-		<div>
-			<span>a</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>a</span></div>");
-});
-
-test("one to zero children", () => {
-	renderer.render(
-		<div>
-			<span>a</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>a</span></div>");
-	renderer.render(<div />, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-});
-
-test("one to many children", () => {
-	renderer.render(
-		<div>
-			<span>a</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>a</span></div>");
-	renderer.render(
-		<div>
-			<span>a</span>
-			<span>b</span>
-			<span>c</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>a</span><span>b</span><span>c</span></div>",
-	);
-});
-
-test("many to one child", () => {
-	renderer.render(
-		<div>
-			<span>a</span>
-			<span>b</span>
-			<span>c</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>a</span><span>b</span><span>c</span></div>",
-	);
-	renderer.render(
-		<div>
-			<span>only</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>only</span></div>");
-});
-
-test("many to zero children", () => {
-	renderer.render(
-		<div>
-			<span>a</span>
-			<span>b</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>a</span><span>b</span></div>");
-	renderer.render(<div />, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-});
-
-test("zero to many children", () => {
-	renderer.render(<div />, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	renderer.render(
-		<div>
-			<span>a</span>
-			<span>b</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>a</span><span>b</span></div>");
-});
-
-test("one to one child, same tag reuse", () => {
-	renderer.render(
-		<div>
-			<span>first</span>
-		</div>,
-		document.body,
-	);
-	const span = document.body.querySelector("span")!;
-	renderer.render(
-		<div>
-			<span>second</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>second</span></div>");
-	Assert.is(
-		document.body.querySelector("span"),
-		span,
-		"should reuse the span element",
-	);
-});
-
-test("one to one child, different tag", () => {
-	renderer.render(
-		<div>
-			<span>hello</span>
-		</div>,
-		document.body,
-	);
-	renderer.render(
-		<div>
-			<b>hello</b>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><b>hello</b></div>");
-});
-
-test("one text to one element", () => {
-	renderer.render(<div>hello</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div>hello</div>");
-	renderer.render(
-		<div>
-			<span>hello</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>hello</span></div>");
-});
-
-test("one element to one text", () => {
-	renderer.render(
-		<div>
-			<span>hello</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>hello</span></div>");
-	renderer.render(<div>hello</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div>hello</div>");
-});
-
-test("one to one child with null intermediate", () => {
-	renderer.render(
-		<div>
-			<span>a</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>a</span></div>");
-	renderer.render(<div>{null}</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	renderer.render(
-		<div>
-			<span>b</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>b</span></div>");
-});
-
-test("one to one child with boolean intermediate", () => {
-	renderer.render(
-		<div>
-			<span>a</span>
-		</div>,
-		document.body,
-	);
-	renderer.render(<div>{false}</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	renderer.render(
-		<div>
-			<span>b</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>b</span></div>");
-});
-
-test("one child with key to one child with different key", () => {
-	renderer.render(
-		<div>
-			<span key="a">a</span>
-		</div>,
-		document.body,
-	);
-	const span1 = document.body.querySelector("span")!;
-	renderer.render(
-		<div>
-			<span key="b">b</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>b</span></div>");
-	Assert.is.not(
-		document.body.querySelector("span"),
-		span1,
-		"should create a new span for different key",
-	);
-});
-
-test("one child with key to one child without key", () => {
-	renderer.render(
-		<div>
-			<span key="a">a</span>
-		</div>,
-		document.body,
-	);
-	const span1 = document.body.querySelector("span")!;
-	renderer.render(
-		<div>
-			<span>b</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>b</span></div>");
-	Assert.is.not(
-		document.body.querySelector("span"),
-		span1,
-		"should create a new span when key removed",
-	);
-});
-
-test("one child without key to one child with key", () => {
-	renderer.render(
-		<div>
-			<span>a</span>
-		</div>,
-		document.body,
-	);
-	const span1 = document.body.querySelector("span")!;
-	renderer.render(
-		<div>
-			<span key="b">b</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>b</span></div>");
-	Assert.is.not(
-		document.body.querySelector("span"),
-		span1,
-		"should create a new span when key added",
-	);
-});
-
-test("one keyed child to many children", () => {
-	renderer.render(
-		<div>
-			<span key="a">a</span>
-		</div>,
-		document.body,
-	);
-	renderer.render(
-		<div>
-			<span key="a">a</span>
-			<span key="b">b</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>a</span><span>b</span></div>");
-});
-
-test("many children to one keyed child", () => {
-	renderer.render(
-		<div>
-			<span key="a">a</span>
-			<span key="b">b</span>
-		</div>,
-		document.body,
-	);
-	renderer.render(
-		<div>
-			<span key="a">a</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>a</span></div>");
-});
-
-test("fragment single child transition", () => {
-	function Component({count}: {count: number}) {
-		const children = [];
-		for (let i = 0; i < count; i++) {
-			children.push(<span>{i}</span>);
-		}
-		return <div>{children}</div>;
-	}
-
-	renderer.render(<Component count={1} />, document.body);
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	renderer.render(<Component count={3} />, document.body);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>0</span><span>1</span><span>2</span></div>",
-	);
-	renderer.render(<Component count={1} />, document.body);
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	renderer.render(<Component count={0} />, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	renderer.render(<Component count={1} />, document.body);
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-});
-
-test("component single child transition", () => {
-	function* Inner(this: Context, {message}: {message: string}): Generator {
-		let count = 0;
-		for ({message} of this) {
-			count++;
-			yield (
-				<span>
-					{message} ({count})
-				</span>
-			);
-		}
-	}
-
-	renderer.render(
-		<div>
-			<Inner message="a" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>a (1)</span></div>");
-	renderer.render(
-		<div>
-			<Inner message="b" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>b (2)</span></div>");
-	renderer.render(<div>{null}</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	// Re-mounting should reset the generator
-	renderer.render(
-		<div>
-			<Inner message="c" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>c (1)</span></div>");
-});
-
-test("rapid cardinality cycling", () => {
-	for (let round = 0; round < 3; round++) {
-		renderer.render(<div />, document.body);
-		Assert.is(document.body.innerHTML, "<div></div>", `round ${round}: zero`);
-
+	test("multiple children", () => {
 		renderer.render(
 			<div>
-				<span>one</span>
+				<span>1</span>
+				<span>2</span>
+				<span>3</span>
+				<span>4</span>
 			</div>,
 			document.body,
 		);
-		Assert.is(
-			document.body.innerHTML,
-			"<div><span>one</span></div>",
-			`round ${round}: one`,
+
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span></div>",
+		);
+	});
+
+	test("nested children", () => {
+		renderer.render(
+			<div id="1">
+				<div id="2">
+					<div id="3">Hi</div>
+				</div>
+			</div>,
+			document.body,
 		);
 
+		expect(document.body.innerHTML).toBe(
+			'<div id="1"><div id="2"><div id="3">Hi</div></div></div>',
+		);
+
+		const div1 = document.getElementById("1")!;
+		renderer.render(<div id="1" />, document.body);
+		expect(document.body.innerHTML).toBe('<div id="1"></div>');
+		expect(document.body.firstChild).toBe(div1);
+	});
+
+	test("boolean replaces nested children", () => {
+		renderer.render(
+			<div id="1">
+				<div id="2">
+					<div id="3">Hi</div>
+				</div>
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			'<div id="1"><div id="2"><div id="3">Hi</div></div></div>',
+		);
+
+		const div1 = document.getElementById("1")!;
+		const div2 = document.getElementById("2")!;
+		renderer.render(
+			<div id="1">
+				<div id="2">{true}</div>
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			'<div id="1"><div id="2"></div></div>',
+		);
+		expect(document.body.firstChild).toBe(div1);
+		expect(document.body.firstChild!.firstChild).toBe(div2);
+	});
+
+	test("attrs", () => {
+		renderer.render(
+			<Fragment>
+				<input id="toggle" type="checkbox" checked={true} data-checked={true} />
+				<label for="toggle" />
+			</Fragment>,
+			document.body,
+		);
+		// this expectation is based on non-standard jsdom innerHTML behavior jsdom doesn‘t seem to reflect checked property
+		expect(document.body.innerHTML).toBe(
+			'<input id="toggle" type="checkbox" data-checked=""><label for="toggle"></label>',
+		);
+		expect((document.body.firstChild! as any).checked).toBe(true);
+		renderer.render(
+			<Fragment>
+				<input
+					id="toggle"
+					type="checkbox"
+					checked={false}
+					data-checked={false}
+				/>
+				<label for="toggle" class="inactive" />
+			</Fragment>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			'<input id="toggle" type="checkbox"><label for="toggle" class="inactive"></label>',
+		);
+		expect((document.body.firstChild! as any).checked).toBe(false);
+	});
+
+	test("doesn’t blow away user-created html when it doesn’t have to", () => {
+		renderer.render(<div id="mount" />, document.body);
+		expect(document.body.innerHTML).toBe('<div id="mount"></div>');
+		document.getElementById("mount")!.innerHTML = "<span>Hello world</span>";
+		expect(document.body.innerHTML).toBe(
+			'<div id="mount"><span>Hello world</span></div>',
+		);
+		renderer.render(<div id="mount" />, document.body);
+		expect(document.body.innerHTML).toBe(
+			'<div id="mount"><span>Hello world</span></div>',
+		);
+	});
+
+	test("rerender text", () => {
+		renderer.render(<h1>Hello world 1</h1>, document.body);
+		expect(document.body.innerHTML).toBe("<h1>Hello world 1</h1>");
+		const h1 = document.body.firstChild!;
+		expect(h1.childNodes.length).toBe(1);
+		const text = h1.firstChild!;
+		renderer.render(<h1>Hello {"world"} 2</h1>, document.body);
+		expect(document.body.innerHTML).toBe("<h1>Hello world 2</h1>");
+		expect(document.body.firstChild!).toBe(h1);
+		expect(h1.childNodes.length).toBe(3);
+		expect(document.body.firstChild!.childNodes[0] as Text).toBe(text);
+		expect((document.body.firstChild!.childNodes[0] as Text).data).toBe(
+			"Hello ",
+		);
+		expect((document.body.firstChild!.childNodes[1] as Text).data).toBe(
+			"world",
+		);
+		expect((document.body.firstChild!.childNodes[2] as Text).data).toBe(" 2");
+		const text1 = document.body.firstChild!.childNodes[1] as Text;
+		const text2 = document.body.firstChild!.childNodes[2] as Text;
+		renderer.render(<h1>Hello world {3}</h1>, document.body);
+		expect(document.body.innerHTML).toBe("<h1>Hello world 3</h1>");
+		expect(document.body.firstChild!).toBe(h1);
+		expect(h1.childNodes.length).toBe(2);
+		expect(document.body.firstChild!.childNodes[0] as Text).toBe(text);
+		expect(document.body.firstChild!.childNodes[1] as Text).toBe(text1);
+		expect(text2.parentNode).toBe(null);
+	});
+
+	test("rerender different child", () => {
+		renderer.render(
+			<div>
+				<h1>Hello world</h1>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><h1>Hello world</h1></div>");
+		const div = document.body.firstChild!;
+		renderer.render(
+			<div>
+				<h2>Hello world</h2>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><h2>Hello world</h2></div>");
+		expect(document.body.firstChild!).toBe(div);
+	});
+
+	test("rerender text with children", () => {
+		renderer.render(<div>Hello world</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello world</div>");
+		const div = document.body.firstChild!;
+		renderer.render(
+			<div>
+				<span>1</span>
+				<span>2</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span></div>",
+		);
+		expect(document.body.firstChild!).toBe(div);
+	});
+
+	test("rerender children with text", () => {
+		renderer.render(
+			<div>
+				<span>1</span>
+				<span>2</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span></div>",
+		);
+		const div = document.body.firstChild!;
+		renderer.render(<div>Hello world</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello world</div>");
+		expect(document.body.firstChild!).toBe(div);
+	});
+
+	test("rerender more children", () => {
+		renderer.render(
+			<div>
+				<span>1</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		const div = document.body.firstChild!;
+		const span = div.firstChild!;
+		renderer.render(
+			<div>
+				<span>1</span>
+				<span>2</span>
+				<span>3</span>
+				<span>4</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span></div>",
+		);
+		expect(document.body.firstChild!).toBe(div);
+		expect(document.body.firstChild!.firstChild).toBe(span);
+	});
+
+	test("rerender fewer children", () => {
+		renderer.render(
+			<div>
+				<span>1</span>
+				<span>2</span>
+				<span>3</span>
+				<span>4</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span></div>",
+		);
+		const div = document.body.firstChild!;
+		const span = div.firstChild!;
+		renderer.render(
+			<div>
+				<span>1</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		expect(document.body.firstChild!).toBe(div);
+		expect(document.body.firstChild!.firstChild).toBe(span);
+	});
+
+	test("null and undefined", () => {
+		renderer.render(<h1>Hello world</h1>, document.body);
+		expect(document.body.innerHTML).toBe("<h1>Hello world</h1>");
+		renderer.render(null, document.body);
+		expect(document.body.innerHTML).toBe("");
+		renderer.render(<h1>Hello again</h1>, document.body);
+		expect(document.body.innerHTML).toBe("<h1>Hello again</h1>");
+		renderer.render(undefined, document.body);
+		expect(document.body.innerHTML).toBe("");
+	});
+
+	test("fragment", () => {
+		renderer.render(
+			<Fragment>
+				<span>1</span>
+				<span>2</span>
+			</Fragment>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<span>1</span><span>2</span>");
+		const span1 = document.body.childNodes[0];
+		const span2 = document.body.childNodes[1];
+		renderer.render(
+			<Fragment>
+				<span>1</span>
+				<span>2</span>
+				<span>3</span>
+			</Fragment>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<span>1</span><span>2</span><span>3</span>",
+		);
+		expect(document.body.childNodes[0]).toBe(span1);
+		expect(document.body.childNodes[1]).toBe(span2);
+	});
+
+	test("fragment with null and undefined", () => {
+		renderer.render(
+			<Fragment>
+				{null}
+				{undefined}
+			</Fragment>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("");
+		renderer.render(
+			<Fragment>
+				<span>1</span>
+				<span>2</span>
+			</Fragment>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<span>1</span><span>2</span>");
+	});
+
+	test("iterable", () => {
+		renderer.render(["1", 2, <div>3</div>], document.body);
+		expect(document.body.innerHTML).toBe("12<div>3</div>");
+		renderer.render(null, document.body);
+		expect(document.body.innerHTML).toBe("");
+	});
+
+	test("array", () => {
+		renderer.render(
+			<div>
+				<span>1</span>
+				{[<span>2</span>, <span>3</span>]}
+				<span>4</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span></div>",
+		);
+		const span1 = document.body.firstChild!.childNodes[0];
+		const span4 = document.body.firstChild!.childNodes[3];
+		renderer.render(
+			<div>
+				<span>1</span>
+				{[]}
+				<span>4</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>4</span></div>",
+		);
+		expect(document.body.firstChild!.childNodes[0]).toBe(span1);
+		expect(document.body.firstChild!.childNodes[1]).toBe(span4);
+	});
+
+	test("nested arrays", () => {
+		renderer.render(
+			<div>
+				<span>1</span>
+				{[<span>2</span>, [<span>3</span>, <span>4</span>], <span>5</span>]}
+				<span>6</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></div>",
+		);
+		const span1 = document.body.firstChild!.childNodes[0];
+		const span2 = document.body.firstChild!.childNodes[1];
+		const span3 = document.body.firstChild!.childNodes[2];
+		const span6 = document.body.firstChild!.childNodes[5];
+		renderer.render(
+			<div>
+				<span>1</span>
+				{[<span>2</span>, [<span>4</span>]]}
+				<span>6</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>4</span><span>6</span></div>",
+		);
+		expect(document.body.firstChild!.childNodes[0]).toBe(span1);
+		expect(document.body.firstChild!.childNodes[1]).toBe(span2);
+		expect(document.body.firstChild!.childNodes[2]).toBe(span3);
+		expect(document.body.firstChild!.childNodes[3]).toBe(span6);
+	});
+
+	test("raw html", () => {
+		const html = '<span id="raw">Hi</span>';
+		renderer.render(
+			<div>
+				Raw: <Raw value={html} />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			'<div>Raw: <span id="raw">Hi</span></div>',
+		);
+		expect(document.getElementById("raw")).toBeTruthy();
+	});
+
+	test("raw svg", () => {
+		const html = '<circle cx="5" cy="5" r="5" />';
+		renderer.render(
+			<svg>
+				Raw: <Raw value={html} />
+			</svg>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			'<svg>Raw: <circle cx="5" cy="5" r="5"></circle></svg>',
+		);
+
+		expect(
+			document.body.firstChild!.childNodes[1] instanceof SVGCircleElement,
+		).toBeTruthy();
+	});
+
+	test("raw node", () => {
+		var template = document.createElement("template");
+		template.innerHTML = '<span id="raw">Hi</span>';
+		const span = template.content.firstChild!;
+		renderer.render(
+			<div>
+				Raw: <Raw value={span} />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			'<div>Raw: <span id="raw">Hi</span></div>',
+		);
+		expect(document.getElementById("raw")).toBeTruthy();
+	});
+
+	test("raw changes", () => {
+		let html = '<span id="raw">Hi</span>';
+		renderer.render(
+			<div>
+				Raw: <Raw value={html} />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			'<div>Raw: <span id="raw">Hi</span></div>',
+		);
+
+		html = "RAWRAWRAW<div>Raw</div>RAWRAWRAW";
+		renderer.render(
+			<div>
+				Raw: <Raw value={html} />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			"<div>Raw: RAWRAWRAW<div>Raw</div>RAWRAWRAW</div>",
+		);
+	});
+
+	test("style text", () => {
+		renderer.render(<div style="display: none" />, document.body);
+		expect(document.body.innerHTML).toBe('<div style="display: none;"></div>');
+		expect((document.body.firstChild as HTMLElement).style.display).toBe(
+			"none",
+		);
+	});
+
+	test("style object", () => {
+		renderer.render(
+			<div style={{display: "none", "margin-top": "30px"}} />,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			'<div style="display: none; margin-top: 30px;"></div>',
+		);
+		expect((document.body.firstChild as HTMLElement).style.display).toBe(
+			"none",
+		);
+		expect((document.body.firstChild as HTMLElement).style.marginTop).toBe(
+			"30px",
+		);
+	});
+
+	test("style text to object", () => {
+		renderer.render(<div style="font-weight: bold" />, document.body);
+
+		expect(document.body.innerHTML).toBe(
+			'<div style="font-weight: bold;"></div>',
+		);
+
+		renderer.render(<div style={{color: "goldenrod"}} />, document.body);
+
+		expect(document.body.innerHTML).toBe(
+			'<div style="color: goldenrod;"></div>',
+		);
+	});
+
+	test("outside DOM mutations", () => {
+		renderer.render(<div />, document.body);
+
+		const div = document.body.firstChild as HTMLDivElement;
+		div.innerHTML = "<span>child</span>";
+		renderer.render(<div />, document.body);
+
+		expect(document.body.innerHTML).toBe("<div><span>child</span></div>");
+		renderer.render(<div>{[]}</div>, document.body);
+
+		expect(document.body.innerHTML).toBe("<div><span>child</span></div>");
+		div.innerHTML = "<span>child</span>";
+		renderer.render(<div>{null}</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div><span>child</span></div>");
+	});
+
+	test("unknown attribute", () => {
+		renderer.render(
+			<div
+				unknown="value"
+				unknown-attribute="value"
+				data-unknown-attribute="value"
+			/>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			'<div unknown="value" unknown-attribute="value" data-unknown-attribute="value"></div>',
+		);
+
+		const div = document.body.firstChild as HTMLDivElement;
+		expect(div.getAttribute("unknown")).toBe("value");
+		expect(div.getAttribute("unknown-attribute")).toBe("value");
+		expect(div.getAttribute("data-unknown-attribute")).toBe("value");
+	});
+
+	test("removing props", () => {
+		const input = renderer.render(
+			<input dir="rtl" autofocus={true} value="hello" />,
+			document.body,
+		) as any;
+
+		expect(input.dir).toBe("rtl");
+		expect(input.autofocus).toBe(true);
+		renderer.render(<input />, document.body);
+		expect(input.dir).toBe("");
+		expect(input.autofocus).toBe(false);
+	});
+
+	test("removing styles", () => {
+		const div = renderer.render(
+			<div style={{color: "red", "background-color": "blue"}} />,
+			document.body,
+		) as any;
+
+		expect(div.style.color).toBe("red");
+		expect(div.style.backgroundColor).toBe("blue");
+		renderer.render(<div style={{color: "red"}} />, document.body) as any;
+		expect(div.style.color).toBe("red");
+		expect(div.style.backgroundColor).toBe("");
+	});
+
+	test("style object camelCase", () => {
+		renderer.render(
+			<div
+				style={{
+					fontSize: "16px",
+					backgroundColor: "red",
+					marginTop: "10px",
+					borderRadius: "4px",
+					WebkitTransform: "rotate(45deg)",
+				}}
+			/>,
+			document.body,
+		);
+
+		// Check HTML output has kebab-case properties
+		// Note: Browser normalizes -webkit-transform to transform in innerHTML
+		const expectedHTML =
+			'<div style="font-size: 16px; background-color: red; margin-top: 10px; border-radius: 4px; transform: rotate(45deg);"></div>';
+		expect(document.body.innerHTML).toBe(expectedHTML);
+
+		// Check DOM element properties are accessible via camelCase
+		const div = document.body.firstChild as HTMLElement;
+		expect(div.style.fontSize).toBe("16px");
+		expect(div.style.backgroundColor).toBe("red");
+		expect(div.style.marginTop).toBe("10px");
+		expect(div.style.borderRadius).toBe("4px");
+		// Browser normalizes WebkitTransform to transform
+		expect(div.style.transform).toBe("rotate(45deg)");
+	});
+
+	test("style object numeric values with px conversion", () => {
+		renderer.render(
+			<div
+				style={{
+					width: 100,
+					height: 200,
+					opacity: 0.5,
+					zIndex: 10,
+					fontSize: 16,
+				}}
+			/>,
+			document.body,
+		);
+
+		// Check HTML output - numeric values should have px added except for unitless properties
+		const expectedHTML =
+			'<div style="width: 100px; height: 200px; opacity: 0.5; z-index: 10; font-size: 16px;"></div>';
+		expect(document.body.innerHTML).toBe(expectedHTML);
+
+		// Check DOM element properties
+		const div = document.body.firstChild as HTMLElement;
+		expect(div.style.width).toBe("100px");
+		expect(div.style.height).toBe("200px");
+		expect(div.style.opacity).toBe("0.5");
+		expect(div.style.zIndex).toBe("10");
+		expect(div.style.fontSize).toBe("16px");
+	});
+
+	test("uncontrolled props", () => {
+		const input = renderer.render(
+			<input value="hello" />,
+			document.body,
+		) as any;
+		expect(input instanceof HTMLInputElement).toBeTruthy();
+		expect(input.value).toBe("hello");
+		input.value = "world";
+		expect(input.value).toBe("world");
+		renderer.render(<input value={Copy} />, document.body);
+	});
+
+	test("default props", () => {
+		renderer.render(
+			<Fragment>
+				<input />
+				<input type="text" />
+			</Fragment>,
+			document.body,
+		);
+		expect(document.querySelectorAll("input").length).toEqual(2);
+		expect(document.querySelectorAll('input[type="text"]').length).toEqual(1);
+	});
+
+	test("set/unset default props", () => {
+		// Attribute should be set on initial render.
+		renderer.render(<input type="text" />, document.body);
+		expect(document.querySelectorAll('input[type="text"]').length).toEqual(1);
+
+		// Remove attribute.
+		renderer.render(<input />, document.body);
+		expect(document.querySelectorAll('input[type="text"]').length).toEqual(0);
+
+		// Attribute should also be set on subsequent renders if it was previously missing.
+		renderer.render(<input type="text" />, document.body);
+		expect(document.querySelectorAll('input[type="text"]').length).toEqual(1);
+	});
+
+	test("prop: prefix forces prop", () => {
+		let el: any;
+		renderer.render(
+			<custom-el prop:prop="value" ref={(el1: any) => (el = el1)} />,
+			document.body,
+		);
+		expect(el.prop).toBe("value");
+	});
+
+	test("attr: prefix forces attribute", () => {
+		let el: any;
+		renderer.render(
+			<custom-el ref={(el1: any) => (el = el1)} />,
+			document.body,
+		);
+		el.attr = "value";
+		renderer.render(<custom-el attr:attr="other" />, document.body);
+		expect(el.getAttribute("attr")).toBe("other");
+		expect(el.attr).toBe("value");
+	});
+
+	test("attr: prefix removes attribute when null", () => {
+		renderer.render(<div attr:data-x="hello" />, document.body);
+		const div = document.body.firstChild as HTMLElement;
+		expect(div.getAttribute("data-x")).toBe("hello");
+
+		renderer.render(<div attr:data-x={null} />, document.body);
+		expect(div.getAttribute("data-x")).toBe(null);
+	});
+
+	test("attr: prefix removes attribute when false", () => {
+		renderer.render(<div attr:data-x="hello" />, document.body);
+		const div = document.body.firstChild as HTMLElement;
+		expect(div.getAttribute("data-x")).toBe("hello");
+
+		renderer.render(<div attr:data-x={false} />, document.body);
+		expect(div.getAttribute("data-x")).toBe(null);
+	});
+
+	test("attr: prefix sets empty string when true", () => {
+		renderer.render(<div attr:data-x={true} />, document.body);
+		const div = document.body.firstChild as HTMLElement;
+		expect(div.getAttribute("data-x")).toBe("");
+	});
+
+	test("object classnames basic", () => {
+		renderer.render(
+			<div
+				class={{
+					active: true,
+					disabled: false,
+					primary: true,
+				}}
+			>
+				Test
+			</div>,
+			document.body,
+		);
+
+		const element = document.querySelector("div")!;
+		expect(element.classList.contains("active")).toBeTruthy();
+		expect(element.classList.contains("disabled")).toBeFalsy();
+		expect(element.classList.contains("primary")).toBeTruthy();
+	});
+
+	test("object classnames update", () => {
+		renderer.render(
+			<div
+				class={{
+					active: true,
+					disabled: false,
+					primary: true,
+				}}
+			>
+				Test
+			</div>,
+			document.body,
+		);
+
+		let element = document.querySelector("div")!;
+		expect(element.classList.contains("active")).toBeTruthy();
+		expect(element.classList.contains("primary")).toBeTruthy();
+		expect(element.classList.contains("disabled")).toBeFalsy();
+		expect(element.classList.contains("warning")).toBeFalsy();
+
+		// Update classnames
+		renderer.render(
+			<div
+				class={{
+					active: false,
+					disabled: true,
+					primary: true,
+					warning: true,
+				}}
+			>
+				Test
+			</div>,
+			document.body,
+		);
+
+		element = document.querySelector("div")!;
+		expect(element.classList.contains("active")).toBeFalsy();
+		expect(element.classList.contains("disabled")).toBeTruthy();
+		expect(element.classList.contains("primary")).toBeTruthy();
+		expect(element.classList.contains("warning")).toBeTruthy();
+	});
+
+	test("object classnames string to object transition", () => {
+		// Start with string classnames
+		renderer.render(<div class="string-class other">Test</div>, document.body);
+
+		let element = document.querySelector("div")!;
+		expect(element.classList.contains("string-class")).toBeTruthy();
+		expect(element.classList.contains("other")).toBeTruthy();
+
+		// Switch to object classnames (should clear old string classes)
+		renderer.render(
+			<div
+				class={{
+					"object-class": true,
+					"new-class": true,
+				}}
+			>
+				Test
+			</div>,
+			document.body,
+		);
+
+		element = document.querySelector("div")!;
+		expect(element.classList.contains("string-class")).toBeFalsy();
+		expect(element.classList.contains("other")).toBeFalsy();
+		expect(element.classList.contains("object-class")).toBeTruthy();
+		expect(element.classList.contains("new-class")).toBeTruthy();
+	});
+
+	test("object classnames object to string transition", () => {
+		// Start with object classnames
+		renderer.render(
+			<div
+				class={{
+					"object-class": true,
+					"another-class": true,
+				}}
+			>
+				Test
+			</div>,
+			document.body,
+		);
+
+		let element = document.querySelector("div")!;
+		expect(element.classList.contains("object-class")).toBeTruthy();
+		expect(element.classList.contains("another-class")).toBeTruthy();
+
+		// Switch to string classnames (completely replaces class attribute)
+		renderer.render(<div class="string-class final">Test</div>, document.body);
+
+		element = document.querySelector("div")!;
+		expect(element.classList.contains("string-class")).toBeTruthy();
+		expect(element.classList.contains("final")).toBeTruthy();
+		expect(element.classList.contains("object-class")).toBeFalsy();
+		expect(element.classList.contains("another-class")).toBeFalsy();
+	});
+
+	test("object classnames with space-separated keys", () => {
+		renderer.render(
+			<div
+				class={{
+					"w-5 h-5 rounded-full flex items-center justify-center": true,
+					"bg-green-500 text-white": true,
+					"bg-gray-200 text-gray-400": false,
+				}}
+			>
+				Test
+			</div>,
+			document.body,
+		);
+
+		const element = document.querySelector("div")!;
+		// All classes from truthy keys should be present
+		expect(element.classList.contains("w-5")).toBeTruthy();
+		expect(element.classList.contains("h-5")).toBeTruthy();
+		expect(element.classList.contains("rounded-full")).toBeTruthy();
+		expect(element.classList.contains("flex")).toBeTruthy();
+		expect(element.classList.contains("items-center")).toBeTruthy();
+		expect(element.classList.contains("justify-center")).toBeTruthy();
+		expect(element.classList.contains("bg-green-500")).toBeTruthy();
+		expect(element.classList.contains("text-white")).toBeTruthy();
+		// Classes from falsy keys should not be present
+		expect(element.classList.contains("bg-gray-200")).toBeFalsy();
+		expect(element.classList.contains("text-gray-400")).toBeFalsy();
+	});
+
+	test("object classnames with space-separated keys update", () => {
+		renderer.render(
+			<div
+				class={{
+					"base-class shared": true,
+					"variant-a extra-a": true,
+					"variant-b extra-b": false,
+				}}
+			>
+				Test
+			</div>,
+			document.body,
+		);
+
+		let element = document.querySelector("div")!;
+		expect(element.classList.contains("base-class")).toBeTruthy();
+		expect(element.classList.contains("shared")).toBeTruthy();
+		expect(element.classList.contains("variant-a")).toBeTruthy();
+		expect(element.classList.contains("extra-a")).toBeTruthy();
+		expect(element.classList.contains("variant-b")).toBeFalsy();
+		expect(element.classList.contains("extra-b")).toBeFalsy();
+
+		// Update: swap which variant is active
+		renderer.render(
+			<div
+				class={{
+					"base-class shared": true,
+					"variant-a extra-a": false,
+					"variant-b extra-b": true,
+				}}
+			>
+				Test
+			</div>,
+			document.body,
+		);
+
+		element = document.querySelector("div")!;
+		expect(element.classList.contains("base-class")).toBeTruthy();
+		expect(element.classList.contains("shared")).toBeTruthy();
+		expect(element.classList.contains("variant-a")).toBeFalsy();
+		expect(element.classList.contains("extra-a")).toBeFalsy();
+		expect(element.classList.contains("variant-b")).toBeTruthy();
+		expect(element.classList.contains("extra-b")).toBeTruthy();
+	});
+
+	test("object classnames with overlapping space-separated keys", () => {
+		// When two keys share a class, toggling one shouldn't remove the shared class
+		renderer.render(
+			<div
+				class={{
+					"a b": true,
+					"b c": true,
+				}}
+			>
+				Test
+			</div>,
+			document.body,
+		);
+
+		let element = document.querySelector("div")!;
+		expect(element.classList.contains("a")).toBeTruthy();
+		expect(element.classList.contains("b")).toBeTruthy();
+		expect(element.classList.contains("c")).toBeTruthy();
+
+		// Toggle first key off - "b" should remain because "b c" is still true
+		renderer.render(
+			<div
+				class={{
+					"a b": false,
+					"b c": true,
+				}}
+			>
+				Test
+			</div>,
+			document.body,
+		);
+
+		element = document.querySelector("div")!;
+		expect(element.classList.contains("a")).toBeFalsy();
+		expect(element.classList.contains("b")).toBeTruthy(); // Still present from "b c"
+		expect(element.classList.contains("c")).toBeTruthy();
+
+		// Toggle both off
+		renderer.render(
+			<div
+				class={{
+					"a b": false,
+					"b c": false,
+				}}
+			>
+				Test
+			</div>,
+			document.body,
+		);
+
+		element = document.querySelector("div")!;
+		expect(element.classList.contains("a")).toBeFalsy();
+		expect(element.classList.contains("b")).toBeFalsy();
+		expect(element.classList.contains("c")).toBeFalsy();
+	});
+
+	test("relative src should not cause unnecessary updates", () => {
+		// Track how many times src property is set
+		let srcSetCount = 0;
+		const originalDescriptor = Object.getOwnPropertyDescriptor(
+			HTMLIFrameElement.prototype,
+			"src",
+		)!;
+		Object.defineProperty(HTMLIFrameElement.prototype, "src", {
+			get: originalDescriptor.get,
+			set(value) {
+				srcSetCount++;
+				originalDescriptor.set!.call(this, value);
+			},
+			configurable: true,
+		});
+
+		try {
+			// Initial render
+			renderer.render(<iframe src="/test-path" />, document.body);
+			expect(srcSetCount).toBe(
+				1,
+			) /* src should be set once on initial render */;
+
+			// Re-render with same src
+			renderer.render(<iframe src="/test-path" />, document.body);
+			expect(srcSetCount).toBe(
+				1,
+			) /* src should not be set again when unchanged */;
+
+			// Re-render with different src
+			renderer.render(<iframe src="/different-path" />, document.body);
+			expect(srcSetCount).toBe(2) /* src should be set when changed */;
+		} finally {
+			// Restore original property
+			Object.defineProperty(
+				HTMLIFrameElement.prototype,
+				"src",
+				originalDescriptor,
+			);
+		}
+	});
+
+	test("relative href should not cause unnecessary updates", () => {
+		// Track how many times href property is set
+		let hrefSetCount = 0;
+		const originalDescriptor = Object.getOwnPropertyDescriptor(
+			HTMLAnchorElement.prototype,
+			"href",
+		)!;
+		Object.defineProperty(HTMLAnchorElement.prototype, "href", {
+			get: originalDescriptor.get,
+			set(value) {
+				hrefSetCount++;
+				originalDescriptor.set!.call(this, value);
+			},
+			configurable: true,
+		});
+
+		try {
+			// Initial render
+			renderer.render(<a href="/test-link">Link</a>, document.body);
+			expect(hrefSetCount).toBe(
+				1,
+			) /* href should be set once on initial render */;
+
+			// Re-render with same href
+			renderer.render(<a href="/test-link">Link</a>, document.body);
+			expect(hrefSetCount).toBe(
+				1,
+			) /* href should not be set again when unchanged */;
+
+			// Re-render with different href
+			renderer.render(<a href="/different-link">Link</a>, document.body);
+			expect(hrefSetCount).toBe(2) /* href should be set when changed */;
+		} finally {
+			// Restore original property
+			Object.defineProperty(
+				HTMLAnchorElement.prototype,
+				"href",
+				originalDescriptor,
+			);
+		}
+	});
+
+	test("absolute URLs should work correctly for src", () => {
+		let srcSetCount = 0;
+		const originalDescriptor = Object.getOwnPropertyDescriptor(
+			HTMLIFrameElement.prototype,
+			"src",
+		)!;
+		Object.defineProperty(HTMLIFrameElement.prototype, "src", {
+			get: originalDescriptor.get,
+			set(value) {
+				srcSetCount++;
+				originalDescriptor.set!.call(this, value);
+			},
+			configurable: true,
+		});
+
+		try {
+			// Initial render with absolute URL
+			renderer.render(<iframe src="https://example.com/page" />, document.body);
+			expect(srcSetCount).toBe(1);
+
+			// Re-render with same absolute URL
+			renderer.render(<iframe src="https://example.com/page" />, document.body);
+			expect(srcSetCount).toBe(
+				1,
+			) /* absolute src should not be set again when unchanged */;
+		} finally {
+			Object.defineProperty(
+				HTMLIFrameElement.prototype,
+				"src",
+				originalDescriptor,
+			);
+		}
+	});
+
+	// Prop patching: two-loop iteration (removals then updates)
+	test("simultaneous prop add, remove, and update", () => {
+		const div = renderer.render(
+			<div id="old" data-a="1" data-b="2" />,
+			document.body,
+		) as HTMLElement;
+		expect(div.id).toBe("old");
+		expect(div.getAttribute("data-a")).toBe("1");
+		expect(div.getAttribute("data-b")).toBe("2");
+
+		renderer.render(
+			<div id="new" data-b="changed" data-c="3" />,
+			document.body,
+		);
+		expect(div.id).toBe("new"); // updated
+		expect(div.getAttribute("data-a")).toBe(null); // removed
+		expect(div.getAttribute("data-b")).toBe("changed"); // updated
+		expect(div.getAttribute("data-c")).toBe("3"); // added
+	});
+
+	test("remove all props", () => {
+		const div = renderer.render(
+			<div dir="rtl" data-a="1" data-b="2" />,
+			document.body,
+		) as HTMLElement;
+		expect(div.dir).toBe("rtl");
+		expect(div.getAttribute("data-a")).toBe("1");
+
+		renderer.render(<div />, document.body);
+		expect(div.dir).toBe("");
+		expect(div.getAttribute("data-a")).toBe(null);
+		expect(div.getAttribute("data-b")).toBe(null);
+	});
+
+	test("add props to element that had none", () => {
+		const div = renderer.render(<div />, document.body) as HTMLElement;
+		expect(div.id).toBe("");
+
+		renderer.render(<div id="added" data-x="y" />, document.body);
+		expect(div.id).toBe("added");
+		expect(div.getAttribute("data-x")).toBe("y");
+	});
+
+	test("event handler swap across renders", () => {
+		const calls: string[] = [];
+		renderer.render(<button onclick={() => calls.push("a")} />, document.body);
+		const button = document.body.firstChild as HTMLButtonElement;
+		button.click();
+		expect(calls).toEqual(["a"]);
+
+		renderer.render(<button onclick={() => calls.push("b")} />, document.body);
+		button.click();
+		expect(calls).toEqual(["a", "b"]);
+	});
+
+	test("event handler removal", () => {
+		const calls: string[] = [];
+		renderer.render(
+			<button onclick={() => calls.push("clicked")} />,
+			document.body,
+		);
+		const button = document.body.firstChild as HTMLButtonElement;
+		button.click();
+		expect(calls).toEqual(["clicked"]);
+
+		renderer.render(<button />, document.body);
+		button.click();
+		expect(calls).toEqual(["clicked"]); // no new call after removal
+	});
+
+	test("event handler add and remove different events simultaneously", () => {
+		const calls: string[] = [];
+		renderer.render(<div onclick={() => calls.push("click")} />, document.body);
+		const div = document.body.firstChild as HTMLDivElement;
+		div.click();
+		expect(calls).toEqual(["click"]);
+
+		// Remove onclick, add onmouseenter
+		renderer.render(
+			<div onmouseenter={() => calls.push("mouseenter")} />,
+			document.body,
+		);
+		div.click();
+		expect(calls).toEqual(["click"]); // onclick removed
+		div.dispatchEvent(new MouseEvent("mouseenter"));
+		expect(calls).toEqual(["click", "mouseenter"]); // onmouseenter added
+	});
+
+	// Style object two-loop: partial overlap
+	test("style object partial overlap across renders", () => {
+		const div = renderer.render(
+			<div style={{color: "red", fontSize: "12px", margin: "5px"}} />,
+			document.body,
+		) as HTMLElement;
+		expect(div.style.color).toBe("red");
+		expect(div.style.fontSize).toBe("12px");
+		expect(div.style.margin).toBe("5px");
+
+		// color removed, fontSize updated, padding added, margin removed
+		renderer.render(
+			<div style={{fontSize: "14px", padding: "10px"}} />,
+			document.body,
+		);
+		expect(div.style.color).toBe(""); // removed
+		expect(div.style.fontSize).toBe("14px"); // updated
+		expect(div.style.margin).toBe(""); // removed
+		expect(div.style.padding).toBe("10px"); // added
+	});
+
+	test("style object with explicit null values", () => {
+		const div = renderer.render(
+			<div style={{color: "red", fontSize: "12px", margin: "5px"}} />,
+			document.body,
+		) as HTMLElement;
+		expect(div.style.color).toBe("red");
+		expect(div.style.fontSize).toBe("12px");
+		expect(div.style.margin).toBe("5px");
+
+		// Explicitly null out color, keep fontSize, update margin
+		renderer.render(
+			<div style={{color: null, fontSize: "12px", margin: "10px"}} />,
+			document.body,
+		);
+		expect(div.style.color).toBe(""); // explicitly removed
+		expect(div.style.fontSize).toBe("12px"); // unchanged
+		expect(div.style.margin).toBe("10px"); // updated
+	});
+
+	test("style object to empty object clears all styles", () => {
+		const div = renderer.render(
+			<div style={{color: "red", fontSize: "12px"}} />,
+			document.body,
+		) as HTMLElement;
+		expect(div.style.color).toBe("red");
+		expect(div.style.fontSize).toBe("12px");
+
+		renderer.render(<div style={{}} />, document.body);
+		expect(div.style.color).toBe(""); // removed
+		expect(div.style.fontSize).toBe(""); // removed
+	});
+
+	test("style object completely disjoint sets across renders", () => {
+		const div = renderer.render(
+			<div style={{color: "red", margin: "5px"}} />,
+			document.body,
+		) as HTMLElement;
+		expect(div.style.color).toBe("red");
+		expect(div.style.margin).toBe("5px");
+
+		// Completely different properties
+		renderer.render(
+			<div style={{padding: "10px", border: "1px solid black"}} />,
+			document.body,
+		);
+		expect(div.style.color).toBe(""); // removed
+		expect(div.style.margin).toBe(""); // removed
+		expect(div.style.padding).toBe("10px"); // added
+		expect(div.style.border).toBe("1px solid black"); // added
+	});
+
+	// Class object two-loop: partial overlap
+	test("class object partial overlap across renders", () => {
+		renderer.render(
+			<div class={{active: true, highlight: true, large: true}}>Test</div>,
+			document.body,
+		);
+		let div = document.querySelector("div")!;
+		expect(div.classList.contains("active")).toBeTruthy();
+		expect(div.classList.contains("highlight")).toBeTruthy();
+		expect(div.classList.contains("large")).toBeTruthy();
+
+		// active removed, highlight kept, small added, large removed
+		renderer.render(
+			<div class={{active: false, highlight: true, small: true}}>Test</div>,
+			document.body,
+		);
+		expect(div.classList.contains("active")).toBeFalsy(); // removed
+		expect(div.classList.contains("highlight")).toBeTruthy(); // kept
+		expect(div.classList.contains("large")).toBeFalsy(); // removed (not in new)
+		expect(div.classList.contains("small")).toBeTruthy(); // added
+	});
+
+	test("class object all classes removed", () => {
+		renderer.render(
+			<div class={{a: true, b: true, c: true}}>Test</div>,
+			document.body,
+		);
+		let div = document.querySelector("div")!;
+		expect(div.classList.contains("a")).toBeTruthy();
+		expect(div.classList.contains("b")).toBeTruthy();
+		expect(div.classList.contains("c")).toBeTruthy();
+
+		renderer.render(
+			<div class={{a: false, b: false, c: false}}>Test</div>,
+			document.body,
+		);
+		expect(div.classList.contains("a")).toBeFalsy();
+		expect(div.classList.contains("b")).toBeFalsy();
+		expect(div.classList.contains("c")).toBeFalsy();
+	});
+
+	test("class object to empty object clears classes", () => {
+		renderer.render(<div class={{x: true, y: true}}>Test</div>, document.body);
+		let div = document.querySelector("div")!;
+		expect(div.classList.contains("x")).toBeTruthy();
+		expect(div.classList.contains("y")).toBeTruthy();
+
+		renderer.render(<div class={{}}>Test</div>, document.body);
+		expect(div.classList.contains("x")).toBeFalsy();
+		expect(div.classList.contains("y")).toBeFalsy();
+	});
+
+	// Mixed prop types changing simultaneously
+	test("style, class, and attributes all change in single render", () => {
+		renderer.render(
+			<div id="old" style={{color: "red"}} class={{active: true}} data-x="1">
+				Test
+			</div>,
+			document.body,
+		);
+		let div = document.querySelector("div")!;
+		expect(div.id).toBe("old");
+		expect(div.style.color).toBe("red");
+		expect(div.classList.contains("active")).toBeTruthy();
+		expect(div.getAttribute("data-x")).toBe("1");
+
+		renderer.render(
+			<div
+				id="new"
+				style={{fontSize: "14px"}}
+				class={{highlight: true}}
+				data-y="2"
+			>
+				Test
+			</div>,
+			document.body,
+		);
+		expect(div.id).toBe("new"); // updated
+		expect(div.style.color).toBe(""); // removed
+		expect(div.style.fontSize).toBe("14px"); // added
+		expect(div.classList.contains("active")).toBeFalsy(); // removed
+		expect(div.classList.contains("highlight")).toBeTruthy(); // added
+		expect(div.getAttribute("data-x")).toBe(null); // removed
+		expect(div.getAttribute("data-y")).toBe("2"); // added
+	});
+
+	test("htmlFor sets for attribute", () => {
+		renderer.render(<label htmlFor="email">Email</label>, document.body);
+		const label = document.body.firstChild as HTMLLabelElement;
+		expect(label.getAttribute("for")).toBe("email");
+	});
+
+	test("htmlFor removes for attribute when null", () => {
+		renderer.render(<label htmlFor="email">Email</label>, document.body);
+		renderer.render(<label htmlFor={null}>Email</label>, document.body);
+		const label = document.body.firstChild as HTMLLabelElement;
+		expect(label.getAttribute("for")).toBe(null);
+	});
+
+	test("htmlFor skipped when for is also present", () => {
+		renderer.render(
+			<label for="email" htmlFor="other">
+				Email
+			</label>,
+			document.body,
+		);
+		const label = document.body.firstChild as HTMLLabelElement;
+		expect(label.getAttribute("for")).toBe("email");
+	});
+
+	test("className skipped when class is also present", () => {
+		renderer.render(<div class="real" className="ignored" />, document.body);
+		const div = document.body.firstChild as HTMLDivElement;
+		expect(div.getAttribute("class")).toBe("real");
+	});
+
+	test("dangerouslySetInnerHTML sets innerHTML", () => {
+		renderer.render(
+			<div dangerouslySetInnerHTML={{__html: "<b>bold</b>"}} />,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><b>bold</b></div>");
+	});
+
+	test("dangerouslySetInnerHTML does not insert children", () => {
+		renderer.render(
+			<div dangerouslySetInnerHTML={{__html: "<b>bold</b>"}} />,
+			document.body,
+		);
+		const div = document.body.firstChild as HTMLElement;
+		expect(div.innerHTML).toBe("<b>bold</b>");
+		expect(div.childNodes.length).toBe(1);
+	});
+
+	test("dangerouslySetInnerHTML updates", () => {
+		renderer.render(
+			<div dangerouslySetInnerHTML={{__html: "<b>first</b>"}} />,
+			document.body,
+		);
+		renderer.render(
+			<div dangerouslySetInnerHTML={{__html: "<i>second</i>"}} />,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><i>second</i></div>");
+	});
+
+	// Child cardinality transitions — exercises the diffChild/diffChildren boundary
+	test("zero to one child", () => {
+		renderer.render(<div />, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		renderer.render(
+			<div>
+				<span>a</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>a</span></div>");
+	});
+
+	test("one to zero children", () => {
+		renderer.render(
+			<div>
+				<span>a</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>a</span></div>");
+		renderer.render(<div />, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+	});
+
+	test("one to many children", () => {
+		renderer.render(
+			<div>
+				<span>a</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>a</span></div>");
 		renderer.render(
 			<div>
 				<span>a</span>
@@ -1729,341 +1415,674 @@ test("rapid cardinality cycling", () => {
 			</div>,
 			document.body,
 		);
-		Assert.is(
-			document.body.innerHTML,
+		expect(document.body.innerHTML).toBe(
 			"<div><span>a</span><span>b</span><span>c</span></div>",
-			`round ${round}: many`,
 		);
-	}
-});
+	});
 
-test("async component as single child", async () => {
-	async function Async({msg}: {msg: string}) {
-		await new Promise((r) => setTimeout(r, 10));
-		return <span>{msg}</span>;
-	}
-
-	const p1 = renderer.render(
-		<div>
-			<Async msg="hello" />
-		</div>,
-		document.body,
-	);
-	// while async is pending, nothing is committed yet
-	Assert.is(document.body.innerHTML, "");
-	await p1;
-	Assert.is(document.body.innerHTML, "<div><span>hello</span></div>");
-
-	// update the async component
-	const p2 = renderer.render(
-		<div>
-			<Async msg="world" />
-		</div>,
-		document.body,
-	);
-	await p2;
-	Assert.is(document.body.innerHTML, "<div><span>world</span></div>");
-
-	// transition from async single child to sync single child
-	renderer.render(
-		<div>
-			<b>sync</b>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><b>sync</b></div>");
-});
-
-test("array child implicitly wrapped in fragment", () => {
-	// An array child gets wrapped in a Fragment by narrow(), exercising
-	// diffChild placing a Fragment then recursing into diffChildren.
-	const items = [<li key="a">a</li>, <li key="b">b</li>];
-	renderer.render(<ul>{items}</ul>, document.body);
-	Assert.is(document.body.innerHTML, "<ul><li>a</li><li>b</li></ul>");
-
-	// Transition from array (Fragment) to single element
-	renderer.render(
-		<ul>
-			<li>only</li>
-		</ul>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<ul><li>only</li></ul>");
-
-	// Back to array
-	renderer.render(
-		<ul>{[<li key="x">x</li>, <li key="y">y</li>, <li key="z">z</li>]}</ul>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<ul><li>x</li><li>y</li><li>z</li></ul>");
-});
-
-test("Copy element as single child", () => {
-	function* Counter(this: Context): Generator {
-		let count = 0;
-		for (const _ of this) {
-			count++;
-			yield <span>{count}</span>;
-		}
-	}
-
-	renderer.render(
-		<div>
-			<Counter />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	renderer.render(
-		<div>
-			<Counter />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>2</span></div>");
-	// Copy should preserve the component without re-rendering
-	renderer.render(
-		<div>
-			<Copy />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>2</span></div>");
-	// Render again — Copy doesn't increment the counter
-	renderer.render(
-		<div>
-			<Copy />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>2</span></div>");
-	// Regular render increments again
-	renderer.render(
-		<div>
-			<Counter />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>3</span></div>");
-});
-
-test("same element reference skips re-render", () => {
-	let renderCount = 0;
-	function Tracker(): ReturnType<typeof createElement> {
-		renderCount++;
-		return <span>rendered</span>;
-	}
-
-	const el = <Tracker />;
-	renderer.render(<div>{el}</div>, document.body);
-	Assert.is(renderCount, 1);
-	Assert.is(document.body.innerHTML, "<div><span>rendered</span></div>");
-	// Same reference — should skip
-	renderer.render(<div>{el}</div>, document.body);
-	Assert.is(renderCount, 1);
-	// New element — should re-render
-	renderer.render(
-		<div>
-			<Tracker />
-		</div>,
-		document.body,
-	);
-	Assert.is(renderCount, 2);
-});
-
-test("nullish child unmounts component subtree", () => {
-	const cleanups: string[] = [];
-	function* Child(this: Context, {name}: {name: string}): Generator {
-		try {
-			for ({name} of this) {
-				yield <span>{name}</span>;
-			}
-		} finally {
-			cleanups.push(name);
-		}
-	}
-
-	renderer.render(
-		<div>
-			<Child name="a" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>a</span></div>");
-	Assert.equal(cleanups, []);
-
-	// null should unmount the component and fire cleanup
-	renderer.render(<div>{null}</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	Assert.equal(cleanups, ["a"]);
-
-	// mount again
-	renderer.render(
-		<div>
-			<Child name="b" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>b</span></div>");
-
-	// undefined should also unmount
-	renderer.render(<div>{undefined}</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	Assert.equal(cleanups, ["a", "b"]);
-
-	// false should also unmount
-	renderer.render(
-		<div>
-			<Child name="c" />
-		</div>,
-		document.body,
-	);
-	renderer.render(<div>{false}</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	Assert.equal(cleanups, ["a", "b", "c"]);
-});
-
-test("nullish child unmounts nested component tree", () => {
-	const cleanups: string[] = [];
-	function* Leaf(this: Context, {id}: {id: string}): Generator {
-		try {
-			for ({id} of this) {
-				yield <span>{id}</span>;
-			}
-		} finally {
-			cleanups.push(id);
-		}
-	}
-
-	function Branch({id}: {id: string}) {
-		return (
+	test("many to one child", () => {
+		renderer.render(
 			<div>
-				<Leaf id={`${id}-1`} />
-				<Leaf id={`${id}-2`} />
-			</div>
+				<span>a</span>
+				<span>b</span>
+				<span>c</span>
+			</div>,
+			document.body,
 		);
-	}
+		expect(document.body.innerHTML).toBe(
+			"<div><span>a</span><span>b</span><span>c</span></div>",
+		);
+		renderer.render(
+			<div>
+				<span>only</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>only</span></div>");
+	});
 
-	renderer.render(
-		<div>
-			<Branch id="a" />
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><div><span>a-1</span><span>a-2</span></div></div>",
-	);
+	test("many to zero children", () => {
+		renderer.render(
+			<div>
+				<span>a</span>
+				<span>b</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>a</span><span>b</span></div>",
+		);
+		renderer.render(<div />, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+	});
 
-	// Nulling out the single Branch child should unmount both leaves
-	renderer.render(<div>{null}</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	Assert.equal(cleanups.sort(), ["a-1", "a-2"]);
-});
+	test("zero to many children", () => {
+		renderer.render(<div />, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		renderer.render(
+			<div>
+				<span>a</span>
+				<span>b</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>a</span><span>b</span></div>",
+		);
+	});
 
-test("number child", () => {
-	renderer.render(<div>{42}</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div>42</div>");
-	renderer.render(<div>{0}</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div>0</div>");
-	// transition number → element
-	renderer.render(
-		<div>
-			<span>text</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>text</span></div>");
-	// transition element → number
-	renderer.render(<div>{99}</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div>99</div>");
-});
+	test("one to one child, same tag reuse", () => {
+		renderer.render(
+			<div>
+				<span>first</span>
+			</div>,
+			document.body,
+		);
+		const span = document.body.querySelector("span")!;
+		renderer.render(
+			<div>
+				<span>second</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>second</span></div>");
+		expect(document.body.querySelector("span")).toBe(
+			span,
+		) /* should reuse the span element */;
+	});
 
-test("boolean and undefined children clear content", () => {
-	renderer.render(
-		<div>
-			<span>hello</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>hello</span></div>");
-	renderer.render(<div>{false}</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	renderer.render(
-		<div>
-			<span>back</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>back</span></div>");
-	renderer.render(<div>{undefined}</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	renderer.render(
-		<div>
-			<span>again</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>again</span></div>");
-	renderer.render(<div>{true}</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-});
+	test("one to one child, different tag", () => {
+		renderer.render(
+			<div>
+				<span>hello</span>
+			</div>,
+			document.body,
+		);
+		renderer.render(
+			<div>
+				<b>hello</b>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><b>hello</b></div>");
+	});
 
-test("generator component preserves state through single-child path", () => {
-	function* Stateful(this: Context, {label}: {label: string}): Generator {
-		let renders = 0;
-		for ({label} of this) {
-			renders++;
-			yield (
-				<span>
-					{label}:{renders}
-				</span>
+	test("one text to one element", () => {
+		renderer.render(<div>hello</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div>hello</div>");
+		renderer.render(
+			<div>
+				<span>hello</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>hello</span></div>");
+	});
+
+	test("one element to one text", () => {
+		renderer.render(
+			<div>
+				<span>hello</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>hello</span></div>");
+		renderer.render(<div>hello</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div>hello</div>");
+	});
+
+	test("one to one child with null intermediate", () => {
+		renderer.render(
+			<div>
+				<span>a</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>a</span></div>");
+		renderer.render(<div>{null}</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		renderer.render(
+			<div>
+				<span>b</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>b</span></div>");
+	});
+
+	test("one to one child with boolean intermediate", () => {
+		renderer.render(
+			<div>
+				<span>a</span>
+			</div>,
+			document.body,
+		);
+		renderer.render(<div>{false}</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		renderer.render(
+			<div>
+				<span>b</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>b</span></div>");
+	});
+
+	test("one child with key to one child with different key", () => {
+		renderer.render(
+			<div>
+				<span key="a">a</span>
+			</div>,
+			document.body,
+		);
+		const span1 = document.body.querySelector("span")!;
+		renderer.render(
+			<div>
+				<span key="b">b</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>b</span></div>");
+		expect(document.body.querySelector("span")).not.toBe(
+			span1,
+		) /* should create a new span for different key */;
+	});
+
+	test("one child with key to one child without key", () => {
+		renderer.render(
+			<div>
+				<span key="a">a</span>
+			</div>,
+			document.body,
+		);
+		const span1 = document.body.querySelector("span")!;
+		renderer.render(
+			<div>
+				<span>b</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>b</span></div>");
+		expect(document.body.querySelector("span")).not.toBe(
+			span1,
+		) /* should create a new span when key removed */;
+	});
+
+	test("one child without key to one child with key", () => {
+		renderer.render(
+			<div>
+				<span>a</span>
+			</div>,
+			document.body,
+		);
+		const span1 = document.body.querySelector("span")!;
+		renderer.render(
+			<div>
+				<span key="b">b</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>b</span></div>");
+		expect(document.body.querySelector("span")).not.toBe(
+			span1,
+		) /* should create a new span when key added */;
+	});
+
+	test("one keyed child to many children", () => {
+		renderer.render(
+			<div>
+				<span key="a">a</span>
+			</div>,
+			document.body,
+		);
+		renderer.render(
+			<div>
+				<span key="a">a</span>
+				<span key="b">b</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>a</span><span>b</span></div>",
+		);
+	});
+
+	test("many children to one keyed child", () => {
+		renderer.render(
+			<div>
+				<span key="a">a</span>
+				<span key="b">b</span>
+			</div>,
+			document.body,
+		);
+		renderer.render(
+			<div>
+				<span key="a">a</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>a</span></div>");
+	});
+
+	test("fragment single child transition", () => {
+		function Component({count}: {count: number}) {
+			const children = [];
+			for (let i = 0; i < count; i++) {
+				children.push(<span>{i}</span>);
+			}
+			return <div>{children}</div>;
+		}
+
+		renderer.render(<Component count={1} />, document.body);
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		renderer.render(<Component count={3} />, document.body);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>0</span><span>1</span><span>2</span></div>",
+		);
+		renderer.render(<Component count={1} />, document.body);
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		renderer.render(<Component count={0} />, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		renderer.render(<Component count={1} />, document.body);
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+	});
+
+	test("component single child transition", () => {
+		function* Inner(this: Context, {message}: {message: string}): Generator {
+			let count = 0;
+			for ({message} of this) {
+				count++;
+				yield (
+					<span>
+						{message} ({count})
+					</span>
+				);
+			}
+		}
+
+		renderer.render(
+			<div>
+				<Inner message="a" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>a (1)</span></div>");
+		renderer.render(
+			<div>
+				<Inner message="b" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>b (2)</span></div>");
+		renderer.render(<div>{null}</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		// Re-mounting should reset the generator
+		renderer.render(
+			<div>
+				<Inner message="c" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>c (1)</span></div>");
+	});
+
+	test("rapid cardinality cycling", () => {
+		for (let round = 0; round < 3; round++) {
+			renderer.render(<div />, document.body);
+			expect(document.body.innerHTML).toBe(
+				"<div></div>",
+			) /* `round ${round}: zero` */;
+
+			renderer.render(
+				<div>
+					<span>one</span>
+				</div>,
+				document.body,
+			);
+			expect(document.body.innerHTML).toBe(
+				"<div><span>one</span></div>",
+			) /* `round ${round}: one` */;
+
+			renderer.render(
+				<div>
+					<span>a</span>
+					<span>b</span>
+					<span>c</span>
+				</div>,
+				document.body,
+			);
+			expect(document.body.innerHTML).toBe(
+				"<div><span>a</span><span>b</span><span>c</span></div>",
+			) /* `round ${round}: many` */;
+		}
+	});
+
+	test("async component as single child", async () => {
+		async function Async({msg}: {msg: string}) {
+			await new Promise((r) => setTimeout(r, 10));
+			return <span>{msg}</span>;
+		}
+
+		const p1 = renderer.render(
+			<div>
+				<Async msg="hello" />
+			</div>,
+			document.body,
+		);
+		// while async is pending, nothing is committed yet
+		expect(document.body.innerHTML).toBe("");
+		await p1;
+		expect(document.body.innerHTML).toBe("<div><span>hello</span></div>");
+
+		// update the async component
+		const p2 = renderer.render(
+			<div>
+				<Async msg="world" />
+			</div>,
+			document.body,
+		);
+		await p2;
+		expect(document.body.innerHTML).toBe("<div><span>world</span></div>");
+
+		// transition from async single child to sync single child
+		renderer.render(
+			<div>
+				<b>sync</b>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><b>sync</b></div>");
+	});
+
+	test("array child implicitly wrapped in fragment", () => {
+		// An array child gets wrapped in a Fragment by narrow(), exercising
+		// diffChild placing a Fragment then recursing into diffChildren.
+		const items = [<li key="a">a</li>, <li key="b">b</li>];
+		renderer.render(<ul>{items}</ul>, document.body);
+		expect(document.body.innerHTML).toBe("<ul><li>a</li><li>b</li></ul>");
+
+		// Transition from array (Fragment) to single element
+		renderer.render(
+			<ul>
+				<li>only</li>
+			</ul>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<ul><li>only</li></ul>");
+
+		// Back to array
+		renderer.render(
+			<ul>{[<li key="x">x</li>, <li key="y">y</li>, <li key="z">z</li>]}</ul>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<ul><li>x</li><li>y</li><li>z</li></ul>",
+		);
+	});
+
+	test("Copy element as single child", () => {
+		function* Counter(this: Context): Generator {
+			let count = 0;
+			for (const _ of this) {
+				count++;
+				yield <span>{count}</span>;
+			}
+		}
+
+		renderer.render(
+			<div>
+				<Counter />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		renderer.render(
+			<div>
+				<Counter />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>2</span></div>");
+		// Copy should preserve the component without re-rendering
+		renderer.render(
+			<div>
+				<Copy />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>2</span></div>");
+		// Render again — Copy doesn't increment the counter
+		renderer.render(
+			<div>
+				<Copy />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>2</span></div>");
+		// Regular render increments again
+		renderer.render(
+			<div>
+				<Counter />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>3</span></div>");
+	});
+
+	test("same element reference skips re-render", () => {
+		let renderCount = 0;
+		function Tracker(): ReturnType<typeof createElement> {
+			renderCount++;
+			return <span>rendered</span>;
+		}
+
+		const el = <Tracker />;
+		renderer.render(<div>{el}</div>, document.body);
+		expect(renderCount).toBe(1);
+		expect(document.body.innerHTML).toBe("<div><span>rendered</span></div>");
+		// Same reference — should skip
+		renderer.render(<div>{el}</div>, document.body);
+		expect(renderCount).toBe(1);
+		// New element — should re-render
+		renderer.render(
+			<div>
+				<Tracker />
+			</div>,
+			document.body,
+		);
+		expect(renderCount).toBe(2);
+	});
+
+	test("nullish child unmounts component subtree", () => {
+		const cleanups: string[] = [];
+		function* Child(this: Context, {name}: {name: string}): Generator {
+			try {
+				for ({name} of this) {
+					yield <span>{name}</span>;
+				}
+			} finally {
+				cleanups.push(name);
+			}
+		}
+
+		renderer.render(
+			<div>
+				<Child name="a" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>a</span></div>");
+		expect(cleanups).toEqual([]);
+
+		// null should unmount the component and fire cleanup
+		renderer.render(<div>{null}</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		expect(cleanups).toEqual(["a"]);
+
+		// mount again
+		renderer.render(
+			<div>
+				<Child name="b" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>b</span></div>");
+
+		// undefined should also unmount
+		renderer.render(<div>{undefined}</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		expect(cleanups).toEqual(["a", "b"]);
+
+		// false should also unmount
+		renderer.render(
+			<div>
+				<Child name="c" />
+			</div>,
+			document.body,
+		);
+		renderer.render(<div>{false}</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		expect(cleanups).toEqual(["a", "b", "c"]);
+	});
+
+	test("nullish child unmounts nested component tree", () => {
+		const cleanups: string[] = [];
+		function* Leaf(this: Context, {id}: {id: string}): Generator {
+			try {
+				for ({id} of this) {
+					yield <span>{id}</span>;
+				}
+			} finally {
+				cleanups.push(id);
+			}
+		}
+
+		function Branch({id}: {id: string}) {
+			return (
+				<div>
+					<Leaf id={`${id}-1`} />
+					<Leaf id={`${id}-2`} />
+				</div>
 			);
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Stateful label="a" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>a:1</span></div>");
-	// Re-render with same tag — should reuse retainer and preserve state
-	renderer.render(
-		<div>
-			<Stateful label="b" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>b:2</span></div>");
-	renderer.render(
-		<div>
-			<Stateful label="c" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>c:3</span></div>");
-	// Transition to many — first Stateful is reused, second is new
-	renderer.render(
-		<div>
-			<Stateful label="x" />
-			<Stateful label="y" />
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>x:4</span><span>y:1</span></div>",
-	);
-	// Back to single — first Stateful keeps state, second unmounted
-	renderer.render(
-		<div>
-			<Stateful label="z" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>z:5</span></div>");
+		renderer.render(
+			<div>
+				<Branch id="a" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><div><span>a-1</span><span>a-2</span></div></div>",
+		);
+
+		// Nulling out the single Branch child should unmount both leaves
+		renderer.render(<div>{null}</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		expect(cleanups.sort()).toEqual(["a-1", "a-2"]);
+	});
+
+	test("number child", () => {
+		renderer.render(<div>{42}</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div>42</div>");
+		renderer.render(<div>{0}</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div>0</div>");
+		// transition number → element
+		renderer.render(
+			<div>
+				<span>text</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>text</span></div>");
+		// transition element → number
+		renderer.render(<div>{99}</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div>99</div>");
+	});
+
+	test("boolean and undefined children clear content", () => {
+		renderer.render(
+			<div>
+				<span>hello</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>hello</span></div>");
+		renderer.render(<div>{false}</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		renderer.render(
+			<div>
+				<span>back</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>back</span></div>");
+		renderer.render(<div>{undefined}</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		renderer.render(
+			<div>
+				<span>again</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>again</span></div>");
+		renderer.render(<div>{true}</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+	});
+
+	test("generator component preserves state through single-child path", () => {
+		function* Stateful(this: Context, {label}: {label: string}): Generator {
+			let renders = 0;
+			for ({label} of this) {
+				renders++;
+				yield (
+					<span>
+						{label}:{renders}
+					</span>
+				);
+			}
+		}
+
+		renderer.render(
+			<div>
+				<Stateful label="a" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>a:1</span></div>");
+		// Re-render with same tag — should reuse retainer and preserve state
+		renderer.render(
+			<div>
+				<Stateful label="b" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>b:2</span></div>");
+		renderer.render(
+			<div>
+				<Stateful label="c" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>c:3</span></div>");
+		// Transition to many — first Stateful is reused, second is new
+		renderer.render(
+			<div>
+				<Stateful label="x" />
+				<Stateful label="y" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>x:4</span><span>y:1</span></div>",
+		);
+		// Back to single — first Stateful keeps state, second unmounted
+		renderer.render(
+			<div>
+				<Stateful label="z" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>z:5</span></div>");
+	});
 });
-
-test.run();

--- a/test/errors.tsx
+++ b/test/errors.tsx
@@ -1,838 +1,829 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import * as Sinon from "sinon";
 
 import {createElement, Child, Context} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("errors");
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
-
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
-
-test("sync function throws", () => {
-	function Thrower(): never {
-		throw new Error("sync function throws");
-	}
-
-	try {
-		renderer.render(<Thrower />, document.body);
-		Assert.unreachable();
-	} catch (err: any) {
-		Assert.is(err.message, "sync function throws");
-	}
-});
-
-test("async function throws", async () => {
-	async function Thrower(): Promise<never> {
-		throw new Error("async function throws");
-	}
-
-	try {
-		await renderer.render(<Thrower />, document.body);
-		Assert.unreachable();
-	} catch (err: any) {
-		Assert.is(err.message, "async function throws");
-	}
-});
-
-test("sync gen throws", () => {
-	function* Thrower(this: Context) {
-		let i = 0;
-		for ({} of this) {
-			if (i >= 2) {
-				throw new Error("sync gen throws");
-			}
-
-			yield i++;
-		}
-	}
-
-	renderer.render(<Thrower />, document.body);
-	Assert.is(document.body.innerHTML, "0");
-	renderer.render(<Thrower />, document.body);
-	Assert.is(document.body.innerHTML, "1");
-
-	try {
-		renderer.render(<Thrower />, document.body);
-		Assert.unreachable();
-	} catch (err: any) {
-		Assert.is(err.message, "sync gen throws");
-	}
-});
-
-test("async gen for await throws", async () => {
-	async function* Thrower(this: Context) {
-		let i = 0;
-		for await ({} of this) {
-			if (i >= 2) {
-				throw new Error("async gen for await throws");
-			}
-
-			yield i++;
-		}
-	}
-
-	await renderer.render(<Thrower />, document.body);
-	Assert.is(document.body.innerHTML, "0");
-	await renderer.render(<Thrower />, document.body);
-	Assert.is(document.body.innerHTML, "1");
-	try {
-		await renderer.render(<Thrower />, document.body);
-		Assert.unreachable();
-	} catch (err: any) {
-		Assert.is(err.message, "async gen for await throws");
-	}
-});
-
-test("sync gen throws refresh call", () => {
-	let ctx!: Context;
-	function* Thrower(this: Context) {
-		ctx = this;
-		let i = 0;
-		for ({} of this) {
-			if (i >= 2) {
-				throw new Error("sync gen throws by refresh");
-			}
-
-			yield i++;
-		}
-	}
-
-	renderer.render(<Thrower />, document.body);
-	Assert.is(document.body.innerHTML, "0");
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "1");
-	try {
-		ctx.refresh();
-		Assert.unreachable();
-	} catch (err: any) {
-		Assert.is(err.message, "sync gen throws by refresh");
-	}
-});
-
-test("sync gen throws by parent refresh", () => {
-	function* Thrower(this: Context) {
-		let i = 0;
-		for ({} of this) {
-			if (i >= 2) {
-				throw new Error("sync gen throws by parent refresh");
-			}
-
-			yield i++;
-		}
-	}
-
-	let ctx!: Context;
-	function* Parent(this: Context) {
-		ctx = this;
-		for ({} of this) {
-			yield (
-				<div>
-					<Thrower />
-				</div>
-			);
-		}
-	}
-
-	renderer.render(<Parent />, document.body);
-	Assert.is(document.body.innerHTML, "<div>0</div>");
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div>1</div>");
-	try {
-		ctx.refresh();
-		Assert.unreachable();
-	} catch (err: any) {
-		Assert.is(err.message, "sync gen throws by parent refresh");
-	}
-});
-
-test("async gen throws by parent sync gen refresh", async () => {
-	async function* Thrower(this: Context) {
-		let i = 0;
-		for await ({} of this) {
-			if (i >= 2) {
-				throw new Error("async gen throws by parent sync gen refresh");
-			}
-
-			yield i++;
-		}
-	}
-
-	let ctx!: Context;
-	function* Parent(this: Context) {
-		ctx = this;
-		for ({} of this) {
-			yield (
-				<div>
-					<Thrower />
-				</div>
-			);
-		}
-	}
-
-	await renderer.render(<Parent />, document.body);
-	Assert.is(document.body.innerHTML, "<div>0</div>");
-	await ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div>1</div>");
-	const mock = Sinon.fake();
-	try {
-		await ctx.refresh();
-		Assert.unreachable();
-	} catch (err: any) {
-		Assert.is(err.message, "async gen throws by parent sync gen refresh");
-		mock();
-	}
-
-	Assert.is(mock.callCount, 1);
-});
-
-test("for await of throws in for await of", async () => {
-	/* eslint-disable require-yield */
-	async function* Thrower(this: Context) {
-		for await ({} of this) {
-			throw new Error("for await of throws in for await of");
-		}
-	}
-
-	async function* Parent(this: Context) {
-		for await ({} of this) {
-			yield (
-				<div>
-					<Thrower />
-				</div>
-			);
-		}
-	}
-
-	try {
-		await renderer.render(<Parent />, document.body);
-		Assert.unreachable();
-	} catch (err: any) {
-		Assert.is(err.message, "for await of throws in for await of");
-	}
-
-	Assert.is(document.body.innerHTML, "");
-});
-
-test("async gen throws by parent async gen refresh", async () => {
-	async function* Thrower(this: Context) {
-		let i = 0;
-		for await ({} of this) {
-			if (i >= 2) {
-				throw new Error("async gen throws by parent async gen refresh");
-			}
-
-			yield i++;
-		}
-	}
-
-	let parentCtx!: Context;
-	async function* Parent(this: Context) {
-		parentCtx = this;
-		for await ({} of this) {
-			yield (
-				<div>
-					<Thrower />
-				</div>
-			);
-		}
-	}
-
-	await renderer.render(<Parent />, document.body);
-	Assert.is(document.body.innerHTML, "<div>0</div>");
-	await parentCtx.refresh();
-	Assert.is(document.body.innerHTML, "<div>1</div>");
-	const mock = Sinon.fake();
-	try {
-		await parentCtx.refresh();
-		Assert.unreachable();
-	} catch (err: any) {
-		Assert.is(err.message, "async gen throws by parent async gen refresh");
-		mock();
-	}
-
-	Assert.is(mock.callCount, 1);
-});
-
-test("async gen returns after child throws", async () => {
-	async function Thrower(this: Context) {
-		throw new Error("async gen returns after child throws");
-	}
-
-	async function* Component(this: Context) {
-		try {
-			for await ({} of this) {
-				yield <Thrower />;
-			}
-		} catch (err: any) {
-			return <span>{err.message}</span>;
-		}
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(
-		document.body.innerHTML,
-		"<span>async gen returns after child throws</span>",
-	);
-});
-
-test("async gen throws independently", async () => {
-	async function* Thrower(this: Context) {
-		for await ({} of this) {
-			yield 1;
-			yield 2;
-			yield 3;
-			await new Promise((resolve) => setTimeout(resolve));
-			throw new Error("async gen throws independently");
-		}
-	}
-
-	let resolve: (err: Error) => void;
-	const err = new Promise<Error>((resolve1) => {
-		resolve = resolve1;
+describe("errors", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
 	});
-	const onUnhandledRejection = (ev: PromiseRejectionEvent) => {
-		if (ev.reason.message === "async gen throws independently") {
-			ev.preventDefault();
-			resolve(ev.reason);
+
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
+
+	test("sync function throws", () => {
+		function Thrower(): never {
+			throw new Error("sync function throws");
 		}
-	};
-	try {
-		window.addEventListener("unhandledrejection", onUnhandledRejection);
+
+		try {
+			renderer.render(<Thrower />, document.body);
+			throw new Error("unreachable");
+		} catch (err: any) {
+			expect(err.message).toBe("sync function throws");
+		}
+	});
+
+	test("async function throws", async () => {
+		async function Thrower(): Promise<never> {
+			throw new Error("async function throws");
+		}
+
+		try {
+			await renderer.render(<Thrower />, document.body);
+			throw new Error("unreachable");
+		} catch (err: any) {
+			expect(err.message).toBe("async function throws");
+		}
+	});
+
+	test("sync gen throws", () => {
+		function* Thrower(this: Context) {
+			let i = 0;
+			for ({} of this) {
+				if (i >= 2) {
+					throw new Error("sync gen throws");
+				}
+
+				yield i++;
+			}
+		}
+
+		renderer.render(<Thrower />, document.body);
+		expect(document.body.innerHTML).toBe("0");
+		renderer.render(<Thrower />, document.body);
+		expect(document.body.innerHTML).toBe("1");
+
+		try {
+			renderer.render(<Thrower />, document.body);
+			throw new Error("unreachable");
+		} catch (err: any) {
+			expect(err.message).toBe("sync gen throws");
+		}
+	});
+
+	test("async gen for await throws", async () => {
+		async function* Thrower(this: Context) {
+			let i = 0;
+			for await ({} of this) {
+				if (i >= 2) {
+					throw new Error("async gen for await throws");
+				}
+
+				yield i++;
+			}
+		}
 
 		await renderer.render(<Thrower />, document.body);
-		await new Promise((resolve) => setTimeout(resolve, 100));
-		Assert.is(document.body.innerHTML, "3");
-		Assert.is((await err).message, "async gen throws independently");
-	} finally {
-		window.removeEventListener("unhandledrejection", onUnhandledRejection);
-	}
-});
-
-test("async gen rethrows after child error", async () => {
-	const mock = Sinon.fake();
-	async function Thrower(this: Context) {
-		throw new Error("async gen rethrows after child error");
-	}
-
-	async function* Component(this: Context) {
+		expect(document.body.innerHTML).toBe("0");
+		await renderer.render(<Thrower />, document.body);
+		expect(document.body.innerHTML).toBe("1");
 		try {
-			for await (const _ of this) {
-				yield <Thrower />;
+			await renderer.render(<Thrower />, document.body);
+			throw new Error("unreachable");
+		} catch (err: any) {
+			expect(err.message).toBe("async gen for await throws");
+		}
+	});
+
+	test("sync gen throws refresh call", () => {
+		let ctx!: Context;
+		function* Thrower(this: Context) {
+			ctx = this;
+			let i = 0;
+			for ({} of this) {
+				if (i >= 2) {
+					throw new Error("sync gen throws by refresh");
+				}
+
+				yield i++;
 			}
-		} catch (err) {
-			mock();
-			throw new Error("async gen rethrows after child error 1");
 		}
-	}
 
-	try {
-		await renderer.render(<Component />, document.body);
-		Assert.unreachable();
-	} catch (err: any) {
-		Assert.is(err.message, "async gen rethrows after child error 1");
-	}
-
-	Assert.is(mock.callCount, 1);
-});
-
-test("async gen rethrows after child error in async gen", async () => {
-	const mock = Sinon.fake();
-	/* eslint-disable require-yield */
-	async function* Thrower() {
-		throw new Error("async gen rethrows after child error in async gen");
-	}
-	/* eslint-enable require-yield */
-
-	async function* Component(this: Context) {
+		renderer.render(<Thrower />, document.body);
+		expect(document.body.innerHTML).toBe("0");
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("1");
 		try {
-			for await (const _ of this) {
-				yield <Thrower />;
+			ctx.refresh();
+			throw new Error("unreachable");
+		} catch (err: any) {
+			expect(err.message).toBe("sync gen throws by refresh");
+		}
+	});
+
+	test("sync gen throws by parent refresh", () => {
+		function* Thrower(this: Context) {
+			let i = 0;
+			for ({} of this) {
+				if (i >= 2) {
+					throw new Error("sync gen throws by parent refresh");
+				}
+
+				yield i++;
 			}
-		} catch (err) {
-			mock();
-			throw new Error("async gen rethrows after child error in async gen 1");
 		}
-	}
 
-	try {
-		await renderer.render(<Component />, document.body);
-		Assert.unreachable();
-	} catch (err: any) {
-		Assert.is(
-			err.message,
-			"async gen rethrows after child error in async gen 1",
-		);
-	}
-
-	Assert.is(mock.callCount, 1);
-});
-
-test("async gen throws in async gen after yield", async () => {
-	const mock = Sinon.fake();
-	async function* Thrower(this: Context) {
-		yield 1;
-		for await ({} of this) {
-			throw new Error("async gen throws in async gen after yield");
-		}
-	}
-
-	async function* Component(this: Context) {
-		try {
-			for await ({} of this) {
-				yield <Thrower />;
-			}
-		} catch (err) {
-			mock();
-			throw err;
-		}
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "1");
-	try {
-		await renderer.render(<Component />, document.body);
-		Assert.unreachable();
-	} catch (err: any) {
-		Assert.is(err.message, "async gen throws in async gen after yield");
-		mock();
-	}
-
-	Assert.is(mock.callCount, 2);
-});
-
-test("delayed async function throws but is raced with faster component", async () => {
-	async function DelayedThrower(): Promise<never> {
-		await new Promise((resolve) => setTimeout(resolve, 100));
-		throw new Error(
-			"delayed async function throws but is raced with faster component",
-		);
-	}
-
-	async function FastComponent(): Promise<Child> {
-		await new Promise((resolve) => setTimeout(resolve, 50));
-		return <span>Fast Component</span>;
-	}
-
-	async function* Component(this: Context): AsyncGenerator<Child> {
-		for ({} of this) {
-			yield <DelayedThrower />;
-			yield <FastComponent />;
-		}
-	}
-
-	try {
-		await renderer.render(<Component />, document.body);
-		Assert.unreachable();
-	} catch (err: any) {
-		Assert.is(
-			err.message,
-			"delayed async function throws but is raced with faster component",
-		);
-	}
-
-	Assert.is(document.body.innerHTML, "");
-});
-
-test("async siblings throw", async () => {
-	async function Child1(): Promise<Child> {
-		await new Promise((resolve) => setTimeout(resolve, 50));
-		throw new Error("async siblings throw - Child1");
-	}
-
-	async function Child2(): Promise<Child> {
-		await new Promise((resolve) => setTimeout(resolve));
-		throw new Error("async siblings throw - Child1");
-	}
-
-	async function* Component(this: Context): AsyncGenerator<Child> {
-		for ({} of this) {
-			yield (
-				<div>
-					<Child1 />
-					<Child2 />
-				</div>
-			);
-		}
-	}
-
-	try {
-		await renderer.render(<Component />, document.body);
-		Assert.unreachable();
-	} catch (err: any) {
-		Assert.is(err.message, "async siblings throw - Child1");
-	}
-});
-
-test("sync function throws, sync gen catches", () => {
-	function Thrower(): never {
-		throw new Error("sync function throws, sync gen catches");
-	}
-
-	function* Component(): Generator<Child> {
-		try {
-			yield <Thrower />;
-		} catch (err) {
-			return <span>Error</span>;
-		}
-	}
-
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<span>Error</span>");
-});
-
-test("nested sync functions", () => {
-	function Thrower(): never {
-		throw new Error("nested sync functions");
-	}
-
-	function PassThrough() {
-		return <Thrower />;
-	}
-
-	function* Component(): Generator<Child> {
-		try {
-			yield <PassThrough />;
-		} catch (err) {
-			return <span>Error</span>;
-		}
-	}
-
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<span>Error</span>");
-});
-
-test("async function throws, sync gen catches", async () => {
-	async function Thrower(): Promise<never> {
-		throw new Error("async function throws, sync gen catches");
-	}
-
-	function* Component(): Generator<Child> {
-		try {
-			yield <Thrower />;
-		} catch (err) {
-			return <span>Error</span>;
-		}
-	}
-
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>Error</span></div>");
-	await new Promise((resolve) => setTimeout(resolve, 20));
-	Assert.is(document.body.innerHTML, "<div><span>Error</span></div>");
-});
-
-test("error recovery", () => {
-	const err = new Error("error recovery");
-	function* Thrower() {
-		yield 1;
-		yield 2;
-		yield 3;
-		throw err;
-	}
-
-	const mock = Sinon.fake();
-	function* Component(this: Context) {
-		while (true) {
-			try {
+		let ctx!: Context;
+		function* Parent(this: Context) {
+			ctx = this;
+			for ({} of this) {
 				yield (
 					<div>
 						<Thrower />
 					</div>
 				);
-			} catch (err) {
-				mock(err);
-				yield <div>Restarting</div>;
 			}
 		}
-	}
 
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>1</div>");
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>2</div>");
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>3</div>");
-	renderer.render(<Component />, document.body);
-	Assert.is(mock.callCount, 1);
-	Assert.is(mock.lastCall.args[0], err);
-	Assert.is(document.body.innerHTML, "<div>Restarting</div>");
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>1</div>");
-});
-
-test("async gen causes unhandled rejection", async () => {
-	async function One() {
-		await new Promise((r) => setTimeout(r, 100));
-		return <div>Hello</div>;
-	}
-
-	async function Two() {
-		await new Promise((r) => setTimeout(r, 200));
-		throw new Error("async gen causes unhandled rejection");
-	}
-
-	async function* Loader(this: Context) {
-		for await ({} of this) {
-			yield <One />;
-			yield <Two />;
+		renderer.render(<Parent />, document.body);
+		expect(document.body.innerHTML).toBe("<div>0</div>");
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div>1</div>");
+		try {
+			ctx.refresh();
+			throw new Error("unreachable");
+		} catch (err: any) {
+			expect(err.message).toBe("sync gen throws by parent refresh");
 		}
-	}
+	});
 
-	let resolve: (err: Error) => void;
-	const err = new Promise<any>((r) => (resolve = r));
-	const onUnhandledRejection = (ev: PromiseRejectionEvent) => {
-		if (ev.reason.message === "async gen causes unhandled rejection") {
-			resolve(ev.reason);
-			ev.preventDefault();
+	test("async gen throws by parent sync gen refresh", async () => {
+		async function* Thrower(this: Context) {
+			let i = 0;
+			for await ({} of this) {
+				if (i >= 2) {
+					throw new Error("async gen throws by parent sync gen refresh");
+				}
+
+				yield i++;
+			}
 		}
-	};
-	try {
-		window.addEventListener("unhandledrejection", onUnhandledRejection);
-		await renderer.render(<Loader />, document.body);
-		Assert.is(document.body.innerHTML, "<div>Hello</div>");
-		Assert.is((await err).message, "async gen causes unhandled rejection");
-	} finally {
-		window.removeEventListener("unhandledrejection", onUnhandledRejection);
-	}
-});
 
-test("nested gen function throws with refresh can be caught by parent", () => {
-	let throwerCtx!: Context;
-	function* Thrower(this: Context): Generator<Child> {
-		throwerCtx = this;
-		yield <div>Hello</div>;
-		throw new Error(
-			"nested gen function throws with refresh can be caught by parent",
+		let ctx!: Context;
+		function* Parent(this: Context) {
+			ctx = this;
+			for ({} of this) {
+				yield (
+					<div>
+						<Thrower />
+					</div>
+				);
+			}
+		}
+
+		await renderer.render(<Parent />, document.body);
+		expect(document.body.innerHTML).toBe("<div>0</div>");
+		await ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div>1</div>");
+		const mock = Sinon.fake();
+		try {
+			await ctx.refresh();
+			throw new Error("unreachable");
+		} catch (err: any) {
+			expect(err.message).toBe("async gen throws by parent sync gen refresh");
+			mock();
+		}
+
+		expect(mock.callCount).toBe(1);
+	});
+
+	test("for await of throws in for await of", async () => {
+		/* eslint-disable require-yield */
+		async function* Thrower(this: Context) {
+			for await ({} of this) {
+				throw new Error("for await of throws in for await of");
+			}
+		}
+
+		async function* Parent(this: Context) {
+			for await ({} of this) {
+				yield (
+					<div>
+						<Thrower />
+					</div>
+				);
+			}
+		}
+
+		try {
+			await renderer.render(<Parent />, document.body);
+			throw new Error("unreachable");
+		} catch (err: any) {
+			expect(err.message).toBe("for await of throws in for await of");
+		}
+
+		expect(document.body.innerHTML).toBe("");
+	});
+
+	test("async gen throws by parent async gen refresh", async () => {
+		async function* Thrower(this: Context) {
+			let i = 0;
+			for await ({} of this) {
+				if (i >= 2) {
+					throw new Error("async gen throws by parent async gen refresh");
+				}
+
+				yield i++;
+			}
+		}
+
+		let parentCtx!: Context;
+		async function* Parent(this: Context) {
+			parentCtx = this;
+			for await ({} of this) {
+				yield (
+					<div>
+						<Thrower />
+					</div>
+				);
+			}
+		}
+
+		await renderer.render(<Parent />, document.body);
+		expect(document.body.innerHTML).toBe("<div>0</div>");
+		await parentCtx.refresh();
+		expect(document.body.innerHTML).toBe("<div>1</div>");
+		const mock = Sinon.fake();
+		try {
+			await parentCtx.refresh();
+			throw new Error("unreachable");
+		} catch (err: any) {
+			expect(err.message).toBe("async gen throws by parent async gen refresh");
+			mock();
+		}
+
+		expect(mock.callCount).toBe(1);
+	});
+
+	test("async gen returns after child throws", async () => {
+		async function Thrower(this: Context) {
+			throw new Error("async gen returns after child throws");
+		}
+
+		async function* Component(this: Context) {
+			try {
+				for await ({} of this) {
+					yield <Thrower />;
+				}
+			} catch (err: any) {
+				return <span>{err.message}</span>;
+			}
+		}
+
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe(
+			"<span>async gen returns after child throws</span>",
 		);
-	}
+	});
 
-	function PassThrough() {
-		return <Thrower />;
-	}
-
-	function* Component(): Generator<Child> {
-		while (true) {
-			try {
-				yield <PassThrough />;
-			} catch (err) {
-				return <span>Error</span>;
+	test("async gen throws independently", async () => {
+		async function* Thrower(this: Context) {
+			for await ({} of this) {
+				yield 1;
+				yield 2;
+				yield 3;
+				await new Promise((resolve) => setTimeout(resolve));
+				throw new Error("async gen throws independently");
 			}
 		}
-	}
 
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello</div>");
-
-	throwerCtx.refresh();
-	Assert.is(document.body.innerHTML, "<span>Error</span>");
-});
-
-test("nested async gen function throws with refresh can be caught by parent", async () => {
-	let throwerCtx!: Context;
-	async function* Thrower(this: Context): AsyncGenerator<Child> {
-		throwerCtx = this;
-		yield <div>Hello</div>;
-		for await ({} of this) {
-			throw new Error(
-				"nested async gen function throws with refresh can be caught by parent",
-			);
-		}
-	}
-
-	function PassThrough() {
-		return <Thrower />;
-	}
-
-	function* Component(): Generator<Child> {
-		while (true) {
-			try {
-				yield <PassThrough />;
-			} catch (err) {
-				return <span>Error</span>;
+		let resolve: (err: Error) => void;
+		const err = new Promise<Error>((resolve1) => {
+			resolve = resolve1;
+		});
+		const onUnhandledRejection = (ev: PromiseRejectionEvent) => {
+			if (ev.reason.message === "async gen throws independently") {
+				ev.preventDefault();
+				resolve(ev.reason);
 			}
+		};
+		try {
+			window.addEventListener("unhandledrejection", onUnhandledRejection);
+
+			await renderer.render(<Thrower />, document.body);
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			expect(document.body.innerHTML).toBe("3");
+			expect((await err).message).toBe("async gen throws independently");
+		} finally {
+			window.removeEventListener("unhandledrejection", onUnhandledRejection);
 		}
-	}
+	});
 
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello</div>");
-
-	await throwerCtx.refresh();
-	Assert.is(document.body.innerHTML, "<span>Error</span>");
-});
-
-test("nested async gen function throws independently", async () => {
-	async function* Thrower(this: Context): AsyncGenerator<Child> {
-		for await ({} of this) {
-			yield <div>Hello</div>;
-			throw new Error("nested async gen function throws independently");
+	test("async gen rethrows after child error", async () => {
+		const mock = Sinon.fake();
+		async function Thrower(this: Context) {
+			throw new Error("async gen rethrows after child error");
 		}
-	}
 
-	let resolve: (err: Error) => void;
-	const err = new Promise<Error>((r) => (resolve = r));
-	const onUnhandledRejection = (ev: PromiseRejectionEvent) => {
-		if (
-			ev.reason.message === "nested async gen function throws independently"
-		) {
-			resolve(ev.reason);
-			ev.preventDefault();
-		}
-	};
-	try {
-		window.addEventListener("unhandledrejection", onUnhandledRejection);
-		await renderer.render(<Thrower />, document.body);
-		Assert.is(document.body.innerHTML, "<div>Hello</div>");
-		Assert.is(
-			(await err).message,
-			"nested async gen function throws independently",
-		);
-	} finally {
-		window.removeEventListener("unhandledrejection", onUnhandledRejection);
-	}
-});
-
-test("nested async gen throws independently can be caught by parent", async () => {
-	async function* Thrower(this: Context) {
-		for await ({} of this) {
-			yield <div>Hello</div>;
-			throw new Error(
-				"nested async gen throws independently can be caught by parent",
-			);
-		}
-	}
-
-	function PassThrough() {
-		return <Thrower />;
-	}
-
-	const mock = Sinon.fake();
-	function* Component(this: Context) {
-		for ({} of this) {
+		async function* Component(this: Context) {
 			try {
-				yield <PassThrough />;
+				for await (const _ of this) {
+					yield <Thrower />;
+				}
 			} catch (err) {
 				mock();
+				throw new Error("async gen rethrows after child error 1");
+			}
+		}
+
+		try {
+			await renderer.render(<Component />, document.body);
+			throw new Error("unreachable");
+		} catch (err: any) {
+			expect(err.message).toBe("async gen rethrows after child error 1");
+		}
+
+		expect(mock.callCount).toBe(1);
+	});
+
+	test("async gen rethrows after child error in async gen", async () => {
+		const mock = Sinon.fake();
+		/* eslint-disable require-yield */
+		async function* Thrower() {
+			throw new Error("async gen rethrows after child error in async gen");
+		}
+		/* eslint-enable require-yield */
+
+		async function* Component(this: Context) {
+			try {
+				for await (const _ of this) {
+					yield <Thrower />;
+				}
+			} catch (err) {
+				mock();
+				throw new Error("async gen rethrows after child error in async gen 1");
+			}
+		}
+
+		try {
+			await renderer.render(<Component />, document.body);
+			throw new Error("unreachable");
+		} catch (err: any) {
+			expect(err.message).toBe(
+				"async gen rethrows after child error in async gen 1",
+			);
+		}
+
+		expect(mock.callCount).toBe(1);
+	});
+
+	test("async gen throws in async gen after yield", async () => {
+		const mock = Sinon.fake();
+		async function* Thrower(this: Context) {
+			yield 1;
+			for await ({} of this) {
+				throw new Error("async gen throws in async gen after yield");
+			}
+		}
+
+		async function* Component(this: Context) {
+			try {
+				for await ({} of this) {
+					yield <Thrower />;
+				}
+			} catch (err) {
+				mock();
+				throw err;
+			}
+		}
+
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("1");
+		try {
+			await renderer.render(<Component />, document.body);
+			throw new Error("unreachable");
+		} catch (err: any) {
+			expect(err.message).toBe("async gen throws in async gen after yield");
+			mock();
+		}
+
+		expect(mock.callCount).toBe(2);
+	});
+
+	test("delayed async function throws but is raced with faster component", async () => {
+		async function DelayedThrower(): Promise<never> {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			throw new Error(
+				"delayed async function throws but is raced with faster component",
+			);
+		}
+
+		async function FastComponent(): Promise<Child> {
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			return <span>Fast Component</span>;
+		}
+
+		async function* Component(this: Context): AsyncGenerator<Child> {
+			for ({} of this) {
+				yield <DelayedThrower />;
+				yield <FastComponent />;
+			}
+		}
+
+		try {
+			await renderer.render(<Component />, document.body);
+			throw new Error("unreachable");
+		} catch (err: any) {
+			expect(err.message).toBe(
+				"delayed async function throws but is raced with faster component",
+			);
+		}
+
+		expect(document.body.innerHTML).toBe("");
+	});
+
+	test("async siblings throw", async () => {
+		async function Child1(): Promise<Child> {
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			throw new Error("async siblings throw - Child1");
+		}
+
+		async function Child2(): Promise<Child> {
+			await new Promise((resolve) => setTimeout(resolve));
+			throw new Error("async siblings throw - Child1");
+		}
+
+		async function* Component(this: Context): AsyncGenerator<Child> {
+			for ({} of this) {
+				yield (
+					<div>
+						<Child1 />
+						<Child2 />
+					</div>
+				);
+			}
+		}
+
+		try {
+			await renderer.render(<Component />, document.body);
+			throw new Error("unreachable");
+		} catch (err: any) {
+			expect(err.message).toBe("async siblings throw - Child1");
+		}
+	});
+
+	test("sync function throws, sync gen catches", () => {
+		function Thrower(): never {
+			throw new Error("sync function throws, sync gen catches");
+		}
+
+		function* Component(): Generator<Child> {
+			try {
+				yield <Thrower />;
+			} catch (err) {
 				return <span>Error</span>;
 			}
 		}
-	}
 
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<span>Error</span>");
-	Assert.is(mock.callCount, 1);
-});
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<span>Error</span>");
+	});
 
-test("async gen with for await of rejects children passed back in awaited", async () => {
-	const mock = Sinon.fake();
-	/* eslint-disable require-yield */
-	async function* Thrower(this: Context) {
-		for await ({} of this) {
+	test("nested sync functions", () => {
+		function Thrower(): never {
+			throw new Error("nested sync functions");
+		}
+
+		function PassThrough() {
+			return <Thrower />;
+		}
+
+		function* Component(): Generator<Child> {
+			try {
+				yield <PassThrough />;
+			} catch (err) {
+				return <span>Error</span>;
+			}
+		}
+
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<span>Error</span>");
+	});
+
+	test("async function throws, sync gen catches", async () => {
+		async function Thrower(): Promise<never> {
+			throw new Error("async function throws, sync gen catches");
+		}
+
+		function* Component(): Generator<Child> {
+			try {
+				yield <Thrower />;
+			} catch (err) {
+				return <span>Error</span>;
+			}
+		}
+
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><span>Error</span></div>");
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		expect(document.body.innerHTML).toBe("<div><span>Error</span></div>");
+	});
+
+	test("error recovery", () => {
+		const err = new Error("error recovery");
+		function* Thrower() {
+			yield 1;
+			yield 2;
+			yield 3;
+			throw err;
+		}
+
+		const mock = Sinon.fake();
+		function* Component(this: Context) {
+			while (true) {
+				try {
+					yield (
+						<div>
+							<Thrower />
+						</div>
+					);
+				} catch (err) {
+					mock(err);
+					yield <div>Restarting</div>;
+				}
+			}
+		}
+
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>1</div>");
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>2</div>");
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>3</div>");
+		renderer.render(<Component />, document.body);
+		expect(mock.callCount).toBe(1);
+		expect(mock.lastCall.args[0]).toBe(err);
+		expect(document.body.innerHTML).toBe("<div>Restarting</div>");
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>1</div>");
+	});
+
+	test("async gen causes unhandled rejection", async () => {
+		async function One() {
+			await new Promise((r) => setTimeout(r, 100));
+			return <div>Hello</div>;
+		}
+
+		async function Two() {
+			await new Promise((r) => setTimeout(r, 200));
+			throw new Error("async gen causes unhandled rejection");
+		}
+
+		async function* Loader(this: Context) {
+			for await ({} of this) {
+				yield <One />;
+				yield <Two />;
+			}
+		}
+
+		let resolve: (err: Error) => void;
+		const err = new Promise<any>((r) => (resolve = r));
+		const onUnhandledRejection = (ev: PromiseRejectionEvent) => {
+			if (ev.reason.message === "async gen causes unhandled rejection") {
+				resolve(ev.reason);
+				ev.preventDefault();
+			}
+		};
+		try {
+			window.addEventListener("unhandledrejection", onUnhandledRejection);
+			await renderer.render(<Loader />, document.body);
+			expect(document.body.innerHTML).toBe("<div>Hello</div>");
+			expect((await err).message).toBe("async gen causes unhandled rejection");
+		} finally {
+			window.removeEventListener("unhandledrejection", onUnhandledRejection);
+		}
+	});
+
+	test("nested gen function throws with refresh can be caught by parent", () => {
+		let throwerCtx!: Context;
+		function* Thrower(this: Context): Generator<Child> {
+			throwerCtx = this;
+			yield <div>Hello</div>;
 			throw new Error(
-				"async gen with for await of rejects children passed back in awaited",
+				"nested gen function throws with refresh can be caught by parent",
 			);
 		}
-	}
 
-	async function* Component(this: Context): AsyncGenerator<Child, void, any> {
-		for await ({} of this) {
-			const p = yield <Thrower />;
+		function PassThrough() {
+			return <Thrower />;
+		}
 
-			try {
-				await p;
-			} catch (err: any) {
-				mock(err);
+		function* Component(): Generator<Child> {
+			while (true) {
+				try {
+					yield <PassThrough />;
+				} catch (err) {
+					return <span>Error</span>;
+				}
+			}
+		}
+
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello</div>");
+
+		throwerCtx.refresh();
+		expect(document.body.innerHTML).toBe("<span>Error</span>");
+	});
+
+	test("nested async gen function throws with refresh can be caught by parent", async () => {
+		let throwerCtx!: Context;
+		async function* Thrower(this: Context): AsyncGenerator<Child> {
+			throwerCtx = this;
+			yield <div>Hello</div>;
+			for await ({} of this) {
+				throw new Error(
+					"nested async gen function throws with refresh can be caught by parent",
+				);
+			}
+		}
+
+		function PassThrough() {
+			return <Thrower />;
+		}
+
+		function* Component(): Generator<Child> {
+			while (true) {
+				try {
+					yield <PassThrough />;
+				} catch (err) {
+					return <span>Error</span>;
+				}
+			}
+		}
+
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello</div>");
+
+		await throwerCtx.refresh();
+		expect(document.body.innerHTML).toBe("<span>Error</span>");
+	});
+
+	test("nested async gen function throws independently", async () => {
+		async function* Thrower(this: Context): AsyncGenerator<Child> {
+			for await ({} of this) {
+				yield <div>Hello</div>;
+				throw new Error("nested async gen function throws independently");
+			}
+		}
+
+		let resolve: (err: Error) => void;
+		const err = new Promise<Error>((r) => (resolve = r));
+		const onUnhandledRejection = (ev: PromiseRejectionEvent) => {
+			if (
+				ev.reason.message === "nested async gen function throws independently"
+			) {
+				resolve(ev.reason);
+				ev.preventDefault();
+			}
+		};
+		try {
+			window.addEventListener("unhandledrejection", onUnhandledRejection);
+			await renderer.render(<Thrower />, document.body);
+			expect(document.body.innerHTML).toBe("<div>Hello</div>");
+			expect((await err).message).toBe(
+				"nested async gen function throws independently",
+			);
+		} finally {
+			window.removeEventListener("unhandledrejection", onUnhandledRejection);
+		}
+	});
+
+	test("nested async gen throws independently can be caught by parent", async () => {
+		async function* Thrower(this: Context) {
+			for await ({} of this) {
+				yield <div>Hello</div>;
+				throw new Error(
+					"nested async gen throws independently can be caught by parent",
+				);
+			}
+		}
+
+		function PassThrough() {
+			return <Thrower />;
+		}
+
+		const mock = Sinon.fake();
+		function* Component(this: Context) {
+			for ({} of this) {
+				try {
+					yield <PassThrough />;
+				} catch (err) {
+					mock();
+					return <span>Error</span>;
+				}
+			}
+		}
+
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<span>Error</span>");
+		expect(mock.callCount).toBe(1);
+	});
+
+	test("async gen with for await of rejects children passed back in awaited", async () => {
+		const mock = Sinon.fake();
+		/* eslint-disable require-yield */
+		async function* Thrower(this: Context) {
+			for await ({} of this) {
+				throw new Error(
+					"async gen with for await of rejects children passed back in awaited",
+				);
+			}
+		}
+
+		async function* Component(this: Context): AsyncGenerator<Child, void, any> {
+			for await ({} of this) {
+				const p = yield <Thrower />;
+
+				try {
+					await p;
+				} catch (err: any) {
+					mock(err);
+					yield <span>Okay!</span>;
+				}
+			}
+		}
+
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<span>Okay!</span>");
+		expect(mock.callCount).toBe(1);
+		expect(mock.lastCall.args[0].message).toBe(
+			"async gen with for await of rejects children passed back in awaited",
+		);
+	});
+
+	test("async gen with for await of rejects children passed back in then", async () => {
+		const mock = Sinon.fake();
+		/* eslint-disable require-yield */
+		async function* Thrower(this: Context) {
+			for ({} of this) {
+				throw new Error(
+					"async gen with for await of rejects children passed back in then",
+				);
+			}
+		}
+
+		async function* Component(this: Context): AsyncGenerator<Child, void, any> {
+			for await ({} of this) {
+				const p = yield <Thrower />;
+				p.then(() => {
+					throw new Error("unreachable");
+				}).catch((err: Error) => {
+					mock(err);
+				});
+
+				await new Promise((resolve) => setTimeout(resolve, 100));
 				yield <span>Okay!</span>;
 			}
 		}
-	}
 
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<span>Okay!</span>");
-	Assert.is(mock.callCount, 1);
-	Assert.is(
-		mock.lastCall.args[0].message,
-		"async gen with for await of rejects children passed back in awaited",
-	);
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<span>Okay!</span>");
+		expect(mock.callCount).toBe(1);
+		expect(mock.lastCall.args[0].message).toBe(
+			"async gen with for await of rejects children passed back in then",
+		);
+	});
+
+	test("async gen with for await of rejects children passed back in catch", async () => {
+		const mock = Sinon.fake();
+		/* eslint-disable require-yield */
+		async function* Thrower(this: Context) {
+			for ({} of this) {
+				throw new Error(
+					"async gen with for await of rejects children passed back in catch",
+				);
+			}
+		}
+
+		async function* Component(this: Context): AsyncGenerator<Child, void, any> {
+			for await ({} of this) {
+				const p = yield <Thrower />;
+
+				p.catch((err: Error) => {
+					mock(err);
+				});
+
+				await new Promise((resolve) => setTimeout(resolve, 100));
+				yield <span>Okay!</span>;
+			}
+		}
+
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<span>Okay!</span>");
+		expect(mock.callCount).toBe(1);
+		expect(mock.lastCall.args[0].message).toBe(
+			"async gen with for await of rejects children passed back in catch",
+		);
+	});
 });
-
-test("async gen with for await of rejects children passed back in then", async () => {
-	const mock = Sinon.fake();
-	/* eslint-disable require-yield */
-	async function* Thrower(this: Context) {
-		for ({} of this) {
-			throw new Error(
-				"async gen with for await of rejects children passed back in then",
-			);
-		}
-	}
-
-	async function* Component(this: Context): AsyncGenerator<Child, void, any> {
-		for await ({} of this) {
-			const p = yield <Thrower />;
-			p.then(() => {
-				Assert.unreachable();
-			}).catch((err: Error) => {
-				mock(err);
-			});
-
-			await new Promise((resolve) => setTimeout(resolve, 100));
-			yield <span>Okay!</span>;
-		}
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<span>Okay!</span>");
-	Assert.is(mock.callCount, 1);
-	Assert.is(
-		mock.lastCall.args[0].message,
-		"async gen with for await of rejects children passed back in then",
-	);
-});
-
-test("async gen with for await of rejects children passed back in catch", async () => {
-	const mock = Sinon.fake();
-	/* eslint-disable require-yield */
-	async function* Thrower(this: Context) {
-		for ({} of this) {
-			throw new Error(
-				"async gen with for await of rejects children passed back in catch",
-			);
-		}
-	}
-
-	async function* Component(this: Context): AsyncGenerator<Child, void, any> {
-		for await ({} of this) {
-			const p = yield <Thrower />;
-
-			p.catch((err: Error) => {
-				mock(err);
-			});
-
-			await new Promise((resolve) => setTimeout(resolve, 100));
-			yield <span>Okay!</span>;
-		}
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<span>Okay!</span>");
-	Assert.is(mock.callCount, 1);
-	Assert.is(
-		mock.lastCall.args[0].message,
-		"async gen with for await of rejects children passed back in catch",
-	);
-});
-
-test.run();

--- a/test/events.tsx
+++ b/test/events.tsx
@@ -1,456 +1,406 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import * as Sinon from "sinon";
 
 import {Context, createElement, Element, Fragment} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("events");
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+describe("events", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test("onevent", () => {
-	const mock = Sinon.fake();
-	renderer.render(<button onclick={mock}>Click me</button>, document.body);
+	test("onevent", () => {
+		const mock = Sinon.fake();
+		renderer.render(<button onclick={mock}>Click me</button>, document.body);
 
-	const button = document.body.firstChild as HTMLButtonElement;
-	button.click()!;
-	button.click()!;
-	button.click()!;
-	Assert.is(mock.callCount, 3);
-});
+		const button = document.body.firstChild as HTMLButtonElement;
+		button.click()!;
+		button.click()!;
+		button.click()!;
+		expect(mock.callCount).toBe(3);
+	});
 
-test("onevent camelCased", () => {
-	const mock = Sinon.fake();
-	renderer.render(<button onClick={mock}>Click me</button>, document.body);
+	test("onevent camelCased", () => {
+		const mock = Sinon.fake();
+		renderer.render(<button onClick={mock}>Click me</button>, document.body);
 
-	const button = document.body.firstChild as HTMLButtonElement;
-	button.click()!;
-	button.click()!;
-	button.click()!;
-	Assert.is(mock.callCount, 3);
-});
+		const button = document.body.firstChild as HTMLButtonElement;
+		button.click()!;
+		button.click()!;
+		button.click()!;
+		expect(mock.callCount).toBe(3);
+	});
 
-test("onevent SVG", () => {
-	const mock = Sinon.fake();
-	renderer.render(<svg onclick={mock} />, document.body);
+	test("onevent SVG", () => {
+		const mock = Sinon.fake();
+		renderer.render(<svg onclick={mock} />, document.body);
 
-	const svg = document.body.firstChild as SVGSVGElement;
-	svg.dispatchEvent(new Event("click"));
-	svg.dispatchEvent(new Event("click"));
-	svg.dispatchEvent(new Event("click"));
-	Assert.is(mock.callCount, 3);
-});
+		const svg = document.body.firstChild as SVGSVGElement;
+		svg.dispatchEvent(new Event("click"));
+		svg.dispatchEvent(new Event("click"));
+		svg.dispatchEvent(new Event("click"));
+		expect(mock.callCount).toBe(3);
+	});
 
-test("function component", () => {
-	const mock = Sinon.fake();
-	function Button(this: Context) {
-		this.addEventListener("click", () => {
-			mock();
-		});
-		return <button>Click me</button>;
-	}
+	test("function component", () => {
+		const mock = Sinon.fake();
+		function Button(this: Context) {
+			this.addEventListener("click", () => {
+				mock();
+			});
+			return <button>Click me</button>;
+		}
 
-	renderer.render(<Button />, document.body);
-	const button = document.body.firstChild as HTMLButtonElement;
-	button.click()!;
-	button.click()!;
-	button.click()!;
-	Assert.is(mock.callCount, 3);
-	renderer.render(<Button />, document.body);
-	renderer.render(<Button />, document.body);
-	renderer.render(<Button />, document.body);
-	renderer.render(<Button />, document.body);
-	renderer.render(<Button />, document.body);
-	Assert.is(mock.callCount, 3);
-	Assert.is(document.body.firstChild, button);
-	button.click();
-	button.click();
-	button.click();
-	Assert.is(mock.callCount, 6);
-	renderer.render(null, document.body);
-	button.click();
-	button.click();
-	button.click();
-	Assert.is(mock.callCount, 6);
-});
+		renderer.render(<Button />, document.body);
+		const button = document.body.firstChild as HTMLButtonElement;
+		button.click()!;
+		button.click()!;
+		button.click()!;
+		expect(mock.callCount).toBe(3);
+		renderer.render(<Button />, document.body);
+		renderer.render(<Button />, document.body);
+		renderer.render(<Button />, document.body);
+		renderer.render(<Button />, document.body);
+		renderer.render(<Button />, document.body);
+		expect(mock.callCount).toBe(3);
+		expect(document.body.firstChild).toBe(button);
+		button.click();
+		button.click();
+		button.click();
+		expect(mock.callCount).toBe(6);
+		renderer.render(null, document.body);
+		button.click();
+		button.click();
+		button.click();
+		expect(mock.callCount).toBe(6);
+	});
 
-test("delegation", () => {
-	let ctx!: Context;
-	function* Component(this: Context): Generator<Element> {
-		ctx = this;
-		for ({} of this) {
+	test("delegation", () => {
+		let ctx!: Context;
+		function* Component(this: Context): Generator<Element> {
+			ctx = this;
+			for ({} of this) {
+				yield (
+					<div>
+						<button>Click me</button>
+					</div>
+				);
+			}
+		}
+
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe(
+			"<div><button>Click me</button></div>",
+		);
+		const div = document.body.firstChild!;
+		const button = div.firstChild!;
+		const divAddEventListener = Sinon.spy(div, "addEventListener");
+		const divRemoveEventListener = Sinon.spy(div, "removeEventListener");
+		const buttonAddEventListener = Sinon.spy(button, "addEventListener");
+		const buttonRemoveEventListener = Sinon.spy(button, "removeEventListener");
+		const listener = Sinon.fake();
+		ctx.addEventListener("click", listener);
+		expect(divAddEventListener.callCount).toBe(1);
+		expect(divAddEventListener.lastCall.args).toEqual(["click", listener, {}]);
+		expect(buttonAddEventListener.callCount).toBe(0);
+		expect(divRemoveEventListener.callCount).toBe(0);
+		expect(buttonRemoveEventListener.callCount).toBe(0);
+		renderer.render(null, document.body);
+		expect(divRemoveEventListener.callCount).toBe(1);
+		expect(divRemoveEventListener.lastCall.args).toEqual([
+			"click",
+			listener,
+			{},
+		]);
+		expect(buttonRemoveEventListener.callCount).toBe(0);
+	});
+
+	test("delegation with unmounting children", () => {
+		let ctx!: Context;
+		function* Component(this: Context): Generator<Element | null> {
+			ctx = this;
 			yield (
 				<div>
 					<button>Click me</button>
 				</div>
 			);
+
+			yield null;
 		}
-	}
 
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div><button>Click me</button></div>");
-	const div = document.body.firstChild!;
-	const button = div.firstChild!;
-	const divAddEventListener = Sinon.spy(div, "addEventListener");
-	const divRemoveEventListener = Sinon.spy(div, "removeEventListener");
-	const buttonAddEventListener = Sinon.spy(button, "addEventListener");
-	const buttonRemoveEventListener = Sinon.spy(button, "removeEventListener");
-	const listener = Sinon.fake();
-	ctx.addEventListener("click", listener);
-	Assert.is(divAddEventListener.callCount, 1);
-	Assert.equal(divAddEventListener.lastCall.args, ["click", listener, {}]);
-	Assert.is(buttonAddEventListener.callCount, 0);
-	Assert.is(divRemoveEventListener.callCount, 0);
-	Assert.is(buttonRemoveEventListener.callCount, 0);
-	renderer.render(null, document.body);
-	Assert.is(divRemoveEventListener.callCount, 1);
-	Assert.equal(divRemoveEventListener.lastCall.args, ["click", listener, {}]);
-	Assert.is(buttonRemoveEventListener.callCount, 0);
-});
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe(
+			"<div><button>Click me</button></div>",
+		);
+		const div = document.body.firstChild!;
+		const button = div.firstChild!;
+		const divAddEventListener = Sinon.spy(div, "addEventListener");
+		const divRemoveEventListener = Sinon.spy(div, "removeEventListener");
+		const buttonAddEventListener = Sinon.spy(button, "addEventListener");
+		const buttonRemoveEventListener = Sinon.spy(button, "removeEventListener");
+		const listener = Sinon.fake();
+		ctx.addEventListener("click", listener);
+		expect(divAddEventListener.callCount).toBe(1);
+		expect(divAddEventListener.lastCall.args).toEqual(["click", listener, {}]);
+		expect(buttonAddEventListener.callCount).toBe(0);
+		expect(divRemoveEventListener.callCount).toBe(0);
+		expect(buttonRemoveEventListener.callCount).toBe(0);
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("");
+		expect(divRemoveEventListener.callCount).toBe(1);
+		expect(divRemoveEventListener.lastCall.args).toEqual([
+			"click",
+			listener,
+			{},
+		]);
+		expect(buttonRemoveEventListener.callCount).toBe(0);
+	});
 
-test("delegation with unmounting children", () => {
-	let ctx!: Context;
-	function* Component(this: Context): Generator<Element | null> {
-		ctx = this;
-		yield (
+	test("non-direct delegation", () => {
+		function Child({depth}: {depth: number}) {
+			if (depth <= 0) {
+				return (
+					<Fragment>
+						<Fragment>
+							<button>Click me</button>
+						</Fragment>
+					</Fragment>
+				);
+			}
+
+			return <Child depth={depth - 1} />;
+		}
+
+		const mock = Sinon.fake();
+		function* Parent(this: Context) {
+			this.addEventListener("click", () => {
+				mock();
+			});
+			for ({} of this) {
+				yield (
+					<Fragment>
+						<Fragment>
+							<Child depth={10} />
+						</Fragment>
+					</Fragment>
+				);
+			}
+		}
+
+		renderer.render(
 			<div>
-				<button>Click me</button>
-			</div>
+				<Parent />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><button>Click me</button></div>",
+		);
+		const button = document.body.firstChild!.firstChild as HTMLButtonElement;
+		button.click();
+		button.click();
+		button.click();
+		expect(mock.callCount).toBe(3);
+		renderer.render(null, document.body);
+		button.click();
+		button.click();
+		button.click();
+		expect(mock.callCount).toBe(3);
+	});
+
+	test("non-direct delegation with refresh", () => {
+		let ctx!: Context;
+		function* Child(this: Context) {
+			ctx = this;
+			yield null;
+			for ({} of this) {
+				yield (
+					<Fragment>
+						<Fragment>
+							<button>Click me</button>
+						</Fragment>
+					</Fragment>
+				);
+			}
+		}
+
+		const mock = Sinon.fake();
+		function* Parent(this: Context) {
+			this.addEventListener("click", (ev) => {
+				if ((ev.target as HTMLElement).tagName === "BUTTON") {
+					mock();
+				}
+			});
+
+			for ({} of this) {
+				yield (
+					<Fragment>
+						<Fragment>
+							<Child />
+						</Fragment>
+					</Fragment>
+				);
+			}
+		}
+
+		renderer.render(
+			<div>
+				<Parent />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div></div>");
+
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe(
+			"<div><button>Click me</button></div>",
+		);
+		const button = document.body.firstChild!.firstChild as HTMLButtonElement;
+		button.click();
+		button.click();
+		button.click();
+		expect(mock.callCount).toBe(3);
+
+		renderer.render(null, document.body);
+		button.click();
+		button.click();
+		button.click();
+		expect(mock.callCount).toBe(3);
+	});
+
+	test("refresh on click", () => {
+		function* Component(this: Context): Generator<string> {
+			let count = 0;
+			this.addEventListener("click", (ev) => {
+				if ((ev.target as HTMLElement).id === "button") {
+					count++;
+					this.refresh();
+				}
+			});
+
+			for ({} of this) {
+				yield (
+					<div>
+						<button id="button">Click me</button>
+						<span>Button has been clicked {count} times</span>
+					</div>
+				);
+			}
+		}
+
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe(
+			'<div><button id="button">Click me</button><span>Button has been clicked 0 times</span></div>',
 		);
 
-		yield null;
-	}
+		const button = document.getElementById("button")!;
+		button.click();
+		expect(document.body.innerHTML).toBe(
+			'<div><button id="button">Click me</button><span>Button has been clicked 1 times</span></div>',
+		);
+		button.click();
+		button.click();
+		button.click();
+		expect(document.body.innerHTML).toBe(
+			'<div><button id="button">Click me</button><span>Button has been clicked 4 times</span></div>',
+		);
+	});
 
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div><button>Click me</button></div>");
-	const div = document.body.firstChild!;
-	const button = div.firstChild!;
-	const divAddEventListener = Sinon.spy(div, "addEventListener");
-	const divRemoveEventListener = Sinon.spy(div, "removeEventListener");
-	const buttonAddEventListener = Sinon.spy(button, "addEventListener");
-	const buttonRemoveEventListener = Sinon.spy(button, "removeEventListener");
-	const listener = Sinon.fake();
-	ctx.addEventListener("click", listener);
-	Assert.is(divAddEventListener.callCount, 1);
-	Assert.equal(divAddEventListener.lastCall.args, ["click", listener, {}]);
-	Assert.is(buttonAddEventListener.callCount, 0);
-	Assert.is(divRemoveEventListener.callCount, 0);
-	Assert.is(buttonRemoveEventListener.callCount, 0);
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "");
-	Assert.is(divRemoveEventListener.callCount, 1);
-	Assert.equal(divRemoveEventListener.lastCall.args, ["click", listener, {}]);
-	Assert.is(buttonRemoveEventListener.callCount, 0);
-});
+	test("refresh callback", () => {
+		function* Component(this: Context): Generator<string> {
+			let count = 0;
+			this.addEventListener("click", (ev) => {
+				if ((ev.target as HTMLElement).id === "button") {
+					this.refresh(() => {
+						count++;
+					});
+				}
+			});
 
-test("non-direct delegation", () => {
-	function Child({depth}: {depth: number}) {
-		if (depth <= 0) {
-			return (
-				<Fragment>
-					<Fragment>
-						<button>Click me</button>
-					</Fragment>
-				</Fragment>
-			);
-		}
-
-		return <Child depth={depth - 1} />;
-	}
-
-	const mock = Sinon.fake();
-	function* Parent(this: Context) {
-		this.addEventListener("click", () => {
-			mock();
-		});
-		for ({} of this) {
-			yield (
-				<Fragment>
-					<Fragment>
-						<Child depth={10} />
-					</Fragment>
-				</Fragment>
-			);
-		}
-	}
-
-	renderer.render(
-		<div>
-			<Parent />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><button>Click me</button></div>");
-	const button = document.body.firstChild!.firstChild as HTMLButtonElement;
-	button.click();
-	button.click();
-	button.click();
-	Assert.is(mock.callCount, 3);
-	renderer.render(null, document.body);
-	button.click();
-	button.click();
-	button.click();
-	Assert.is(mock.callCount, 3);
-});
-
-test("non-direct delegation with refresh", () => {
-	let ctx!: Context;
-	function* Child(this: Context) {
-		ctx = this;
-		yield null;
-		for ({} of this) {
-			yield (
-				<Fragment>
-					<Fragment>
-						<button>Click me</button>
-					</Fragment>
-				</Fragment>
-			);
-		}
-	}
-
-	const mock = Sinon.fake();
-	function* Parent(this: Context) {
-		this.addEventListener("click", (ev) => {
-			if ((ev.target as HTMLElement).tagName === "BUTTON") {
-				mock();
+			for ({} of this) {
+				yield (
+					<div>
+						<button id="button">Click me</button>
+						<span>Button has been clicked {count} times</span>
+					</div>
+				);
 			}
-		});
-
-		for ({} of this) {
-			yield (
-				<Fragment>
-					<Fragment>
-						<Child />
-					</Fragment>
-				</Fragment>
-			);
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Parent />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div></div>");
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe(
+			'<div><button id="button">Click me</button><span>Button has been clicked 0 times</span></div>',
+		);
 
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div><button>Click me</button></div>");
-	const button = document.body.firstChild!.firstChild as HTMLButtonElement;
-	button.click();
-	button.click();
-	button.click();
-	Assert.is(mock.callCount, 3);
+		const button = document.getElementById("button")!;
+		button.click();
+		expect(document.body.innerHTML).toBe(
+			'<div><button id="button">Click me</button><span>Button has been clicked 1 times</span></div>',
+		);
+		button.click();
+		button.click();
+		button.click();
+		expect(document.body.innerHTML).toBe(
+			'<div><button id="button">Click me</button><span>Button has been clicked 4 times</span></div>',
+		);
+	});
 
-	renderer.render(null, document.body);
-	button.click();
-	button.click();
-	button.click();
-	Assert.is(mock.callCount, 3);
-});
+	test("async refresh callback", async () => {
+		let resolve!: Function;
+		function* Component(this: Context): Generator<string> {
+			let count = 0;
+			this.addEventListener("click", (ev) => {
+				if ((ev.target as HTMLElement).id === "button") {
+					this.refresh(async () => {
+						await new Promise((resolve1) => (resolve = resolve1));
+						count++;
+					});
+				}
+			});
 
-test("refresh on click", () => {
-	function* Component(this: Context): Generator<string> {
-		let count = 0;
-		this.addEventListener("click", (ev) => {
-			if ((ev.target as HTMLElement).id === "button") {
-				count++;
-				this.refresh();
+			for ({} of this) {
+				yield (
+					<div>
+						<button id="button">Click me</button>
+						<span>Button has been clicked {count} times</span>
+					</div>
+				);
 			}
-		});
-
-		for ({} of this) {
-			yield (
-				<div>
-					<button id="button">Click me</button>
-					<span>Button has been clicked {count} times</span>
-				</div>
-			);
 		}
-	}
 
-	renderer.render(<Component />, document.body);
-	Assert.is(
-		document.body.innerHTML,
-		'<div><button id="button">Click me</button><span>Button has been clicked 0 times</span></div>',
-	);
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe(
+			'<div><button id="button">Click me</button><span>Button has been clicked 0 times</span></div>',
+		);
 
-	const button = document.getElementById("button")!;
-	button.click();
-	Assert.is(
-		document.body.innerHTML,
-		'<div><button id="button">Click me</button><span>Button has been clicked 1 times</span></div>',
-	);
-	button.click();
-	button.click();
-	button.click();
-	Assert.is(
-		document.body.innerHTML,
-		'<div><button id="button">Click me</button><span>Button has been clicked 4 times</span></div>',
-	);
-});
+		const button = document.getElementById("button")!;
+		button.click();
 
-test("refresh callback", () => {
-	function* Component(this: Context): Generator<string> {
-		let count = 0;
-		this.addEventListener("click", (ev) => {
-			if ((ev.target as HTMLElement).id === "button") {
-				this.refresh(() => {
-					count++;
-				});
-			}
-		});
+		expect(document.body.innerHTML).toBe(
+			'<div><button id="button">Click me</button><span>Button has been clicked 0 times</span></div>',
+		);
 
-		for ({} of this) {
-			yield (
-				<div>
-					<button id="button">Click me</button>
-					<span>Button has been clicked {count} times</span>
-				</div>
-			);
+		resolve();
+		await new Promise((resolve) => setTimeout(resolve));
+
+		expect(document.body.innerHTML).toBe(
+			'<div><button id="button">Click me</button><span>Button has been clicked 1 times</span></div>',
+		);
+	});
+
+	test("unmount and dispatch", () => {
+		let ctx!: Context;
+		function Component(this: Context) {
+			ctx = this;
+			return <span>Hello</span>;
 		}
-	}
 
-	renderer.render(<Component />, document.body);
-	Assert.is(
-		document.body.innerHTML,
-		'<div><button id="button">Click me</button><span>Button has been clicked 0 times</span></div>',
-	);
-
-	const button = document.getElementById("button")!;
-	button.click();
-	Assert.is(
-		document.body.innerHTML,
-		'<div><button id="button">Click me</button><span>Button has been clicked 1 times</span></div>',
-	);
-	button.click();
-	button.click();
-	button.click();
-	Assert.is(
-		document.body.innerHTML,
-		'<div><button id="button">Click me</button><span>Button has been clicked 4 times</span></div>',
-	);
-});
-
-test("async refresh callback", async () => {
-	let resolve!: Function;
-	function* Component(this: Context): Generator<string> {
-		let count = 0;
-		this.addEventListener("click", (ev) => {
-			if ((ev.target as HTMLElement).id === "button") {
-				this.refresh(async () => {
-					await new Promise((resolve1) => (resolve = resolve1));
-					count++;
-				});
-			}
-		});
-
-		for ({} of this) {
-			yield (
-				<div>
-					<button id="button">Click me</button>
-					<span>Button has been clicked {count} times</span>
-				</div>
-			);
-		}
-	}
-
-	renderer.render(<Component />, document.body);
-	Assert.is(
-		document.body.innerHTML,
-		'<div><button id="button">Click me</button><span>Button has been clicked 0 times</span></div>',
-	);
-
-	const button = document.getElementById("button")!;
-	button.click();
-
-	Assert.is(
-		document.body.innerHTML,
-		'<div><button id="button">Click me</button><span>Button has been clicked 0 times</span></div>',
-	);
-
-	resolve();
-	await new Promise((resolve) => setTimeout(resolve));
-
-	Assert.is(
-		document.body.innerHTML,
-		'<div><button id="button">Click me</button><span>Button has been clicked 1 times</span></div>',
-	);
-});
-
-test("unmount and dispatch", () => {
-	let ctx!: Context;
-	function Component(this: Context) {
-		ctx = this;
-		return <span>Hello</span>;
-	}
-
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	const listener1 = Sinon.fake();
-	const listener2 = Sinon.fake();
-	ctx.addEventListener("foo", listener1);
-	ctx.addEventListener("bar", listener1);
-	ctx.dispatchEvent(new Event("foo"));
-	Assert.is(listener1.callCount, 1);
-	Assert.is(listener2.callCount, 0);
-	renderer.render(null, document.body);
-	ctx.dispatchEvent(new Event("foo"));
-	ctx.dispatchEvent(new Event("bar"));
-	Assert.is(listener1.callCount, 1);
-	Assert.is(listener2.callCount, 0);
-});
-
-test("event props", () => {
-	let ctx!: Context;
-	function Component(this: Context, _props: {onfoo: (ev: Event) => any}) {
-		ctx = this;
-		return <span>Hello</span>;
-	}
-
-	const mock = Sinon.fake();
-	renderer.render(<Component onfoo={mock} />, document.body);
-	ctx.dispatchEvent(new Event("foo"));
-	Assert.is(mock.callCount, 1);
-});
-
-test("event props camelCased", () => {
-	let ctx!: Context;
-	function Component(this: Context, _props: {onFoo: (ev: Event) => any}) {
-		ctx = this;
-		return <span>Hello</span>;
-	}
-
-	const mock = Sinon.fake();
-	renderer.render(<Component onFoo={mock} />, document.body);
-	ctx.dispatchEvent(new Event("foo"));
-	Assert.is(mock.callCount, 1);
-});
-
-test("error thrown in listener", () => {
-	let ctx!: Context;
-	function Component(this: Context) {
-		ctx = this;
-		return <span>Hello</span>;
-	}
-
-	const mock = Sinon.stub(console, "error");
-	try {
 		renderer.render(
 			<div>
 				<Component />
@@ -458,48 +408,103 @@ test("error thrown in listener", () => {
 			document.body,
 		);
 
-		const error = new Error("error thrown in listener and dispatchEvent");
-		const listener = () => {
-			throw error;
-		};
-		ctx.addEventListener("foo", listener);
-		ctx.dispatchEvent(new Event("foo"));
-		Assert.is(mock.lastCall.args[0], error);
-	} finally {
-		mock.restore();
-	}
-});
-
-test("errors do not affect other listeners", () => {
-	let ctx!: Context;
-	function Component(this: Context) {
-		ctx = this;
-		return <span>Hello</span>;
-	}
-
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	const mock = Sinon.stub(console, "error");
-	const listener1 = () => {
-		throw new Error("errors do not affect other listeners");
-	};
-
-	const listener2 = Sinon.mock();
-
-	try {
+		const listener1 = Sinon.fake();
+		const listener2 = Sinon.fake();
 		ctx.addEventListener("foo", listener1);
-		ctx.addEventListener("foo", listener2);
+		ctx.addEventListener("bar", listener1);
 		ctx.dispatchEvent(new Event("foo"));
-		Assert.is(mock.callCount, 1);
-		Assert.is(listener2.callCount, 1);
-	} finally {
-		mock.restore();
-	}
-});
+		expect(listener1.callCount).toBe(1);
+		expect(listener2.callCount).toBe(0);
+		renderer.render(null, document.body);
+		ctx.dispatchEvent(new Event("foo"));
+		ctx.dispatchEvent(new Event("bar"));
+		expect(listener1.callCount).toBe(1);
+		expect(listener2.callCount).toBe(0);
+	});
 
-test.run();
+	test("event props", () => {
+		let ctx!: Context;
+		function Component(this: Context, _props: {onfoo: (ev: Event) => any}) {
+			ctx = this;
+			return <span>Hello</span>;
+		}
+
+		const mock = Sinon.fake();
+		renderer.render(<Component onfoo={mock} />, document.body);
+		ctx.dispatchEvent(new Event("foo"));
+		expect(mock.callCount).toBe(1);
+	});
+
+	test("event props camelCased", () => {
+		let ctx!: Context;
+		function Component(this: Context, _props: {onFoo: (ev: Event) => any}) {
+			ctx = this;
+			return <span>Hello</span>;
+		}
+
+		const mock = Sinon.fake();
+		renderer.render(<Component onFoo={mock} />, document.body);
+		ctx.dispatchEvent(new Event("foo"));
+		expect(mock.callCount).toBe(1);
+	});
+
+	test("error thrown in listener", () => {
+		let ctx!: Context;
+		function Component(this: Context) {
+			ctx = this;
+			return <span>Hello</span>;
+		}
+
+		const mock = Sinon.stub(console, "error");
+		try {
+			renderer.render(
+				<div>
+					<Component />
+				</div>,
+				document.body,
+			);
+
+			const error = new Error("error thrown in listener and dispatchEvent");
+			const listener = () => {
+				throw error;
+			};
+			ctx.addEventListener("foo", listener);
+			ctx.dispatchEvent(new Event("foo"));
+			expect(mock.lastCall.args[0]).toBe(error);
+		} finally {
+			mock.restore();
+		}
+	});
+
+	test("errors do not affect other listeners", () => {
+		let ctx!: Context;
+		function Component(this: Context) {
+			ctx = this;
+			return <span>Hello</span>;
+		}
+
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		const mock = Sinon.stub(console, "error");
+		const listener1 = () => {
+			throw new Error("errors do not affect other listeners");
+		};
+
+		const listener2 = Sinon.mock();
+
+		try {
+			ctx.addEventListener("foo", listener1);
+			ctx.addEventListener("foo", listener2);
+			ctx.dispatchEvent(new Event("foo"));
+			expect(mock.callCount).toBe(1);
+			expect(listener2.callCount).toBe(1);
+		} finally {
+			mock.restore();
+		}
+	});
+});

--- a/test/html.tsx
+++ b/test/html.tsx
@@ -1,512 +1,515 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, expect} from "@b9g/libuild/test";
 import * as Sinon from "sinon";
 
 import {Copy, createElement, Fragment, Portal, Raw} from "../src/crank.js";
 import type {Children, Context} from "../src/crank.js";
 import {renderer} from "../src/html.js";
 
-const test = suite("html");
+describe("html", () => {
+	test("simple", () => {
+		expect(renderer.render(<h1>Hello world</h1>)).toBe("<h1>Hello world</h1>");
+	});
 
-test("simple", () => {
-	Assert.is(renderer.render(<h1>Hello world</h1>), "<h1>Hello world</h1>");
-});
+	test("multiple children", () => {
+		expect(
+			renderer.render(
+				<div>
+					<span>1</span>
+					<span>2</span>
+					<span>3</span>
+					<span>4</span>
+				</div>,
+			),
+		).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span></div>",
+		);
+	});
 
-test("multiple children", () => {
-	Assert.is(
-		renderer.render(
-			<div>
-				<span>1</span>
-				<span>2</span>
-				<span>3</span>
-				<span>4</span>
-			</div>,
-		),
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span></div>",
-	);
-});
+	test("nested children", () => {
+		expect(
+			renderer.render(
+				<div id="1">
+					<div id="2">
+						<div id="3">Hi</div>
+					</div>
+				</div>,
+			),
+		).toBe('<div id="1"><div id="2"><div id="3">Hi</div></div></div>');
+	});
 
-test("nested children", () => {
-	Assert.is(
-		renderer.render(
-			<div id="1">
-				<div id="2">
-					<div id="3">Hi</div>
-				</div>
-			</div>,
-		),
-		'<div id="1"><div id="2"><div id="3">Hi</div></div></div>',
-	);
-});
+	test("boolean replaces nested children", () => {
+		expect(
+			renderer.render(
+				<div id="1">
+					<div id="2">
+						<div id="3">Hi</div>
+					</div>
+				</div>,
+			),
+		).toBe('<div id="1"><div id="2"><div id="3">Hi</div></div></div>');
+	});
 
-test("boolean replaces nested children", () => {
-	Assert.is(
-		renderer.render(
-			<div id="1">
-				<div id="2">
-					<div id="3">Hi</div>
-				</div>
-			</div>,
-		),
-		'<div id="1"><div id="2"><div id="3">Hi</div></div></div>',
-	);
-});
+	test("attrs", () => {
+		expect(
+			renderer.render(
+				<Fragment>
+					<input id="toggle" type="checkbox" checked data-checked foo={false} />
+					<label for="toggle" />
+				</Fragment>,
+			),
+		).toBe(
+			'<input id="toggle" type="checkbox" checked data-checked><label for="toggle"></label>',
+		);
+	});
 
-test("attrs", () => {
-	Assert.is(
-		renderer.render(
-			<Fragment>
-				<input id="toggle" type="checkbox" checked data-checked foo={false} />
-				<label for="toggle" />
-			</Fragment>,
-		),
-		'<input id="toggle" type="checkbox" checked data-checked><label for="toggle"></label>',
-	);
-});
+	test("styles", () => {
+		expect(
+			renderer.render(
+				<Fragment>
+					<div style={{color: "red"}} />
+					<img
+						src="x"
+						style={{xss: 'foo;" onerror="alert(\'hack\')" other="'}}
+					/>
+				</Fragment>,
+			),
+		).toBe(
+			'<div style="color:red;"></div><img src="x" style="xss:foo;&quot; onerror=&quot;alert(&#039;hack&#039;)&quot; other=&quot;;">',
+		);
+	});
 
-test("styles", () => {
-	Assert.is(
-		renderer.render(
-			<Fragment>
-				<div style={{color: "red"}} />
-				<img src="x" style={{xss: 'foo;" onerror="alert(\'hack\')" other="'}} />
-			</Fragment>,
-		),
-		'<div style="color:red;"></div><img src="x" style="xss:foo;&quot; onerror=&quot;alert(&#039;hack&#039;)&quot; other=&quot;;">',
-	);
-});
+	test("style null", () => {
+		expect(renderer.render(<div style={null} />)).toBe("<div></div>");
+	});
 
-test("style null", () => {
-	Assert.is(renderer.render(<div style={null} />), "<div></div>");
-});
+	test("styles string", () => {
+		expect(renderer.render(<div style="color: red;" />)).toBe(
+			'<div style="color: red;"></div>',
+		);
+	});
 
-test("styles string", () => {
-	Assert.is(
-		renderer.render(<div style="color: red;" />),
-		'<div style="color: red;"></div>',
-	);
-});
+	test("styles camelCase", () => {
+		expect(
+			renderer.render(
+				<div
+					style={{
+						fontSize: "16px",
+						backgroundColor: "red",
+						marginTop: "10px",
+						borderRadius: "4px",
+						WebkitTransform: "rotate(45deg)",
+					}}
+				/>,
+			),
+		).toBe(
+			'<div style="font-size:16px;background-color:red;margin-top:10px;border-radius:4px;-webkit-transform:rotate(45deg);"></div>',
+		);
 
-test("styles camelCase", () => {
-	Assert.is(
-		renderer.render(
-			<div
-				style={{
-					fontSize: "16px",
-					backgroundColor: "red",
-					marginTop: "10px",
-					borderRadius: "4px",
-					WebkitTransform: "rotate(45deg)",
-				}}
-			/>,
-		),
-		'<div style="font-size:16px;background-color:red;margin-top:10px;border-radius:4px;-webkit-transform:rotate(45deg);"></div>',
-	);
+		// Test mixed camelCase and kebab-case
+		expect(
+			renderer.render(
+				<div
+					style={{
+						fontSize: "16px",
+						"background-color": "blue",
+						marginTop: "5px",
+					}}
+				/>,
+			),
+		).toBe(
+			'<div style="font-size:16px;background-color:blue;margin-top:5px;"></div>',
+		);
+	});
 
-	// Test mixed camelCase and kebab-case
-	Assert.is(
-		renderer.render(
-			<div
-				style={{
-					fontSize: "16px",
-					"background-color": "blue",
-					marginTop: "5px",
-				}}
-			/>,
-		),
-		'<div style="font-size:16px;background-color:blue;margin-top:5px;"></div>',
-	);
-});
+	test("styles numeric values with px conversion", () => {
+		expect(
+			renderer.render(
+				<div
+					style={{
+						width: 100,
+						height: 200,
+						opacity: 0.5,
+						zIndex: 10,
+						fontSize: 16,
+					}}
+				/>,
+			),
+		).toBe(
+			'<div style="width:100px;height:200px;opacity:0.5;z-index:10;font-size:16px;"></div>',
+		);
+	});
 
-test("styles numeric values with px conversion", () => {
-	Assert.is(
-		renderer.render(
-			<div
-				style={{
-					width: 100,
-					height: 200,
-					opacity: 0.5,
-					zIndex: 10,
-					fontSize: 16,
-				}}
-			/>,
-		),
-		'<div style="width:100px;height:200px;opacity:0.5;z-index:10;font-size:16px;"></div>',
-	);
-});
+	test("class and className", () => {
+		expect(
+			renderer.render(
+				<Fragment>
+					<div class="class1 class2" />
+					<div className="class1 class2" />
+					<div className="hidden" class="override" />
+					<div class="override" className="hidden" />
+					<div className={null} />
+					<div class={undefined} />
+				</Fragment>,
+			),
+		).toBe(
+			'<div class="class1 class2"></div><div class="class1 class2"></div><div class="override"></div><div class="override"></div><div></div><div></div>',
+		);
+	});
 
-test("class and className", () => {
-	Assert.is(
-		renderer.render(
-			<Fragment>
-				<div class="class1 class2" />
-				<div className="class1 class2" />
-				<div className="hidden" class="override" />
-				<div class="override" className="hidden" />
-				<div className={null} />
-				<div class={undefined} />
-			</Fragment>,
-		),
-		'<div class="class1 class2"></div><div class="class1 class2"></div><div class="override"></div><div class="override"></div><div></div><div></div>',
-	);
-});
+	test("class object syntax", () => {
+		expect(
+			renderer.render(
+				<div class={{active: true, disabled: false, primary: true}} />,
+			),
+		).toBe('<div class="active primary"></div>');
+	});
 
-test("class object syntax", () => {
-	Assert.is(
-		renderer.render(
-			<div class={{active: true, disabled: false, primary: true}} />,
-		),
-		'<div class="active primary"></div>',
-	);
-});
+	test("class object syntax with space-separated keys", () => {
+		expect(
+			renderer.render(
+				<div
+					class={{
+						"w-5 h-5 rounded-full": true,
+						"bg-green-500 text-white": true,
+						"bg-gray-200 text-gray-400": false,
+					}}
+				/>,
+			),
+		).toBe('<div class="w-5 h-5 rounded-full bg-green-500 text-white"></div>');
+	});
 
-test("class object syntax with space-separated keys", () => {
-	Assert.is(
-		renderer.render(
-			<div
-				class={{
-					"w-5 h-5 rounded-full": true,
-					"bg-green-500 text-white": true,
-					"bg-gray-200 text-gray-400": false,
-				}}
-			/>,
-		),
-		'<div class="w-5 h-5 rounded-full bg-green-500 text-white"></div>',
-	);
-});
+	test("null", () => {
+		expect(renderer.render(null)).toBe("");
+	});
 
-test("null", () => {
-	Assert.is(renderer.render(null), "");
-});
+	test("callbacks are not rendered", () => {
+		expect(
+			renderer.render(
+				<div
+					onclick={() => {
+						// do nothing
+					}}
+				/>,
+			),
+		).toBe("<div></div>");
+	});
 
-test("callbacks are not rendered", () => {
-	Assert.is(
-		renderer.render(
-			<div
-				onclick={() => {
-					// do nothing
-				}}
-			/>,
-		),
-		"<div></div>",
-	);
-});
+	test("fragment", () => {
+		expect(
+			renderer.render(
+				<Fragment>
+					<span>1</span>
+					<span>2</span>
+				</Fragment>,
+			),
+		).toBe("<span>1</span><span>2</span>");
+	});
 
-test("fragment", () => {
-	Assert.is(
-		renderer.render(
-			<Fragment>
-				<span>1</span>
-				<span>2</span>
-			</Fragment>,
-		),
-		"<span>1</span><span>2</span>",
-	);
-});
+	test("array", () => {
+		expect(
+			renderer.render(
+				<div>
+					<span>1</span>
+					{[<span>2</span>, <span>3</span>]}
+					<span>4</span>
+				</div>,
+			),
+		).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span></div>",
+		);
+	});
 
-test("array", () => {
-	Assert.is(
-		renderer.render(
-			<div>
-				<span>1</span>
-				{[<span>2</span>, <span>3</span>]}
-				<span>4</span>
-			</div>,
-		),
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span></div>",
-	);
-});
+	test("nested arrays", () => {
+		expect(
+			renderer.render(
+				<div>
+					<span>1</span>
+					{[<span>2</span>, [<span>3</span>, <span>4</span>], <span>5</span>]}
+					<span>6</span>
+				</div>,
+			),
+		).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></div>",
+		);
+	});
 
-test("nested arrays", () => {
-	Assert.is(
-		renderer.render(
-			<div>
-				<span>1</span>
-				{[<span>2</span>, [<span>3</span>, <span>4</span>], <span>5</span>]}
-				<span>6</span>
-			</div>,
-		),
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></div>",
-	);
-});
+	test("keyed array", () => {
+		const spans = [
+			<span key="2">2</span>,
+			<span key="3">3</span>,
+			<span key="4">4</span>,
+		];
+		expect(
+			renderer.render(
+				<div>
+					<span>1</span>
+					{spans}
+					<span>5</span>
+				</div>,
+			),
+		).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></div>",
+		);
+	});
 
-test("keyed array", () => {
-	const spans = [
-		<span key="2">2</span>,
-		<span key="3">3</span>,
-		<span key="4">4</span>,
-	];
-	Assert.is(
-		renderer.render(
-			<div>
-				<span>1</span>
-				{spans}
-				<span>5</span>
-			</div>,
-		),
+	test("escaped text", () => {
+		expect(renderer.render(<div>{"< > & \" '"}</div>)).toBe(
+			"<div>&lt; &gt; &amp; &quot; &#039;</div>",
+		);
+	});
 
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></div>",
-	);
-});
+	test("copied escaped text", () => {
+		const key = {};
+		expect(renderer.render(<div>{"< > & \" '"}</div>, key)).toBe(
+			"<div>&lt; &gt; &amp; &quot; &#039;</div>",
+		);
 
-test("escaped text", () => {
-	Assert.is(
-		renderer.render(<div>{"< > & \" '"}</div>),
-		"<div>&lt; &gt; &amp; &quot; &#039;</div>",
-	);
-});
+		expect(
+			renderer.render(
+				<div>
+					<Copy />
+				</div>,
+				key,
+			),
+		).toBe("<div>&lt; &gt; &amp; &quot; &#039;</div>");
+	});
 
-test("copied escaped text", () => {
-	const key = {};
-	Assert.is(
-		renderer.render(<div>{"< > & \" '"}</div>, key),
-		"<div>&lt; &gt; &amp; &quot; &#039;</div>",
-	);
+	test("raw html", () => {
+		const html = '<span id="raw">Hi</span>';
+		expect(
+			renderer.render(
+				<div>
+					Raw: <Raw value={html} />
+				</div>,
+			),
+		).toBe('<div>Raw: <span id="raw">Hi</span></div>');
+	});
 
-	Assert.is(
-		renderer.render(
-			<div>
-				<Copy />
-			</div>,
-			key,
-		),
-		"<div>&lt; &gt; &amp; &quot; &#039;</div>",
-	);
-});
-
-test("raw html", () => {
-	const html = '<span id="raw">Hi</span>';
-	Assert.is(
-		renderer.render(
-			<div>
-				Raw: <Raw value={html} />
-			</div>,
-		),
-		'<div>Raw: <span id="raw">Hi</span></div>',
-	);
-});
-
-test("sync generator components are cleaned up", () => {
-	const mock = Sinon.fake();
-	function* Component() {
-		let i = 0;
-		try {
-			while (true) {
-				yield <div>{i++}</div>;
+	test("sync generator components are cleaned up", () => {
+		const mock = Sinon.fake();
+		function* Component() {
+			let i = 0;
+			try {
+				while (true) {
+					yield <div>{i++}</div>;
+				}
+			} finally {
+				mock();
 			}
-		} finally {
-			mock();
 		}
-	}
 
-	Assert.is(renderer.render(<Component />), "<div>0</div>");
-	Assert.is(renderer.render(<Component />), "<div>0</div>");
-	Assert.is(mock.callCount, 2);
-});
+		expect(renderer.render(<Component />)).toBe("<div>0</div>");
+		expect(renderer.render(<Component />)).toBe("<div>0</div>");
+		expect(mock.callCount).toBe(2);
+	});
 
-test("async generator components are cleaned up", async () => {
-	const mock = Sinon.fake();
-	async function* Component(this: Context) {
-		let i = 0;
-		// TODO: investigate why using a while loop causes renderer.render to
-		// resolve to <div>1</div>
-		try {
-			for await (const _ of this) {
-				yield <div>{i++}</div>;
+	test("async generator components are cleaned up", async () => {
+		const mock = Sinon.fake();
+		async function* Component(this: Context) {
+			let i = 0;
+			// TODO: investigate why using a while loop causes renderer.render to
+			// resolve to <div>1</div>
+			try {
+				for await (const _ of this) {
+					yield <div>{i++}</div>;
+				}
+			} finally {
+				mock();
 			}
-		} finally {
-			mock();
 		}
-	}
 
-	Assert.is(await renderer.render(<Component />), "<div>0</div>");
-	Assert.is(await renderer.render(<Component />), "<div>0</div>");
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(mock.callCount, 2);
-});
+		expect(await renderer.render(<Component />)).toBe("<div>0</div>");
+		expect(await renderer.render(<Component />)).toBe("<div>0</div>");
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(mock.callCount).toBe(2);
+	});
 
-test("stateful", () => {
-	const mock = Sinon.fake();
-	function* Component() {
-		let i = 0;
-		try {
-			while (true) {
-				yield <div>{i++}</div>;
+	test("stateful", () => {
+		const mock = Sinon.fake();
+		function* Component() {
+			let i = 0;
+			try {
+				while (true) {
+					yield <div>{i++}</div>;
+				}
+			} finally {
+				mock();
 			}
-		} finally {
-			mock();
 		}
-	}
 
-	const key = {};
-	Assert.is(renderer.render(<Component />, key), "<div>0</div>");
-	Assert.is(renderer.render(<Component />, key), "<div>1</div>");
-	Assert.is(mock.callCount, 0);
-	Assert.is(renderer.render(null, key), "");
-	Assert.is(mock.callCount, 1);
-});
+		const key = {};
+		expect(renderer.render(<Component />, key)).toBe("<div>0</div>");
+		expect(renderer.render(<Component />, key)).toBe("<div>1</div>");
+		expect(mock.callCount).toBe(0);
+		expect(renderer.render(null, key)).toBe("");
+		expect(mock.callCount).toBe(1);
+	});
 
-test("prop: prefix is not rendered", () => {
-	Assert.is(renderer.render(<div prop:foo="bar" />), "<div></div>");
-});
+	test("prop: prefix is not rendered", () => {
+		expect(renderer.render(<div prop:foo="bar" />)).toBe("<div></div>");
+	});
 
-test("attr: prefix renders correctly", () => {
-	renderer.render(<custom-el />, document.body);
-	Assert.is(
-		renderer.render(<div attr:attr="value" />),
-		'<div attr="value"></div>',
-	);
-});
+	test("attr: prefix renders correctly", () => {
+		renderer.render(<custom-el />, document.body);
+		expect(renderer.render(<div attr:attr="value" />)).toBe(
+			'<div attr="value"></div>',
+		);
+	});
 
-test("after callback called once", async () => {
-	let i = 0;
-	const fn = Sinon.fake();
-	async function Component(this: Context) {
-		this.after(fn);
-		return <span>{i++}</span>;
-	}
-
-	const result = await renderer.render(
-		<div>
-			<Component />
-		</div>,
-	);
-
-	Assert.is(result, "<div><span>0</span></div>");
-	Assert.is(fn.callCount, 1);
-
-	const result1 = await renderer.render(
-		<div>
-			<Component />
-		</div>,
-	);
-
-	Assert.is(result1, "<div><span>1</span></div>");
-	Assert.is(fn.callCount, 2);
-});
-
-test("refs work", () => {
-	let mock = Sinon.fake();
-	renderer.render(<div ref={mock}>Hello world</div>);
-
-	Assert.is(mock.callCount, 1);
-	Assert.is(mock.firstCall.args[0], "<div>Hello world</div>");
-});
-
-test("schedule allows for re-render", () => {
-	function* Child(this: Context, {children}: {children: Children}) {
-		for ({children} of this) {
-			yield children;
+	test("after callback called once", async () => {
+		let i = 0;
+		const fn = Sinon.fake();
+		async function Component(this: Context) {
+			this.after(fn);
+			return <span>{i++}</span>;
 		}
-	}
 
-	function* Component(this: Context) {
-		for ({} of this) {
-			this.schedule(() => this.refresh());
-			yield <div>Render 1</div>;
-			yield (
-				<Child>
-					<div>Render 2</div>
-				</Child>
-			);
+		const result = await renderer.render(
+			<div>
+				<Component />
+			</div>,
+		);
+
+		expect(result).toBe("<div><span>0</span></div>");
+		expect(fn.callCount).toBe(1);
+
+		const result1 = await renderer.render(
+			<div>
+				<Component />
+			</div>,
+		);
+
+		expect(result1).toBe("<div><span>1</span></div>");
+		expect(fn.callCount).toBe(2);
+	});
+
+	test("refs work", () => {
+		let mock = Sinon.fake();
+		renderer.render(<div ref={mock}>Hello world</div>);
+
+		expect(mock.callCount).toBe(1);
+		expect(mock.firstCall.args[0]).toBe("<div>Hello world</div>");
+	});
+
+	test("schedule allows for re-render", () => {
+		function* Child(this: Context, {children}: {children: Children}) {
+			for ({children} of this) {
+				yield children;
+			}
 		}
-	}
 
-	const result = renderer.render(<Component />);
-	Assert.is(result, "<div>Render 2</div>");
-});
-
-test("schedule with async children on second render", async () => {
-	async function Child(this: Context, {children}: {children: Children}) {
-		await new Promise((resolve) => setTimeout(resolve, 10));
-		return children;
-	}
-
-	function* Component(this: Context) {
-		for ({} of this) {
-			this.schedule(() => this.refresh());
-			yield <div>Render 1</div>;
-			yield (
-				<Child>
-					<div>Render 2</div>
-				</Child>
-			);
+		function* Component(this: Context) {
+			for ({} of this) {
+				this.schedule(() => this.refresh());
+				yield <div>Render 1</div>;
+				yield (
+					<Child>
+						<div>Render 2</div>
+					</Child>
+				);
+			}
 		}
-	}
 
-	const result = await renderer.render(<Component />);
-	Assert.is(result, "<div>Render 2</div>");
+		const result = renderer.render(<Component />);
+		expect(result).toBe("<div>Render 2</div>");
+	});
+
+	test("schedule with async children on second render", async () => {
+		async function Child(this: Context, {children}: {children: Children}) {
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			return children;
+		}
+
+		function* Component(this: Context) {
+			for ({} of this) {
+				this.schedule(() => this.refresh());
+				yield <div>Render 1</div>;
+				yield (
+					<Child>
+						<div>Render 2</div>
+					</Child>
+				);
+			}
+		}
+
+		const result = await renderer.render(<Component />);
+		expect(result).toBe("<div>Render 2</div>");
+	});
+
+	test("htmlFor renders as for attribute", () => {
+		expect(renderer.render(<label htmlFor="email">Email</label>)).toBe(
+			'<label for="email">Email</label>',
+		);
+	});
+
+	test("htmlFor skipped when for is also present", () => {
+		expect(
+			renderer.render(
+				<label for="email" htmlFor="other">
+					Email
+				</label>,
+			),
+		).toBe('<label for="email">Email</label>');
+	});
+
+	test("Portal children are not included in HTML output", () => {
+		function MyPortal({children}: {children: Children}) {
+			return <Portal root={undefined}>{children}</Portal>;
+		}
+
+		const result = renderer.render(
+			<div>
+				Before
+				<MyPortal>
+					<span>Inside portal</span>
+				</MyPortal>
+				After
+			</div>,
+		);
+		// Portal children are dropped in the HTML renderer since there's no
+		// alternate root to render them into.
+		expect(result).toBe("<div>BeforeAfter</div>");
+	});
+
+	test("foreignObject resets SVG scope for children but not itself", () => {
+		expect(
+			renderer.render(
+				// eslint-disable-next-line crank/no-react-svg-props
+				<svg viewBox="0 0 100 100">
+					{/* eslint-disable crank/no-react-svg-props */}
+					<rect strokeWidth="2" />
+					<foreignObject
+						x="0"
+						y="0"
+						width="100"
+						height="100"
+						clipPath="url(#c)"
+					>
+						<div strokeWidth="2" />
+					</foreignObject>
+					{/* eslint-enable crank/no-react-svg-props */}
+				</svg>,
+			),
+		).toBe(
+			// rect and foreignObject get SVG prop mapping (stroke-width, clip-path)
+			// div inside foreignObject does NOT (strokeWidth stays as-is)
+			'<svg viewBox="0 0 100 100"><rect stroke-width="2"></rect><foreignObject x="0" y="0" width="100" height="100" clip-path="url(#c)"><div strokeWidth="2"></div></foreignObject></svg>',
+		);
+	});
+
+	test("dangerouslySetInnerHTML renders content", () => {
+		expect(
+			renderer.render(
+				<div dangerouslySetInnerHTML={{__html: "<b>bold</b>"}} />,
+			),
+		).toBe("<div><b>bold</b></div>");
+	});
+
+	test("dangerouslySetInnerHTML not rendered as attribute", () => {
+		const result = renderer.render(
+			<div dangerouslySetInnerHTML={{__html: "<em>hi</em>"}} />,
+		) as string;
+		expect(!result.includes("dangerouslySetInnerHTML")).toBeTruthy();
+		expect(result).toBe("<div><em>hi</em></div>");
+	});
 });
-
-test("htmlFor renders as for attribute", () => {
-	Assert.is(
-		renderer.render(<label htmlFor="email">Email</label>),
-		'<label for="email">Email</label>',
-	);
-});
-
-test("htmlFor skipped when for is also present", () => {
-	Assert.is(
-		renderer.render(
-			<label for="email" htmlFor="other">
-				Email
-			</label>,
-		),
-		'<label for="email">Email</label>',
-	);
-});
-
-test("Portal children are not included in HTML output", () => {
-	function MyPortal({children}: {children: Children}) {
-		return <Portal root={undefined}>{children}</Portal>;
-	}
-
-	const result = renderer.render(
-		<div>
-			Before
-			<MyPortal>
-				<span>Inside portal</span>
-			</MyPortal>
-			After
-		</div>,
-	);
-	// Portal children are dropped in the HTML renderer since there's no
-	// alternate root to render them into.
-	Assert.is(result, "<div>BeforeAfter</div>");
-});
-
-test("foreignObject resets SVG scope for children but not itself", () => {
-	Assert.is(
-		renderer.render(
-			// eslint-disable-next-line crank/no-react-svg-props
-			<svg viewBox="0 0 100 100">
-				{/* eslint-disable crank/no-react-svg-props */}
-				<rect strokeWidth="2" />
-				<foreignObject x="0" y="0" width="100" height="100" clipPath="url(#c)">
-					<div strokeWidth="2" />
-				</foreignObject>
-				{/* eslint-enable crank/no-react-svg-props */}
-			</svg>,
-		),
-		// rect and foreignObject get SVG prop mapping (stroke-width, clip-path)
-		// div inside foreignObject does NOT (strokeWidth stays as-is)
-		'<svg viewBox="0 0 100 100"><rect stroke-width="2"></rect><foreignObject x="0" y="0" width="100" height="100" clip-path="url(#c)"><div strokeWidth="2"></div></foreignObject></svg>',
-	);
-});
-
-test("dangerouslySetInnerHTML renders content", () => {
-	Assert.is(
-		renderer.render(<div dangerouslySetInnerHTML={{__html: "<b>bold</b>"}} />),
-		"<div><b>bold</b></div>",
-	);
-});
-
-test("dangerouslySetInnerHTML not rendered as attribute", () => {
-	const result = renderer.render(
-		<div dangerouslySetInnerHTML={{__html: "<em>hi</em>"}} />,
-	) as string;
-	Assert.ok(!result.includes("dangerouslySetInnerHTML"));
-	Assert.is(result, "<div><em>hi</em></div>");
-});
-
-test.run();

--- a/test/hydration.tsx
+++ b/test/hydration.tsx
@@ -1,6 +1,5 @@
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 /// <ref lib="dom" />
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
 import * as Sinon from "sinon";
 import {
 	createElement,
@@ -13,998 +12,1014 @@ import type {Context} from "../src/crank.js";
 
 import {renderer} from "../src/dom.js";
 
-const test = suite("hydration");
-let consoleWarn: Sinon.SinonStub;
-let container: HTMLDivElement;
-test.before.each(() => {
-	document.body.innerHTML = "";
-	container = document.createElement("div");
-	document.body.appendChild(container);
-	consoleWarn = Sinon.stub(console, "warn");
-});
+describe("hydration", () => {
+	let consoleWarn: Sinon.SinonStub;
+	let container: HTMLDivElement;
+	// libuild's browser runner has no test.skip, so these stay registered as no-ops
+	// rather than being deleted. They were already disabled under uvu.
+	const skip = (_name: string, _fn: () => unknown): void => {};
 
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-	consoleWarn.restore();
-});
-
-test("simple", () => {
-	container.innerHTML = "<button>Click</button>";
-	const button = container.firstChild as HTMLButtonElement;
-	const onclick = Sinon.fake();
-	renderer.hydrate(<button onclick={onclick}>Click</button>, container);
-
-	Assert.is(container.innerHTML, "<button>Click</button>");
-	Assert.is(container.firstChild, button);
-	button.click();
-	Assert.ok(onclick.called);
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("fragment", () => {
-	container.innerHTML = "<button>Click</button>";
-	const button = container.firstChild as HTMLButtonElement;
-	const onclick = Sinon.fake();
-	renderer.hydrate(
-		<Fragment>
-			<button onclick={onclick}>Click</button>
-		</Fragment>,
-		container,
-	);
-
-	Assert.is(container.innerHTML, "<button>Click</button>");
-	Assert.is(container.firstChild, button);
-	button.click();
-	Assert.ok(onclick.called);
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("sync function component", () => {
-	container.innerHTML = "<button>Click</button>";
-	const button = container.firstChild as HTMLButtonElement;
-
-	const onclick = Sinon.fake();
-	const Component = Sinon.fake(function Component() {
-		return <button onclick={onclick}>Click</button>;
+	beforeEach(() => {
+		document.body.innerHTML = "";
+		container = document.createElement("div");
+		document.body.appendChild(container);
+		consoleWarn = Sinon.stub(console, "warn");
 	});
 
-	renderer.hydrate(<Component />, container);
-
-	Assert.ok(Component.called);
-	Assert.is(container.innerHTML, "<button>Click</button>");
-	Assert.is(container.firstChild, button);
-	button.click();
-	Assert.ok(onclick.called);
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("sync generator component", () => {
-	container.innerHTML = "<button>Click</button>";
-	const button = container.firstChild as HTMLButtonElement;
-
-	const onclick = Sinon.fake();
-	const Component = Sinon.fake(function* Component(this: Context) {
-		for ({} of this) {
-			yield <button onclick={onclick}>Click</button>;
-		}
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+		consoleWarn.restore();
 	});
 
-	renderer.hydrate(<Component />, container);
+	test("simple", () => {
+		container.innerHTML = "<button>Click</button>";
+		const button = container.firstChild as HTMLButtonElement;
+		const onclick = Sinon.fake();
+		renderer.hydrate(<button onclick={onclick}>Click</button>, container);
 
-	Assert.ok(Component.called);
-	Assert.is(container.innerHTML, "<button>Click</button>");
-	Assert.is(container.firstChild, button);
-	button.click();
-	Assert.ok(onclick.called);
-	Assert.is(consoleWarn.callCount, 0);
-});
+		expect(container.innerHTML).toBe("<button>Click</button>");
+		expect(container.firstChild).toBe(button);
+		button.click();
+		expect(onclick.called).toBeTruthy();
+		expect(consoleWarn.callCount).toBe(0);
+	});
 
-test("refresh", () => {
-	container.innerHTML = "<button>Click</button>";
-	const button = container.firstChild as HTMLButtonElement;
+	test("fragment", () => {
+		container.innerHTML = "<button>Click</button>";
+		const button = container.firstChild as HTMLButtonElement;
+		const onclick = Sinon.fake();
+		renderer.hydrate(
+			<Fragment>
+				<button onclick={onclick}>Click</button>
+			</Fragment>,
+			container,
+		);
 
-	const onclick = Sinon.fake();
-	const Component = Sinon.fake(function* Component(this: Context) {
-		let count = 0;
-		for ({} of this) {
-			yield (
-				<button
-					onclick={() => {
-						onclick();
-						count++;
-						this.refresh();
-					}}
-				>
-					Click {count}
-				</button>
+		expect(container.innerHTML).toBe("<button>Click</button>");
+		expect(container.firstChild).toBe(button);
+		button.click();
+		expect(onclick.called).toBeTruthy();
+		expect(consoleWarn.callCount).toBe(0);
+	});
+
+	test("sync function component", () => {
+		container.innerHTML = "<button>Click</button>";
+		const button = container.firstChild as HTMLButtonElement;
+
+		const onclick = Sinon.fake();
+		const Component = Sinon.fake(function Component() {
+			return <button onclick={onclick}>Click</button>;
+		});
+
+		renderer.hydrate(<Component />, container);
+
+		expect(Component.called).toBeTruthy();
+		expect(container.innerHTML).toBe("<button>Click</button>");
+		expect(container.firstChild).toBe(button);
+		button.click();
+		expect(onclick.called).toBeTruthy();
+		expect(consoleWarn.callCount).toBe(0);
+	});
+
+	test("sync generator component", () => {
+		container.innerHTML = "<button>Click</button>";
+		const button = container.firstChild as HTMLButtonElement;
+
+		const onclick = Sinon.fake();
+		const Component = Sinon.fake(function* Component(this: Context) {
+			for ({} of this) {
+				yield <button onclick={onclick}>Click</button>;
+			}
+		});
+
+		renderer.hydrate(<Component />, container);
+
+		expect(Component.called).toBeTruthy();
+		expect(container.innerHTML).toBe("<button>Click</button>");
+		expect(container.firstChild).toBe(button);
+		button.click();
+		expect(onclick.called).toBeTruthy();
+		expect(consoleWarn.callCount).toBe(0);
+	});
+
+	test("refresh", () => {
+		container.innerHTML = "<button>Click</button>";
+		const button = container.firstChild as HTMLButtonElement;
+
+		const onclick = Sinon.fake();
+		const Component = Sinon.fake(function* Component(this: Context) {
+			let count = 0;
+			for ({} of this) {
+				yield (
+					<button
+						onclick={() => {
+							onclick();
+							count++;
+							this.refresh();
+						}}
+					>
+						Click {count}
+					</button>
+				);
+			}
+		});
+
+		renderer.hydrate(<Component />, container);
+
+		expect(Component.called).toBeTruthy();
+		expect(container.innerHTML).toBe("<button>Click 0</button>");
+		expect(container.firstChild).toBe(button);
+		button.click();
+		expect(onclick.called).toBeTruthy();
+		expect(container.innerHTML).toBe("<button>Click 1</button>");
+		expect(container.firstChild).toBe(button);
+		expect(consoleWarn.callCount).toBe(2);
+	});
+
+	test("async function component", async () => {
+		container.innerHTML = "<button>Click</button>";
+		const button = container.firstChild as HTMLButtonElement;
+
+		const onclick = Sinon.fake();
+		const Component = Sinon.fake(async function Component() {
+			return <button onclick={onclick}>Click</button>;
+		});
+
+		await renderer.hydrate(<Component />, container);
+
+		expect(Component.called).toBeTruthy();
+		expect(container.innerHTML).toBe("<button>Click</button>");
+		expect(container.firstChild).toBe(button);
+		button.click();
+		expect(onclick.called).toBeTruthy();
+		expect(consoleWarn.callCount).toBe(0);
+	});
+
+	test("async generator component", async () => {
+		container.innerHTML = "<button>Click</button>";
+		const button = container.firstChild as HTMLButtonElement;
+
+		const onclick = Sinon.fake();
+		const Component = Sinon.fake(async function* Component(this: Context) {
+			for await ({} of this) {
+				yield <button onclick={onclick}>Click</button>;
+			}
+		});
+
+		await renderer.hydrate(<Component />, container);
+
+		expect(Component.called).toBeTruthy();
+		expect(container.innerHTML).toBe("<button>Click</button>");
+		expect(container.firstChild).toBe(button);
+		button.click();
+		expect(onclick.called).toBeTruthy();
+		expect(consoleWarn.callCount).toBe(0);
+	});
+
+	test("async component and host sibling", async () => {
+		container.innerHTML =
+			"<div><div><button>Slow</button></div><button>Fast</button></div>";
+		const div = container.firstChild!;
+		const button1 = div.childNodes[0].childNodes[0] as HTMLButtonElement;
+		const button2 = div.childNodes[1] as HTMLButtonElement;
+		const onclick1 = Sinon.fake();
+		const onclick2 = Sinon.fake();
+		async function Component() {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+			return (
+				<div>
+					<button onclick={onclick1}>Slow</button>
+				</div>
 			);
 		}
+
+		await renderer.hydrate(
+			<div>
+				<Component />
+				<button onclick={onclick2}>Fast</button>
+			</div>,
+			container,
+		);
+		expect(container.innerHTML).toBe(
+			"<div><div><button>Slow</button></div><button>Fast</button></div>",
+		);
+		expect(container.firstChild).toBe(div);
+		expect(container.firstChild!.childNodes[0].childNodes[0]).toBe(button1);
+		expect(container.firstChild!.childNodes[1]).toBe(button2);
+		button1.click();
+		button2.click();
+		expect(onclick1.called).toBeTruthy();
+		expect(onclick2.called).toBeTruthy();
+		expect(consoleWarn.callCount).toBe(0);
 	});
 
-	renderer.hydrate(<Component />, container);
-
-	Assert.ok(Component.called);
-	Assert.is(container.innerHTML, "<button>Click 0</button>");
-	Assert.is(container.firstChild, button);
-	button.click();
-	Assert.ok(onclick.called);
-	Assert.is(container.innerHTML, "<button>Click 1</button>");
-	Assert.is(container.firstChild, button);
-	Assert.is(consoleWarn.callCount, 2);
-});
-
-test("async function component", async () => {
-	container.innerHTML = "<button>Click</button>";
-	const button = container.firstChild as HTMLButtonElement;
-
-	const onclick = Sinon.fake();
-	const Component = Sinon.fake(async function Component() {
-		return <button onclick={onclick}>Click</button>;
-	});
-
-	await renderer.hydrate(<Component />, container);
-
-	Assert.ok(Component.called);
-	Assert.is(container.innerHTML, "<button>Click</button>");
-	Assert.is(container.firstChild, button);
-	button.click();
-	Assert.ok(onclick.called);
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("async generator component", async () => {
-	container.innerHTML = "<button>Click</button>";
-	const button = container.firstChild as HTMLButtonElement;
-
-	const onclick = Sinon.fake();
-	const Component = Sinon.fake(async function* Component(this: Context) {
-		for await ({} of this) {
-			yield <button onclick={onclick}>Click</button>;
+	test("async sibling components resolve out of order", async () => {
+		container.innerHTML =
+			"<div><button>Slow</button><button>Fast</button></div>";
+		const div = container.firstChild!;
+		const button1 = div.childNodes[0] as HTMLButtonElement;
+		const button2 = div.childNodes[1] as HTMLButtonElement;
+		const onclick1 = Sinon.fake();
+		const onclick2 = Sinon.fake();
+		async function Slow() {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+			return <button onclick={onclick1}>Slow</button>;
 		}
+
+		async function Fast() {
+			return <button onclick={onclick2}>Fast</button>;
+		}
+
+		function Component() {
+			return (
+				<div>
+					<Slow />
+					<Fast />
+				</div>
+			);
+		}
+
+		await renderer.hydrate(<Component />, container);
+		expect(container.innerHTML).toBe(
+			"<div><button>Slow</button><button>Fast</button></div>",
+		);
+
+		expect(container.firstChild).toBe(div);
+		expect(container.firstChild!.childNodes[0]).toBe(button1);
+		expect(container.firstChild!.childNodes[1]).toBe(button2);
+		button1.click();
+		button2.click();
+		expect(onclick1.called).toBeTruthy();
+		expect(onclick2.called).toBeTruthy();
+		expect(consoleWarn.callCount).toBe(0);
 	});
 
-	await renderer.hydrate(<Component />, container);
+	test("text sibling", async () => {
+		container.innerHTML = "<div>Text1<button>Click</button>Text2</div>";
+		const div = container.firstChild!;
+		const text1 = div.childNodes[0] as Text;
+		const button = div.childNodes[1] as HTMLButtonElement;
+		const text2 = div.childNodes[2] as Text;
+		const Component = Sinon.fake(function () {
+			return (
+				<Fragment>
+					Text1<button onclick={onclick}>Click</button>Text2
+				</Fragment>
+			);
+		});
 
-	Assert.ok(Component.called);
-	Assert.is(container.innerHTML, "<button>Click</button>");
-	Assert.is(container.firstChild, button);
-	button.click();
-	Assert.ok(onclick.called);
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("async component and host sibling", async () => {
-	container.innerHTML =
-		"<div><div><button>Slow</button></div><button>Fast</button></div>";
-	const div = container.firstChild!;
-	const button1 = div.childNodes[0].childNodes[0] as HTMLButtonElement;
-	const button2 = div.childNodes[1] as HTMLButtonElement;
-	const onclick1 = Sinon.fake();
-	const onclick2 = Sinon.fake();
-	async function Component() {
-		await new Promise((resolve) => setTimeout(resolve, 5));
-		return (
+		renderer.hydrate(
 			<div>
-				<button onclick={onclick1}>Slow</button>
-			</div>
+				<Component />
+			</div>,
+			container,
 		);
-	}
 
-	await renderer.hydrate(
-		<div>
-			<Component />
-			<button onclick={onclick2}>Fast</button>
-		</div>,
-		container,
-	);
-	Assert.is(
-		container.innerHTML,
-		"<div><div><button>Slow</button></div><button>Fast</button></div>",
-	);
-	Assert.is(container.firstChild, div);
-	Assert.is(container.firstChild!.childNodes[0].childNodes[0], button1);
-	Assert.is(container.firstChild!.childNodes[1], button2);
-	button1.click();
-	button2.click();
-	Assert.ok(onclick1.called);
-	Assert.ok(onclick2.called);
-	Assert.is(consoleWarn.callCount, 0);
-});
+		expect(container.innerHTML).toBe(
+			"<div>Text1<button>Click</button>Text2</div>",
+		);
 
-test("async sibling components resolve out of order", async () => {
-	container.innerHTML = "<div><button>Slow</button><button>Fast</button></div>";
-	const div = container.firstChild!;
-	const button1 = div.childNodes[0] as HTMLButtonElement;
-	const button2 = div.childNodes[1] as HTMLButtonElement;
-	const onclick1 = Sinon.fake();
-	const onclick2 = Sinon.fake();
-	async function Slow() {
-		await new Promise((resolve) => setTimeout(resolve, 5));
-		return <button onclick={onclick1}>Slow</button>;
-	}
+		expect(container.firstChild).toBe(div);
+		expect(container.firstChild!.childNodes[0]).toBe(text1);
+		expect(container.firstChild!.childNodes[1]).toBe(button);
+		expect(container.firstChild!.childNodes[2]).toBe(text2);
+		expect(consoleWarn.callCount).toBe(0);
+	});
 
-	async function Fast() {
-		return <button onclick={onclick2}>Fast</button>;
-	}
+	test("split text", async () => {
+		container.innerHTML = "<div>Text1Text2<button>Click</button></div>";
+		const div = container.firstChild!;
+		const text = div.childNodes[0] as Text;
+		const button = div.childNodes[1] as HTMLButtonElement;
+		const Component = Sinon.fake(function () {
+			return (
+				<Fragment>
+					{"Text1"}
+					{"Text2"}
+					<button onclick={onclick}>Click</button>
+				</Fragment>
+			);
+		});
 
-	function Component() {
-		return (
+		renderer.hydrate(
 			<div>
-				<Slow />
-				<Fast />
-			</div>
+				<Component />
+			</div>,
+			container,
 		);
-	}
 
-	await renderer.hydrate(<Component />, container);
-	Assert.is(
-		container.innerHTML,
-		"<div><button>Slow</button><button>Fast</button></div>",
-	);
+		expect(container.innerHTML).toBe(
+			"<div>Text1Text2<button>Click</button></div>",
+		);
 
-	Assert.is(container.firstChild, div);
-	Assert.is(container.firstChild!.childNodes[0], button1);
-	Assert.is(container.firstChild!.childNodes[1], button2);
-	button1.click();
-	button2.click();
-	Assert.ok(onclick1.called);
-	Assert.ok(onclick2.called);
-	Assert.is(consoleWarn.callCount, 0);
-});
+		expect(container.firstChild).toBe(div);
+		expect(container.firstChild!.childNodes[0]).toBe(text);
+		expect(container.firstChild!.childNodes[1].nodeType).toBe(Node.TEXT_NODE);
+		expect(container.firstChild!.childNodes[2]).toBe(button);
+		expect(consoleWarn.callCount).toBe(0);
+	});
 
-test("text sibling", async () => {
-	container.innerHTML = "<div>Text1<button>Click</button>Text2</div>";
-	const div = container.firstChild!;
-	const text1 = div.childNodes[0] as Text;
-	const button = div.childNodes[1] as HTMLButtonElement;
-	const text2 = div.childNodes[2] as Text;
-	const Component = Sinon.fake(function () {
-		return (
+	test("mismatched tag", () => {
+		container.innerHTML = "<div>Hello</div>";
+		const onclick = Sinon.fake();
+		const Component = Sinon.fake(function () {
+			return <button onclick={onclick}>Click</button>;
+		});
+
+		renderer.hydrate(<Component />, container);
+		expect(Component.called).toBeTruthy();
+		expect(container.innerHTML).toBe("<button>Click</button>");
+		expect(consoleWarn.callCount).toBe(1);
+	});
+
+	test("mismatched text", () => {
+		container.innerHTML = "<button>Do not click</button>";
+		const button = container.firstChild as HTMLButtonElement;
+		const onclick = Sinon.fake();
+
+		const Component = Sinon.fake(function () {
+			return <button onclick={onclick}>Click</button>;
+		});
+
+		renderer.hydrate(<Component />, container);
+		expect(Component.called).toBeTruthy();
+		expect(container.innerHTML).toBe("<button>Click</button>");
+		expect(container.firstChild).toBe(button);
+		button.click();
+		expect(onclick.called).toBeTruthy();
+		expect(consoleWarn.callCount).toBe(1);
+	});
+
+	test("missing element", () => {
+		function Component() {
+			return <button>Click</button>;
+		}
+
+		renderer.hydrate(<Component />, container);
+		expect(container.innerHTML).toBe("<button>Click</button>");
+		expect(consoleWarn.callCount).toBe(1);
+	});
+
+	test("raw element", () => {
+		container.innerHTML = "<div><div>Raw</div><button>Click</button></div>";
+		const onclick = Sinon.fake();
+		const button = container.childNodes[0].childNodes[1] as HTMLButtonElement;
+		const Component = Sinon.fake(function () {
+			return (
+				<div>
+					<Raw value="<div>Raw</div>" />
+					<button onclick={onclick}>Click</button>
+				</div>
+			);
+		});
+
+		renderer.hydrate(<Component />, container);
+		expect(Component.called).toBeTruthy();
+		expect(container.innerHTML).toBe(
+			"<div><div>Raw</div><button>Click</button></div>",
+		);
+		expect(container.childNodes[0].childNodes[1]).toBe(button);
+		button.click();
+		expect(onclick.called).toBeTruthy();
+		expect(consoleWarn.callCount).toBe(0);
+	});
+
+	test("raw multiple elements", () => {
+		container.innerHTML =
+			"<div><div>Raw 1</div><div>Raw 2</div><button>Click</button></div>";
+		const onclick = Sinon.fake();
+		const button = container.childNodes[0].childNodes[2] as HTMLButtonElement;
+		const Component = Sinon.fake(function () {
+			return (
+				<div>
+					<Raw value="<div>Raw 1</div><div>Raw 2</div>" />
+					<button onclick={onclick}>Click</button>
+				</div>
+			);
+		});
+
+		renderer.hydrate(<Component />, container);
+		expect(Component.called).toBeTruthy();
+		expect(container.innerHTML).toBe(
+			"<div><div>Raw 1</div><div>Raw 2</div><button>Click</button></div>",
+		);
+		expect(container.childNodes[0].childNodes[2]).toBe(button);
+		button.click();
+		expect(onclick.called).toBeTruthy();
+	});
+
+	test("raw text", () => {
+		container.innerHTML = "<div>Raw<button>Click</button></div>";
+		const onclick = Sinon.fake();
+		const button = container.childNodes[0].childNodes[1] as HTMLButtonElement;
+		const Component = Sinon.fake(function () {
+			return (
+				<div>
+					<Raw value="Raw" />
+					<button onclick={onclick}>Click</button>
+				</div>
+			);
+		});
+
+		renderer.hydrate(<Component />, container);
+		expect(Component.called).toBeTruthy();
+		expect(container.innerHTML).toBe("<div>Raw<button>Click</button></div>");
+		expect(container.childNodes[0].childNodes[1]).toBe(button);
+		button.click();
+		expect(onclick.called).toBeTruthy();
+		expect(consoleWarn.callCount).toBe(0);
+	});
+
+	test("raw comment", () => {
+		container.innerHTML =
+			"<div><!-- comment -->Hello<button>Click</button></div>";
+		const onclick = Sinon.fake();
+		const button = container.childNodes[0].childNodes[2] as HTMLButtonElement;
+		const Component = Sinon.fake(function () {
+			return (
+				<div>
+					<Raw value="<!-- comment -->" />
+					Hello
+					<button onclick={onclick}>Click</button>
+				</div>
+			);
+		});
+
+		renderer.hydrate(<Component />, container);
+		expect(Component.called).toBeTruthy();
+		expect(container.innerHTML).toBe(
+			"<div><!-- comment -->Hello<button>Click</button></div>",
+		);
+
+		expect(container.childNodes[0].childNodes[2]).toBe(button);
+		button.click();
+		expect(onclick.called).toBeTruthy();
+		expect(consoleWarn.callCount).toBe(0);
+	});
+
+	test("ref called with hydrated element", () => {
+		container.innerHTML = "<button>Click</button>";
+		const button = container.firstChild as HTMLButtonElement;
+		const ref = Sinon.fake();
+		const onclick = Sinon.fake();
+
+		renderer.hydrate(
+			<button ref={ref} onclick={onclick}>
+				Click
+			</button>,
+			container,
+		);
+
+		expect(container.innerHTML).toBe("<button>Click</button>");
+		expect(container.firstChild).toBe(button);
+		expect(ref.calledOnce).toBeTruthy();
+		expect(ref.lastCall.firstArg).toBe(button);
+		button.click();
+		expect(onclick.called).toBeTruthy();
+		expect(consoleWarn.callCount).toBe(0);
+	});
+
+	test("warns when attribute present but should be missing during hydration", () => {
+		container.innerHTML = `<div foo="bar"></div>`;
+		renderer.hydrate(<div foo={null} />, container);
+		expect(consoleWarn.callCount).toBe(1);
+		expect(consoleWarn.firstCall.args[0]).toMatch(
+			/Expected "foo" to be missing/,
+		);
+	});
+
+	test("warns when attribute missing but should be present during hydration", () => {
+		container.innerHTML = `<div></div>`;
+		renderer.hydrate(<div foo={true} />, container);
+		expect(consoleWarn.callCount).toBe(1);
+		expect(consoleWarn.firstCall.args[0]).toMatch(/Expected "foo" to be ""/);
+	});
+
+	test("warns when attribute value mismatches during hydration", () => {
+		container.innerHTML = `<div foo="baz"></div>`;
+		renderer.hydrate(<div foo="bar" />, container);
+		expect(consoleWarn.callCount).toBe(1);
+		expect(consoleWarn.firstCall.args[0]).toMatch(/Expected "foo" to be "bar"/);
+	});
+
+	test("warns when style present but should be missing during hydration", () => {
+		container.innerHTML = `<div style="color: red"></div>`;
+		renderer.hydrate(<div style={null} />, container);
+		expect(consoleWarn.callCount).toBe(1);
+		expect(consoleWarn.firstCall.args[0]).toMatch(
+			/Expected "style" to be missing/,
+		);
+	});
+
+	skip("warns when style should be empty string during hydration", () => {
+		container.innerHTML = `<div style="color: red"></div>`;
+		renderer.hydrate(<div style="" />, container);
+		expect(consoleWarn.callCount).toBe(1);
+		expect(consoleWarn.firstCall.args[0]).toMatch(/Expected "style" to be ""/);
+	});
+
+	skip("warns when style value mismatches during hydration", () => {
+		container.innerHTML = `<div style="color: red"></div>`;
+		renderer.hydrate(<div style="color: blue" />, container);
+		expect(consoleWarn.callCount).toBe(1);
+		expect(consoleWarn.firstCall.args[0]).toMatch(
+			/Expected "style" to be "color: blue"/,
+		);
+	});
+
+	test("warns when class present but should be missing during hydration", () => {
+		container.innerHTML = `<div class="foo"></div>`;
+		renderer.hydrate(<div class={null} />, container);
+		expect(consoleWarn.callCount).toBe(1);
+		expect(consoleWarn.firstCall.args[0]).toMatch(
+			/Expected "class" to be missing/,
+		);
+	});
+
+	test("warns when class should be empty string during hydration", () => {
+		container.innerHTML = `<div class="foo"></div>`;
+		renderer.hydrate(<div class="" />, container);
+		expect(consoleWarn.callCount).toBe(1);
+		expect(consoleWarn.firstCall.args[0]).toMatch(/Expected "class" to be ""/);
+	});
+
+	test("warns when class value mismatches during hydration", () => {
+		container.innerHTML = `<div class="foo"></div>`;
+		renderer.hydrate(<div class="bar" />, container);
+		expect(consoleWarn.callCount).toBe(1);
+		expect(consoleWarn.firstCall.args[0]).toMatch(
+			/Expected "class" to be "bar"/,
+		);
+	});
+
+	test("warns when innerHTML mismatches during hydration", () => {
+		container.innerHTML = `<div>baz</div>`;
+		renderer.hydrate(<div innerHTML="bar" />, container);
+		expect(consoleWarn.callCount).toBe(1);
+		expect(consoleWarn.firstCall.args[0]).toMatch(
+			/Expected "innerHTML" to be "bar"/,
+		);
+	});
+
+	test("warns when style property present but should be missing during hydration", () => {
+		container.innerHTML = `<div style="color: red"></div>`;
+		renderer.hydrate(<div style={{color: null}} />, container);
+		expect(consoleWarn.callCount).toBe(1);
+		expect(consoleWarn.firstCall.args[0]).toMatch(
+			/Expected "style\.color" to be missing/,
+		);
+	});
+
+	test("warns when id mismatches during hydration", () => {
+		container.innerHTML = `<div id="server"></div>`;
+		renderer.hydrate(<div id="client" />, container);
+		expect(consoleWarn.callCount).toBe(1);
+		expect(consoleWarn.firstCall.args[0]).toMatch(
+			/Expected "id" to be "client"/,
+		);
+	});
+
+	test("warns when input type and value mismatches during hydration", () => {
+		container.innerHTML = `<input type="email" value="server">`;
+		renderer.hydrate(<input type="text" value="client" />, container);
+		expect(consoleWarn.callCount).toBe(2);
+		expect(consoleWarn.firstCall.args[0]).toMatch(
+			/Expected "type" to be "text"/,
+		);
+		expect(consoleWarn.secondCall.args[0]).toMatch(
+			/Expected "value" to be "client"/,
+		);
+	});
+
+	skip("warns when style property value mismatches during hydration", () => {
+		container.innerHTML = `<div style="color: red"></div>`;
+		renderer.hydrate(<div style={{color: "blue"}} />, container);
+		expect(consoleWarn.callCount).toBe(1);
+		expect(consoleWarn.firstCall.args[0]).toMatch(
+			/Expected "style\.color" to be "blue"/,
+		);
+	});
+
+	test("hydrate={true} can be used to continue hydration", () => {
+		container.innerHTML = `<button>Click</button>Hello`;
+		const button = container.firstChild as HTMLButtonElement;
+		renderer.hydrate(
 			<Fragment>
-				Text1<button onclick={onclick}>Click</button>Text2
-			</Fragment>
-		);
-	});
-
-	renderer.hydrate(
-		<div>
-			<Component />
-		</div>,
-		container,
-	);
-
-	Assert.is(container.innerHTML, "<div>Text1<button>Click</button>Text2</div>");
-
-	Assert.is(container.firstChild, div);
-	Assert.is(container.firstChild!.childNodes[0], text1);
-	Assert.is(container.firstChild!.childNodes[1], button);
-	Assert.is(container.firstChild!.childNodes[2], text2);
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("split text", async () => {
-	container.innerHTML = "<div>Text1Text2<button>Click</button></div>";
-	const div = container.firstChild!;
-	const text = div.childNodes[0] as Text;
-	const button = div.childNodes[1] as HTMLButtonElement;
-	const Component = Sinon.fake(function () {
-		return (
-			<Fragment>
-				{"Text1"}
-				{"Text2"}
-				<button onclick={onclick}>Click</button>
-			</Fragment>
-		);
-	});
-
-	renderer.hydrate(
-		<div>
-			<Component />
-		</div>,
-		container,
-	);
-
-	Assert.is(container.innerHTML, "<div>Text1Text2<button>Click</button></div>");
-
-	Assert.is(container.firstChild, div);
-	Assert.is(container.firstChild!.childNodes[0], text);
-	Assert.is(container.firstChild!.childNodes[1].nodeType, Node.TEXT_NODE);
-	Assert.is(container.firstChild!.childNodes[2], button);
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("mismatched tag", () => {
-	container.innerHTML = "<div>Hello</div>";
-	const onclick = Sinon.fake();
-	const Component = Sinon.fake(function () {
-		return <button onclick={onclick}>Click</button>;
-	});
-
-	renderer.hydrate(<Component />, container);
-	Assert.ok(Component.called);
-	Assert.is(container.innerHTML, "<button>Click</button>");
-	Assert.is(consoleWarn.callCount, 1);
-});
-
-test("mismatched text", () => {
-	container.innerHTML = "<button>Do not click</button>";
-	const button = container.firstChild as HTMLButtonElement;
-	const onclick = Sinon.fake();
-
-	const Component = Sinon.fake(function () {
-		return <button onclick={onclick}>Click</button>;
-	});
-
-	renderer.hydrate(<Component />, container);
-	Assert.ok(Component.called);
-	Assert.is(container.innerHTML, "<button>Click</button>");
-	Assert.is(container.firstChild, button);
-	button.click();
-	Assert.ok(onclick.called);
-	Assert.is(consoleWarn.callCount, 1);
-});
-
-test("missing element", () => {
-	function Component() {
-		return <button>Click</button>;
-	}
-
-	renderer.hydrate(<Component />, container);
-	Assert.is(container.innerHTML, "<button>Click</button>");
-	Assert.is(consoleWarn.callCount, 1);
-});
-
-test("raw element", () => {
-	container.innerHTML = "<div><div>Raw</div><button>Click</button></div>";
-	const onclick = Sinon.fake();
-	const button = container.childNodes[0].childNodes[1] as HTMLButtonElement;
-	const Component = Sinon.fake(function () {
-		return (
-			<div>
-				<Raw value="<div>Raw</div>" />
-				<button onclick={onclick}>Click</button>
-			</div>
-		);
-	});
-
-	renderer.hydrate(<Component />, container);
-	Assert.ok(Component.called);
-	Assert.is(
-		container.innerHTML,
-		"<div><div>Raw</div><button>Click</button></div>",
-	);
-	Assert.is(container.childNodes[0].childNodes[1], button);
-	button.click();
-	Assert.ok(onclick.called);
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("raw multiple elements", () => {
-	container.innerHTML =
-		"<div><div>Raw 1</div><div>Raw 2</div><button>Click</button></div>";
-	const onclick = Sinon.fake();
-	const button = container.childNodes[0].childNodes[2] as HTMLButtonElement;
-	const Component = Sinon.fake(function () {
-		return (
-			<div>
-				<Raw value="<div>Raw 1</div><div>Raw 2</div>" />
-				<button onclick={onclick}>Click</button>
-			</div>
-		);
-	});
-
-	renderer.hydrate(<Component />, container);
-	Assert.ok(Component.called);
-	Assert.is(
-		container.innerHTML,
-		"<div><div>Raw 1</div><div>Raw 2</div><button>Click</button></div>",
-	);
-	Assert.is(container.childNodes[0].childNodes[2], button);
-	button.click();
-	Assert.ok(onclick.called);
-});
-
-test("raw text", () => {
-	container.innerHTML = "<div>Raw<button>Click</button></div>";
-	const onclick = Sinon.fake();
-	const button = container.childNodes[0].childNodes[1] as HTMLButtonElement;
-	const Component = Sinon.fake(function () {
-		return (
-			<div>
-				<Raw value="Raw" />
-				<button onclick={onclick}>Click</button>
-			</div>
-		);
-	});
-
-	renderer.hydrate(<Component />, container);
-	Assert.ok(Component.called);
-	Assert.is(container.innerHTML, "<div>Raw<button>Click</button></div>");
-	Assert.is(container.childNodes[0].childNodes[1], button);
-	button.click();
-	Assert.ok(onclick.called);
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("raw comment", () => {
-	container.innerHTML =
-		"<div><!-- comment -->Hello<button>Click</button></div>";
-	const onclick = Sinon.fake();
-	const button = container.childNodes[0].childNodes[2] as HTMLButtonElement;
-	const Component = Sinon.fake(function () {
-		return (
-			<div>
-				<Raw value="<!-- comment -->" />
+				<button hydrate={true}>Click</button>
 				Hello
-				<button onclick={onclick}>Click</button>
-			</div>
+			</Fragment>,
+			container,
+		);
+		expect(container.innerHTML).toBe(`<button>Click</button>Hello`);
+		expect(container.firstChild).toBe(button);
+	});
+
+	test("hydrate={false} can be used to disable hydration", () => {
+		container.innerHTML = `Before <button id="server">Server</button>After`;
+		const button = container.firstChild as HTMLButtonElement;
+		renderer.hydrate(
+			<Fragment>
+				Before{" "}
+				<button id="client" hydrate={false}>
+					Client
+				</button>
+				After
+			</Fragment>,
+			container,
+		);
+		expect(container.innerHTML).toBe(
+			`Before <button id="client">Client</button>After`,
+		);
+		expect(button === document.getElementById("client")).toBeFalsy();
+		expect(consoleWarn.callCount).toBe(0);
+	});
+
+	test("portals are not hydrated by default", () => {
+		container.innerHTML = `<div id="app">Before After</div><div id="portal"><button>Server</button></div>`;
+		const app = document.getElementById("app")!;
+		const portal = document.getElementById("portal")!;
+		const button = portal.firstChild as HTMLButtonElement;
+		const onclick = Sinon.fake();
+		renderer.hydrate(
+			<Fragment>
+				Before{" "}
+				<Portal root={portal}>
+					<button onclick={onclick}>Client</button>
+				</Portal>
+				After
+			</Fragment>,
+			app,
+		);
+		expect(container.innerHTML).toBe(
+			`<div id="app">Before After</div><div id="portal"><button>Client</button><button>Server</button></div>`,
+		);
+		expect(portal.innerHTML).toBe(
+			`<button>Client</button><button>Server</button>`,
+		);
+		button.click();
+		expect(onclick.callCount).toBe(0);
+		expect(consoleWarn.callCount).toBe(0);
+	});
+
+	test("hydrate={true} can be used to hydrate a nested portal", () => {
+		const onclick = Sinon.fake();
+		container.innerHTML = `<div id="app">Before After</div><div id="portal"><button>Click</button></div>`;
+		const app = document.getElementById("app")!;
+		const portal = document.getElementById("portal")!;
+		const button = portal.firstChild as HTMLButtonElement;
+		renderer.hydrate(
+			<Fragment>
+				{"Before "}
+				<Portal root={portal} hydrate={true}>
+					<button onclick={onclick}>Click</button>
+				</Portal>
+				After
+			</Fragment>,
+			app,
+		);
+
+		expect(container.innerHTML).toBe(
+			`<div id="app">Before After</div><div id="portal"><button>Click</button></div>`,
+		);
+		expect(portal.firstChild).toBe(button);
+		expect(portal.innerHTML).toBe(`<button>Click</button>`);
+		button.click();
+		expect(onclick.callCount).toBe(1);
+		expect(consoleWarn.callCount).toBe(0);
+	});
+
+	test("hydrate={true} can be used to start hydration", () => {
+		const onclick = Sinon.fake();
+		container.innerHTML = `<div id="portal"><button>Click</button></div>`;
+		const portal = document.getElementById("portal")!;
+		const button = portal.firstChild as HTMLButtonElement;
+		renderer.render(
+			<div id="app">
+				Before{" "}
+				<Portal root={portal} hydrate={true}>
+					<button onclick={onclick}>Click</button>
+				</Portal>
+				After
+			</div>,
+			container,
+		);
+
+		expect(container.innerHTML).toBe(
+			`<div id="app">Before After</div><div id="portal"><button>Click</button></div>`,
+		);
+		expect(portal.firstChild).toBe(button);
+		expect(portal.innerHTML).toBe(`<button>Click</button>`);
+		button.click();
+		expect(onclick.callCount).toBe(1);
+		expect(consoleWarn.callCount).toBe(0);
+	});
+
+	test("hydrate={false} can be used to disable hydration for a fragment", () => {
+		container.innerHTML = `<div id="app">Before <button>Click1</button> <button>Click2</button> After</div>`;
+		const app = document.getElementById("app")!;
+		const button1 = container.querySelector(
+			"button:nth-child(1)",
+		) as HTMLButtonElement;
+		const button2 = container.querySelector(
+			"button:nth-child(2)",
+		) as HTMLButtonElement;
+		renderer.hydrate(
+			<Fragment>
+				Before{" "}
+				<Fragment hydrate={false}>
+					<button>Click1</button> <button>Click2</button>
+				</Fragment>{" "}
+				After
+			</Fragment>,
+			app,
+		);
+		expect(container.innerHTML).toBe(
+			`<div id="app">Before <button>Click1</button> <button>Click2</button> After</div>`,
+		);
+		expect(
+			button1 === container.querySelector("button:nth-child(1)"),
+		).toBeFalsy();
+		expect(
+			button2 === container.querySelector("button:nth-child(2)"),
+		).toBeFalsy();
+		expect(consoleWarn.callCount).toBe(0);
+	});
+
+	test("hydrate={false} can be used to disable hydration for a component", () => {
+		container.innerHTML = `<div id="app">Before <button>Click1</button> <button>Click2</button> After</div>`;
+		const app = document.getElementById("app")!;
+		const button1 = container.querySelector(
+			"button:nth-child(1)",
+		) as HTMLButtonElement;
+		const button2 = container.querySelector(
+			"button:nth-child(2)",
+		) as HTMLButtonElement;
+
+		function Component() {
+			return (
+				<Fragment>
+					<button>Click1</button> <button>Click2</button>
+				</Fragment>
+			);
+		}
+
+		renderer.hydrate(
+			<Fragment>
+				Before <Component hydrate={false} /> After
+			</Fragment>,
+			app,
+		);
+		expect(container.innerHTML).toBe(
+			`<div id="app">Before <button>Click1</button> <button>Click2</button> After</div>`,
+		);
+		expect(
+			button1 === container.querySelector("button:nth-child(1)"),
+		).toBeFalsy();
+		expect(
+			button2 === container.querySelector("button:nth-child(2)"),
+		).toBeFalsy();
+		expect(consoleWarn.callCount).toBe(0);
+	});
+
+	test("hydrate={false} can be used to disable hydration for a Raw node", () => {
+		container.innerHTML = `<div id="app">Before <button>Click1</button> <button>Click2</button> After</div>`;
+		const app = document.getElementById("app")!;
+		const button1 = container.querySelector(
+			"button:nth-child(1)",
+		) as HTMLButtonElement;
+		const button2 = container.querySelector(
+			"button:nth-child(2)",
+		) as HTMLButtonElement;
+
+		renderer.hydrate(
+			<Fragment>
+				Before{" "}
+				<Raw
+					value="<button>Click1</button> <button>Click2</button>"
+					hydrate={false}
+				/>{" "}
+				After
+			</Fragment>,
+			app,
+		);
+		expect(container.innerHTML).toBe(
+			`<div id="app">Before <button>Click1</button> <button>Click2</button> After</div>`,
+		);
+		expect(
+			button1 === container.querySelector("button:nth-child(1)"),
+		).toBeFalsy();
+		expect(
+			button2 === container.querySelector("button:nth-child(2)"),
+		).toBeFalsy();
+		expect(consoleWarn.callCount).toBe(0);
+	});
+
+	test("hydrate={false} can be used to disable hydration for Text", () => {
+		container.innerHTML = `<div id="app">Before <button>Click1</button> <button>Click2</button> After</div>`;
+		const app = document.getElementById("app")!;
+		const text1 = (
+			container.querySelector("button:nth-child(1)") as HTMLButtonElement
+		).firstChild as Text;
+		const text2 = (
+			container.querySelector("button:nth-child(2)") as HTMLButtonElement
+		).firstChild as Text;
+
+		renderer.hydrate(
+			<Fragment>
+				Before{" "}
+				<button>
+					<Text1 value="Click1" hydrate={false} />
+				</button>{" "}
+				<button>
+					<Text1 value="Click2" hydrate={false} />
+				</button>{" "}
+				After
+			</Fragment>,
+			app,
+		);
+		expect(container.innerHTML).toBe(
+			`<div id="app">Before <button>Click1</button> <button>Click2</button> After</div>`,
+		);
+		expect(
+			text1 ===
+				(container.querySelector("button:nth-child(1)") as HTMLButtonElement)
+					.firstChild,
+		).toBeFalsy();
+		expect(
+			text2 ===
+				(container.querySelector("button:nth-child(2)") as HTMLButtonElement)
+					.firstChild,
+		).toBeFalsy();
+		expect(consoleWarn.callCount).toBe(0);
+	});
+
+	test("hydration meta-prop can suppress specific property warnings (exclusive)", () => {
+		container.innerHTML = `<div id="server" class="old-class"></div>`;
+		renderer.hydrate(
+			<div id="client" class="new-class" hydrate="!id" />,
+			container,
+		);
+		expect(consoleWarn.callCount).toBe(1);
+		expect(consoleWarn.firstCall.args[0]).toMatch(
+			/Expected "class" to be "new-class"/,
 		);
 	});
 
-	renderer.hydrate(<Component />, container);
-	Assert.ok(Component.called);
-	Assert.is(
-		container.innerHTML,
-		"<div><!-- comment -->Hello<button>Click</button></div>",
-	);
-
-	Assert.is(container.childNodes[0].childNodes[2], button);
-	button.click();
-	Assert.ok(onclick.called);
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("ref called with hydrated element", () => {
-	container.innerHTML = "<button>Click</button>";
-	const button = container.firstChild as HTMLButtonElement;
-	const ref = Sinon.fake();
-	const onclick = Sinon.fake();
-
-	renderer.hydrate(
-		<button ref={ref} onclick={onclick}>
-			Click
-		</button>,
-		container,
-	);
-
-	Assert.is(container.innerHTML, "<button>Click</button>");
-	Assert.is(container.firstChild, button);
-	Assert.ok(ref.calledOnce);
-	Assert.is(ref.lastCall.firstArg, button);
-	button.click();
-	Assert.ok(onclick.called);
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("warns when attribute present but should be missing during hydration", () => {
-	container.innerHTML = `<div foo="bar"></div>`;
-	renderer.hydrate(<div foo={null} />, container);
-	Assert.is(consoleWarn.callCount, 1);
-	Assert.match(consoleWarn.firstCall.args[0], /Expected "foo" to be missing/);
-});
-
-test("warns when attribute missing but should be present during hydration", () => {
-	container.innerHTML = `<div></div>`;
-	renderer.hydrate(<div foo={true} />, container);
-	Assert.is(consoleWarn.callCount, 1);
-	Assert.match(consoleWarn.firstCall.args[0], /Expected "foo" to be ""/);
-});
-
-test("warns when attribute value mismatches during hydration", () => {
-	container.innerHTML = `<div foo="baz"></div>`;
-	renderer.hydrate(<div foo="bar" />, container);
-	Assert.is(consoleWarn.callCount, 1);
-	Assert.match(consoleWarn.firstCall.args[0], /Expected "foo" to be "bar"/);
-});
-
-test("warns when style present but should be missing during hydration", () => {
-	container.innerHTML = `<div style="color: red"></div>`;
-	renderer.hydrate(<div style={null} />, container);
-	Assert.is(consoleWarn.callCount, 1);
-	Assert.match(consoleWarn.firstCall.args[0], /Expected "style" to be missing/);
-});
-
-test.skip("warns when style should be empty string during hydration", () => {
-	container.innerHTML = `<div style="color: red"></div>`;
-	renderer.hydrate(<div style="" />, container);
-	Assert.is(consoleWarn.callCount, 1);
-	Assert.match(consoleWarn.firstCall.args[0], /Expected "style" to be ""/);
-});
-
-test.skip("warns when style value mismatches during hydration", () => {
-	container.innerHTML = `<div style="color: red"></div>`;
-	renderer.hydrate(<div style="color: blue" />, container);
-	Assert.is(consoleWarn.callCount, 1);
-	Assert.match(
-		consoleWarn.firstCall.args[0],
-		/Expected "style" to be "color: blue"/,
-	);
-});
-
-test("warns when class present but should be missing during hydration", () => {
-	container.innerHTML = `<div class="foo"></div>`;
-	renderer.hydrate(<div class={null} />, container);
-	Assert.is(consoleWarn.callCount, 1);
-	Assert.match(consoleWarn.firstCall.args[0], /Expected "class" to be missing/);
-});
-
-test("warns when class should be empty string during hydration", () => {
-	container.innerHTML = `<div class="foo"></div>`;
-	renderer.hydrate(<div class="" />, container);
-	Assert.is(consoleWarn.callCount, 1);
-	Assert.match(consoleWarn.firstCall.args[0], /Expected "class" to be ""/);
-});
-
-test("warns when class value mismatches during hydration", () => {
-	container.innerHTML = `<div class="foo"></div>`;
-	renderer.hydrate(<div class="bar" />, container);
-	Assert.is(consoleWarn.callCount, 1);
-	Assert.match(consoleWarn.firstCall.args[0], /Expected "class" to be "bar"/);
-});
-
-test("warns when innerHTML mismatches during hydration", () => {
-	container.innerHTML = `<div>baz</div>`;
-	renderer.hydrate(<div innerHTML="bar" />, container);
-	Assert.is(consoleWarn.callCount, 1);
-	Assert.match(
-		consoleWarn.firstCall.args[0],
-		/Expected "innerHTML" to be "bar"/,
-	);
-});
-
-test("warns when style property present but should be missing during hydration", () => {
-	container.innerHTML = `<div style="color: red"></div>`;
-	renderer.hydrate(<div style={{color: null}} />, container);
-	Assert.is(consoleWarn.callCount, 1);
-	Assert.match(
-		consoleWarn.firstCall.args[0],
-		/Expected "style\.color" to be missing/,
-	);
-});
-
-test("warns when id mismatches during hydration", () => {
-	container.innerHTML = `<div id="server"></div>`;
-	renderer.hydrate(<div id="client" />, container);
-	Assert.is(consoleWarn.callCount, 1);
-	Assert.match(consoleWarn.firstCall.args[0], /Expected "id" to be "client"/);
-});
-
-test("warns when input type and value mismatches during hydration", () => {
-	container.innerHTML = `<input type="email" value="server">`;
-	renderer.hydrate(<input type="text" value="client" />, container);
-	Assert.is(consoleWarn.callCount, 2);
-	Assert.match(consoleWarn.firstCall.args[0], /Expected "type" to be "text"/);
-	Assert.match(
-		consoleWarn.secondCall.args[0],
-		/Expected "value" to be "client"/,
-	);
-});
-
-test.skip("warns when style property value mismatches during hydration", () => {
-	container.innerHTML = `<div style="color: red"></div>`;
-	renderer.hydrate(<div style={{color: "blue"}} />, container);
-	Assert.is(consoleWarn.callCount, 1);
-	Assert.match(
-		consoleWarn.firstCall.args[0],
-		/Expected "style\.color" to be "blue"/,
-	);
-});
-
-test("hydrate={true} can be used to continue hydration", () => {
-	container.innerHTML = `<button>Click</button>Hello`;
-	const button = container.firstChild as HTMLButtonElement;
-	renderer.hydrate(
-		<Fragment>
-			<button hydrate={true}>Click</button>
-			Hello
-		</Fragment>,
-		container,
-	);
-	Assert.is(container.innerHTML, `<button>Click</button>Hello`);
-	Assert.is(container.firstChild, button);
-});
-
-test("hydrate={false} can be used to disable hydration", () => {
-	container.innerHTML = `Before <button id="server">Server</button>After`;
-	const button = container.firstChild as HTMLButtonElement;
-	renderer.hydrate(
-		<Fragment>
-			Before{" "}
-			<button id="client" hydrate={false}>
-				Client
-			</button>
-			After
-		</Fragment>,
-		container,
-	);
-	Assert.is(
-		container.innerHTML,
-		`Before <button id="client">Client</button>After`,
-	);
-	Assert.not(button === document.getElementById("client"));
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("portals are not hydrated by default", () => {
-	container.innerHTML = `<div id="app">Before After</div><div id="portal"><button>Server</button></div>`;
-	const app = document.getElementById("app")!;
-	const portal = document.getElementById("portal")!;
-	const button = portal.firstChild as HTMLButtonElement;
-	const onclick = Sinon.fake();
-	renderer.hydrate(
-		<Fragment>
-			Before{" "}
-			<Portal root={portal}>
-				<button onclick={onclick}>Client</button>
-			</Portal>
-			After
-		</Fragment>,
-		app,
-	);
-	Assert.is(
-		container.innerHTML,
-		`<div id="app">Before After</div><div id="portal"><button>Client</button><button>Server</button></div>`,
-	);
-	Assert.is(portal.innerHTML, `<button>Client</button><button>Server</button>`);
-	button.click();
-	Assert.is(onclick.callCount, 0);
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("hydrate={true} can be used to hydrate a nested portal", () => {
-	const onclick = Sinon.fake();
-	container.innerHTML = `<div id="app">Before After</div><div id="portal"><button>Click</button></div>`;
-	const app = document.getElementById("app")!;
-	const portal = document.getElementById("portal")!;
-	const button = portal.firstChild as HTMLButtonElement;
-	renderer.hydrate(
-		<Fragment>
-			{"Before "}
-			<Portal root={portal} hydrate={true}>
-				<button onclick={onclick}>Click</button>
-			</Portal>
-			After
-		</Fragment>,
-		app,
-	);
-
-	Assert.is(
-		container.innerHTML,
-		`<div id="app">Before After</div><div id="portal"><button>Click</button></div>`,
-	);
-	Assert.is(portal.firstChild, button);
-	Assert.is(portal.innerHTML, `<button>Click</button>`);
-	button.click();
-	Assert.is(onclick.callCount, 1);
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("hydrate={true} can be used to start hydration", () => {
-	const onclick = Sinon.fake();
-	container.innerHTML = `<div id="portal"><button>Click</button></div>`;
-	const portal = document.getElementById("portal")!;
-	const button = portal.firstChild as HTMLButtonElement;
-	renderer.render(
-		<div id="app">
-			Before{" "}
-			<Portal root={portal} hydrate={true}>
-				<button onclick={onclick}>Click</button>
-			</Portal>
-			After
-		</div>,
-		container,
-	);
-
-	Assert.is(
-		container.innerHTML,
-		`<div id="app">Before After</div><div id="portal"><button>Click</button></div>`,
-	);
-	Assert.is(portal.firstChild, button);
-	Assert.is(portal.innerHTML, `<button>Click</button>`);
-	button.click();
-	Assert.is(onclick.callCount, 1);
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("hydrate={false} can be used to disable hydration for a fragment", () => {
-	container.innerHTML = `<div id="app">Before <button>Click1</button> <button>Click2</button> After</div>`;
-	const app = document.getElementById("app")!;
-	const button1 = container.querySelector(
-		"button:nth-child(1)",
-	) as HTMLButtonElement;
-	const button2 = container.querySelector(
-		"button:nth-child(2)",
-	) as HTMLButtonElement;
-	renderer.hydrate(
-		<Fragment>
-			Before{" "}
-			<Fragment hydrate={false}>
-				<button>Click1</button> <button>Click2</button>
-			</Fragment>{" "}
-			After
-		</Fragment>,
-		app,
-	);
-	Assert.is(
-		container.innerHTML,
-		`<div id="app">Before <button>Click1</button> <button>Click2</button> After</div>`,
-	);
-	Assert.not(button1 === container.querySelector("button:nth-child(1)"));
-	Assert.not(button2 === container.querySelector("button:nth-child(2)"));
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("hydrate={false} can be used to disable hydration for a component", () => {
-	container.innerHTML = `<div id="app">Before <button>Click1</button> <button>Click2</button> After</div>`;
-	const app = document.getElementById("app")!;
-	const button1 = container.querySelector(
-		"button:nth-child(1)",
-	) as HTMLButtonElement;
-	const button2 = container.querySelector(
-		"button:nth-child(2)",
-	) as HTMLButtonElement;
-
-	function Component() {
-		return (
-			<Fragment>
-				<button>Click1</button> <button>Click2</button>
-			</Fragment>
+	test("hydration meta-prop can suppress multiple property warnings (exclusive)", () => {
+		container.innerHTML = `<div id="server" class="old-class" data-test="old"></div>`;
+		renderer.hydrate(
+			<div
+				id="client"
+				class="new-class"
+				data-test="new"
+				hydrate="!id !class"
+			/>,
+			container,
 		);
-	}
+		expect(consoleWarn.callCount).toBe(1);
+		expect(consoleWarn.firstCall.args[0]).toMatch(
+			/Expected "data-test" to be "new"/,
+		);
+	});
 
-	renderer.hydrate(
-		<Fragment>
-			Before <Component hydrate={false} /> After
-		</Fragment>,
-		app,
-	);
-	Assert.is(
-		container.innerHTML,
-		`<div id="app">Before <button>Click1</button> <button>Click2</button> After</div>`,
-	);
-	Assert.not(button1 === container.querySelector("button:nth-child(1)"));
-	Assert.not(button2 === container.querySelector("button:nth-child(2)"));
-	Assert.is(consoleWarn.callCount, 0);
+	test("hydration meta-prop can suppress all but specified property warnings (inclusive)", () => {
+		container.innerHTML = `<div id="server" class="old-class" data-test="old"></div>`;
+		renderer.hydrate(
+			<div id="client" class="new-class" data-test="new" hydrate="id" />,
+			container,
+		);
+		expect(consoleWarn.callCount).toBe(1);
+		expect(consoleWarn.firstCall.args[0]).toMatch(
+			/Expected "id" to be "client"/,
+		);
+	});
+
+	test("hydration meta-prop can suppress style property warnings", () => {
+		container.innerHTML = `<div style="color: red; background: blue"></div>`;
+		renderer.hydrate(
+			<div style={{color: "green", background: "blue"}} hydrate="!style" />,
+			container,
+		);
+		expect(consoleWarn.callCount).toBe(0);
+	});
+
+	test("hydration meta-prop with spaces and mixed syntax", () => {
+		container.innerHTML = `<div id="server" class="old" data-foo="old" data-bar="old"></div>`;
+		renderer.hydrate(
+			<div
+				id="client"
+				class="new"
+				data-foo="new"
+				data-bar="new"
+				hydrate="  !id   !class  "
+			/>,
+			container,
+		);
+		expect(consoleWarn.callCount).toBe(2);
+		expect(consoleWarn.firstCall.args[0]).toMatch(
+			/Expected "data-foo" to be "new"/,
+		);
+		expect(consoleWarn.secondCall.args[0]).toMatch(
+			/Expected "data-bar" to be "new"/,
+		);
+	});
+
+	test("hydration meta-prop can disable children hydration with !children", () => {
+		container.innerHTML = `<div><span>Server Content</span><button>Server Button</button></div>`;
+		const serverSpan = container.querySelector("span") as HTMLSpanElement;
+		const serverButton = container.querySelector("button") as HTMLButtonElement;
+
+		const onclick = Sinon.fake();
+		renderer.hydrate(
+			<div hydrate="!children">
+				<span>Client Content</span>
+				<button onclick={onclick}>Client Button</button>
+			</div>,
+			container,
+		);
+
+		// Children should be fully re-rendered (not hydrated)
+		expect(container.innerHTML).toBe(
+			`<div><span>Client Content</span><button>Client Button</button></div>`,
+		);
+		expect(container.querySelector("span") === serverSpan).toBeFalsy();
+		expect(container.querySelector("button") === serverButton).toBeFalsy();
+
+		// Event handlers should work (since it's client-rendered)
+		const newButton = container.querySelector("button") as HTMLButtonElement;
+		newButton.click();
+		expect(onclick.called).toBeTruthy();
+		expect(onclick.callCount).toBe(1);
+		expect(consoleWarn.callCount).toBe(0);
+	});
+
+	test("hydration meta-prop inclusive mode shows warnings only for specified props", () => {
+		container.innerHTML = `<div class="server" id="server"><span>Server Content</span></div>`;
+
+		renderer.hydrate(
+			<div class="client" id="client" hydrate="class">
+				<span>Client Content</span>
+			</div>,
+			container,
+		);
+
+		// Only class should warn (specified in inclusive mode), id should be quiet
+		expect(consoleWarn.callCount).toBe(1);
+		expect(consoleWarn.firstCall.args[0]).toMatch(
+			/Expected "class" to be "client"/,
+		);
+		expect(container.innerHTML).toBe(
+			`<div class="client" id="client"><span>Client Content</span></div>`,
+		);
+	});
+
+	test("warns when class object doesn't match server classes during hydration", () => {
+		container.innerHTML = `<div class="server-class other-class"></div>`;
+		renderer.hydrate(
+			<div class={{"client-class": true, active: true}} />,
+			container,
+		);
+		expect(consoleWarn.callCount).toBe(1);
+		expect(consoleWarn.firstCall.args[0]).toMatch(
+			/Expected "class" to be "client-class active"/,
+		);
+	});
+
+	test("warns when class object expects missing class during hydration", () => {
+		container.innerHTML = `<div class="existing"></div>`;
+		renderer.hydrate(
+			<div class={{existing: true, missing: true}} />,
+			container,
+		);
+		expect(consoleWarn.callCount).toBe(1);
+		expect(consoleWarn.firstCall.args[0]).toMatch(
+			/Expected "class" to be "existing missing"/,
+		);
+	});
+
+	test("warns when class object encounters unexpected server class during hydration", () => {
+		container.innerHTML = `<div class="expected unexpected"></div>`;
+		renderer.hydrate(<div class={{expected: true}} />, container);
+		expect(consoleWarn.callCount).toBe(1);
+		expect(consoleWarn.firstCall.args[0]).toMatch(
+			/Expected "class" to be "expected"/,
+		);
+	});
+
+	test("no warning class object matches", () => {
+		container.innerHTML = `<div class="active primary"></div>`;
+		renderer.hydrate(
+			<div class={{active: true, primary: true, disabled: false}} />,
+			container,
+		);
+		expect(consoleWarn.callCount).toBe(0);
+	});
+
+	test("no warning when prop is a coerced number", () => {
+		container.innerHTML = `<div tabindex="3"></div>`;
+		renderer.hydrate(<div tabindex={3} />, container);
+
+		expect(consoleWarn.callCount).toBe(0);
+	});
 });
-
-test("hydrate={false} can be used to disable hydration for a Raw node", () => {
-	container.innerHTML = `<div id="app">Before <button>Click1</button> <button>Click2</button> After</div>`;
-	const app = document.getElementById("app")!;
-	const button1 = container.querySelector(
-		"button:nth-child(1)",
-	) as HTMLButtonElement;
-	const button2 = container.querySelector(
-		"button:nth-child(2)",
-	) as HTMLButtonElement;
-
-	renderer.hydrate(
-		<Fragment>
-			Before{" "}
-			<Raw
-				value="<button>Click1</button> <button>Click2</button>"
-				hydrate={false}
-			/>{" "}
-			After
-		</Fragment>,
-		app,
-	);
-	Assert.is(
-		container.innerHTML,
-		`<div id="app">Before <button>Click1</button> <button>Click2</button> After</div>`,
-	);
-	Assert.not(button1 === container.querySelector("button:nth-child(1)"));
-	Assert.not(button2 === container.querySelector("button:nth-child(2)"));
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("hydrate={false} can be used to disable hydration for Text", () => {
-	container.innerHTML = `<div id="app">Before <button>Click1</button> <button>Click2</button> After</div>`;
-	const app = document.getElementById("app")!;
-	const text1 = (
-		container.querySelector("button:nth-child(1)") as HTMLButtonElement
-	).firstChild as Text;
-	const text2 = (
-		container.querySelector("button:nth-child(2)") as HTMLButtonElement
-	).firstChild as Text;
-
-	renderer.hydrate(
-		<Fragment>
-			Before{" "}
-			<button>
-				<Text1 value="Click1" hydrate={false} />
-			</button>{" "}
-			<button>
-				<Text1 value="Click2" hydrate={false} />
-			</button>{" "}
-			After
-		</Fragment>,
-		app,
-	);
-	Assert.is(
-		container.innerHTML,
-		`<div id="app">Before <button>Click1</button> <button>Click2</button> After</div>`,
-	);
-	Assert.not(
-		text1 ===
-			(container.querySelector("button:nth-child(1)") as HTMLButtonElement)
-				.firstChild,
-	);
-	Assert.not(
-		text2 ===
-			(container.querySelector("button:nth-child(2)") as HTMLButtonElement)
-				.firstChild,
-	);
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("hydration meta-prop can suppress specific property warnings (exclusive)", () => {
-	container.innerHTML = `<div id="server" class="old-class"></div>`;
-	renderer.hydrate(
-		<div id="client" class="new-class" hydrate="!id" />,
-		container,
-	);
-	Assert.is(consoleWarn.callCount, 1);
-	Assert.match(
-		consoleWarn.firstCall.args[0],
-		/Expected "class" to be "new-class"/,
-	);
-});
-
-test("hydration meta-prop can suppress multiple property warnings (exclusive)", () => {
-	container.innerHTML = `<div id="server" class="old-class" data-test="old"></div>`;
-	renderer.hydrate(
-		<div id="client" class="new-class" data-test="new" hydrate="!id !class" />,
-		container,
-	);
-	Assert.is(consoleWarn.callCount, 1);
-	Assert.match(
-		consoleWarn.firstCall.args[0],
-		/Expected "data-test" to be "new"/,
-	);
-});
-
-test("hydration meta-prop can suppress all but specified property warnings (inclusive)", () => {
-	container.innerHTML = `<div id="server" class="old-class" data-test="old"></div>`;
-	renderer.hydrate(
-		<div id="client" class="new-class" data-test="new" hydrate="id" />,
-		container,
-	);
-	Assert.is(consoleWarn.callCount, 1);
-	Assert.match(consoleWarn.firstCall.args[0], /Expected "id" to be "client"/);
-});
-
-test("hydration meta-prop can suppress style property warnings", () => {
-	container.innerHTML = `<div style="color: red; background: blue"></div>`;
-	renderer.hydrate(
-		<div style={{color: "green", background: "blue"}} hydrate="!style" />,
-		container,
-	);
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("hydration meta-prop with spaces and mixed syntax", () => {
-	container.innerHTML = `<div id="server" class="old" data-foo="old" data-bar="old"></div>`;
-	renderer.hydrate(
-		<div
-			id="client"
-			class="new"
-			data-foo="new"
-			data-bar="new"
-			hydrate="  !id   !class  "
-		/>,
-		container,
-	);
-	Assert.is(consoleWarn.callCount, 2);
-	Assert.match(
-		consoleWarn.firstCall.args[0],
-		/Expected "data-foo" to be "new"/,
-	);
-	Assert.match(
-		consoleWarn.secondCall.args[0],
-		/Expected "data-bar" to be "new"/,
-	);
-});
-
-test("hydration meta-prop can disable children hydration with !children", () => {
-	container.innerHTML = `<div><span>Server Content</span><button>Server Button</button></div>`;
-	const serverSpan = container.querySelector("span") as HTMLSpanElement;
-	const serverButton = container.querySelector("button") as HTMLButtonElement;
-
-	const onclick = Sinon.fake();
-	renderer.hydrate(
-		<div hydrate="!children">
-			<span>Client Content</span>
-			<button onclick={onclick}>Client Button</button>
-		</div>,
-		container,
-	);
-
-	// Children should be fully re-rendered (not hydrated)
-	Assert.is(
-		container.innerHTML,
-		`<div><span>Client Content</span><button>Client Button</button></div>`,
-	);
-	Assert.not(container.querySelector("span") === serverSpan);
-	Assert.not(container.querySelector("button") === serverButton);
-
-	// Event handlers should work (since it's client-rendered)
-	const newButton = container.querySelector("button") as HTMLButtonElement;
-	newButton.click();
-	Assert.ok(onclick.called);
-	Assert.is(onclick.callCount, 1);
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("hydration meta-prop inclusive mode shows warnings only for specified props", () => {
-	container.innerHTML = `<div class="server" id="server"><span>Server Content</span></div>`;
-
-	renderer.hydrate(
-		<div class="client" id="client" hydrate="class">
-			<span>Client Content</span>
-		</div>,
-		container,
-	);
-
-	// Only class should warn (specified in inclusive mode), id should be quiet
-	Assert.is(consoleWarn.callCount, 1);
-	Assert.match(
-		consoleWarn.firstCall.args[0],
-		/Expected "class" to be "client"/,
-	);
-	Assert.is(
-		container.innerHTML,
-		`<div class="client" id="client"><span>Client Content</span></div>`,
-	);
-});
-
-test("warns when class object doesn't match server classes during hydration", () => {
-	container.innerHTML = `<div class="server-class other-class"></div>`;
-	renderer.hydrate(
-		<div class={{"client-class": true, active: true}} />,
-		container,
-	);
-	Assert.is(consoleWarn.callCount, 1);
-	Assert.match(
-		consoleWarn.firstCall.args[0],
-		/Expected "class" to be "client-class active"/,
-	);
-});
-
-test("warns when class object expects missing class during hydration", () => {
-	container.innerHTML = `<div class="existing"></div>`;
-	renderer.hydrate(<div class={{existing: true, missing: true}} />, container);
-	Assert.is(consoleWarn.callCount, 1);
-	Assert.match(
-		consoleWarn.firstCall.args[0],
-		/Expected "class" to be "existing missing"/,
-	);
-});
-
-test("warns when class object encounters unexpected server class during hydration", () => {
-	container.innerHTML = `<div class="expected unexpected"></div>`;
-	renderer.hydrate(<div class={{expected: true}} />, container);
-	Assert.is(consoleWarn.callCount, 1);
-	Assert.match(
-		consoleWarn.firstCall.args[0],
-		/Expected "class" to be "expected"/,
-	);
-});
-
-test("no warning class object matches", () => {
-	container.innerHTML = `<div class="active primary"></div>`;
-	renderer.hydrate(
-		<div class={{active: true, primary: true, disabled: false}} />,
-		container,
-	);
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test("no warning when prop is a coerced number", () => {
-	container.innerHTML = `<div tabindex="3"></div>`;
-	renderer.hydrate(<div tabindex={3} />, container);
-
-	Assert.is(consoleWarn.callCount, 0);
-});
-
-test.run();

--- a/test/hydration.tsx
+++ b/test/hydration.tsx
@@ -15,10 +15,6 @@ import {renderer} from "../src/dom.js";
 describe("hydration", () => {
 	let consoleWarn: Sinon.SinonStub;
 	let container: HTMLDivElement;
-	// libuild's browser runner has no test.skip, so these stay registered as no-ops
-	// rather than being deleted. They were already disabled under uvu.
-	const skip = (_name: string, _fn: () => unknown): void => {};
-
 	beforeEach(() => {
 		document.body.innerHTML = "";
 		container = document.createElement("div");
@@ -512,14 +508,14 @@ describe("hydration", () => {
 		);
 	});
 
-	skip("warns when style should be empty string during hydration", () => {
+	test.skip("warns when style should be empty string during hydration", () => {
 		container.innerHTML = `<div style="color: red"></div>`;
 		renderer.hydrate(<div style="" />, container);
 		expect(consoleWarn.callCount).toBe(1);
 		expect(consoleWarn.firstCall.args[0]).toMatch(/Expected "style" to be ""/);
 	});
 
-	skip("warns when style value mismatches during hydration", () => {
+	test.skip("warns when style value mismatches during hydration", () => {
 		container.innerHTML = `<div style="color: red"></div>`;
 		renderer.hydrate(<div style="color: blue" />, container);
 		expect(consoleWarn.callCount).toBe(1);
@@ -592,7 +588,7 @@ describe("hydration", () => {
 		);
 	});
 
-	skip("warns when style property value mismatches during hydration", () => {
+	test.skip("warns when style property value mismatches during hydration", () => {
 		container.innerHTML = `<div style="color: red"></div>`;
 		renderer.hydrate(<div style={{color: "blue"}} />, container);
 		expect(consoleWarn.callCount).toBe(1);

--- a/test/jsx-tag.ts
+++ b/test/jsx-tag.ts
@@ -1,640 +1,570 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
-
+import {describe, test, expect} from "@b9g/libuild/test";
 import {createElement} from "../src/crank.js";
 import {jsx} from "../src/jsx-tag.js";
 
-const test = suite("jsx");
+describe("jsx", () => {
+	test("single elements", () => {
+		expect(jsx`<p/>`).toEqual(createElement("p"));
+		expect(jsx`<p />`).toEqual(createElement("p"));
+		expect(jsx`<p></p>`).toEqual(createElement("p"));
+		expect(jsx`<p>hello world</p>`).toEqual(
+			createElement("p", null, "hello world"),
+		);
+	});
 
-test("single elements", () => {
-	Assert.equal(jsx`<p/>`, createElement("p"));
-	Assert.equal(jsx`<p />`, createElement("p"));
-	Assert.equal(jsx`<p></p>`, createElement("p"));
-	Assert.equal(
-		jsx`<p>hello world</p>`,
-		createElement("p", null, "hello world"),
-	);
-});
+	test("top-level strings", () => {
+		expect(jsx`hello world`).toEqual(createElement("", null, "hello world"));
+		expect(jsx`hello <p>world</p>`).toEqual(
+			createElement("", null, ...["hello ", createElement("p", null, "world")]),
+		);
+		expect(jsx`<p>hello</p> world`).toEqual(
+			createElement("", null, ...[createElement("p", null, "hello"), " world"]),
+		);
+		expect(jsx` hello<span> </span>world `).toEqual(
+			createElement(
+				"",
+				null,
+				...["hello", createElement("span", null, " "), "world"],
+			),
+		);
+	});
 
-test("top-level strings", () => {
-	Assert.equal(jsx`hello world`, createElement("", null, "hello world"));
-	Assert.equal(
-		jsx`hello <p>world</p>`,
-		createElement("", null, ...["hello ", createElement("p", null, "world")]),
-	);
-	Assert.equal(
-		jsx`<p>hello</p> world`,
-		createElement("", null, ...[createElement("p", null, "hello"), " world"]),
-	);
-	Assert.equal(
-		jsx` hello<span> </span>world `,
-		createElement(
-			"",
-			null,
-			...["hello", createElement("span", null, " "), "world"],
-		),
-	);
-});
-
-test("newlines and whitespace", () => {
-	// TODO: Figure out how to test this without fricking editors/linters or
-	// whatever getting in the way
-	Assert.equal(
-		jsx`
+	test("newlines and whitespace", () => {
+		// TODO: Figure out how to test this without fricking editors/linters or
+		// whatever getting in the way
+		expect(jsx`
 		<p/>
-	`,
-		createElement("p"),
-	);
-	Assert.equal(
-		jsx`
+	`).toEqual(createElement("p"));
+		expect(jsx`
 		<span>Hello</span> \
 		<span>World</span>
-	`,
-		createElement(
-			"",
-			null,
-			...[
-				createElement("span", null, "Hello"),
-				" ",
-				createElement("span", null, "World"),
-			],
-		),
-	);
-});
+	`).toEqual(
+			createElement(
+				"",
+				null,
+				...[
+					createElement("span", null, "Hello"),
+					" ",
+					createElement("span", null, "World"),
+				],
+			),
+		);
+	});
 
-test("text-text newlines are preserved as a newline (#359)", () => {
-	// A newline between two text runs is preserved as a single newline. Unlike
-	// JSX, which collapses it to a space, the template has no formatter reflowing
-	// it, so the line break is the author's intent: it renders as a space in
-	// normal flow and as a real line break in a `<pre>`.
-	Assert.equal(
-		jsx`<p>alpha
-beta</p>`,
-		createElement("p", null, "alpha\n", "beta"),
-	);
-	// Everything between two text runs is preserved verbatim: the blank line
-	// stays two newlines, and the indentation before `three` is kept.
-	Assert.equal(
-		jsx`<p>one
+	test("text-text newlines are preserved as a newline (#359)", () => {
+		// A newline between two text runs is preserved as a single newline. Unlike
+		// JSX, which collapses it to a space, the template has no formatter reflowing
+		// it, so the line break is the author's intent: it renders as a space in
+		// normal flow and as a real line break in a `<pre>`.
+		expect(jsx`<p>alpha
+beta</p>`).toEqual(createElement("p", null, "alpha\n", "beta"));
+		// Everything between two text runs is preserved verbatim: the blank line
+		// stays two newlines, and the indentation before `three` is kept.
+		expect(jsx`<p>one
 two
 
-   three</p>`,
-		createElement("p", null, "one\n", "two\n\n   ", "three"),
-	);
-	// A newline adjacent to an element is still stripped as layout: only the
-	// text-text break is kept.
-	Assert.equal(
-		jsx`<p>alpha
+   three</p>`).toEqual(
+			createElement("p", null, "one\n", "two\n\n   ", "three"),
+		);
+		// A newline adjacent to an element is still stripped as layout: only the
+		// text-text break is kept.
+		expect(jsx`<p>alpha
 <b>x</b>
-beta</p>`,
-		createElement("p", null, "alpha", createElement("b", null, "x"), "beta"),
-	);
-});
+beta</p>`).toEqual(
+			createElement("p", null, "alpha", createElement("b", null, "x"), "beta"),
+		);
+	});
 
-test("preserves significant whitespace verbatim (diverges from JSX collapse)", () => {
-	// Interior spaces within a line are preserved, not collapsed.
-	Assert.equal(jsx`<p>a   b</p>`, createElement("p", null, "a   b"));
-	// A newline before an expression is stripped as layout — the expression
-	// boundary is structural, like an element.
-	Assert.equal(
-		jsx`<p>a
-${"X"}</p>`,
-		createElement("p", null, "a", "X"),
-	);
-	// Leading whitespace on the first line of a text run is preserved (it is not
-	// indentation following a newline); the break to the next line is kept.
-	Assert.equal(
-		jsx`<p>  Hello
-World</p>`,
-		createElement("p", null, "  Hello\n", "World"),
-	);
-	// Whitespace-only text between elements is preserved on a single line ...
-	Assert.equal(
-		jsx`<p><b>x</b>   <i>y</i></p>`,
-		createElement(
-			"p",
-			null,
-			createElement("b", null, "x"),
-			"   ",
-			createElement("i", null, "y"),
-		),
-	);
-	// ... and removed entirely when it spans a newline.
-	Assert.equal(
-		jsx`<p><b>x</b>
-<i>y</i></p>`,
-		createElement(
-			"p",
-			null,
-			createElement("b", null, "x"),
-			createElement("i", null, "y"),
-		),
-	);
-});
+	test("preserves significant whitespace verbatim (diverges from JSX collapse)", () => {
+		// Interior spaces within a line are preserved, not collapsed.
+		expect(jsx`<p>a   b</p>`).toEqual(createElement("p", null, "a   b"));
+		// A newline before an expression is stripped as layout — the expression
+		// boundary is structural, like an element.
+		expect(jsx`<p>a
+${"X"}</p>`).toEqual(createElement("p", null, "a", "X"));
+		// Leading whitespace on the first line of a text run is preserved (it is not
+		// indentation following a newline); the break to the next line is kept.
+		expect(jsx`<p>  Hello
+World</p>`).toEqual(createElement("p", null, "  Hello\n", "World"));
+		// Whitespace-only text between elements is preserved on a single line ...
+		expect(jsx`<p><b>x</b>   <i>y</i></p>`).toEqual(
+			createElement(
+				"p",
+				null,
+				createElement("b", null, "x"),
+				"   ",
+				createElement("i", null, "y"),
+			),
+		);
+		// ... and removed entirely when it spans a newline.
+		expect(jsx`<p><b>x</b>
+<i>y</i></p>`).toEqual(
+			createElement(
+				"p",
+				null,
+				createElement("b", null, "x"),
+				createElement("i", null, "y"),
+			),
+		);
+	});
 
-test("string props", () => {
-	Assert.equal(jsx`<p class="foo" />`, createElement("p", {class: "foo"}));
-	Assert.equal(
-		jsx`<p f="foo" b="bar" />`,
-		createElement("p", {f: "foo", b: "bar"}),
-	);
-	Assert.equal(
-		jsx`<p f="'foo'" b='"bar"' />`,
-		createElement("p", {f: "'foo'", b: '"bar"'}),
-	);
-});
+	test("string props", () => {
+		expect(jsx`<p class="foo" />`).toEqual(createElement("p", {class: "foo"}));
+		expect(jsx`<p f="foo" b="bar" />`).toEqual(
+			createElement("p", {f: "foo", b: "bar"}),
+		);
+		expect(jsx`<p f="'foo'" b='"bar"' />`).toEqual(
+			createElement("p", {f: "'foo'", b: '"bar"'}),
+		);
+	});
 
-test("string escapes", () => {
-	Assert.equal(
-		jsx`<p a="a\"a\"a\"a" b='b\'b\'b\'b' />`,
-		createElement("p", {a: 'a"a"a"a', b: "b'b'b'b"}),
-	);
-	Assert.equal(
-		jsx`<p a="\\\"\'\a\b\\\"" />`,
-		createElement("p", {a: `\\"'a\b\\"`}),
-	);
-	Assert.equal(
-		jsx`<p a="hello\r\nworld" />`,
-		createElement("p", {a: "hello\r\nworld"}),
-	);
-});
+	test("string escapes", () => {
+		expect(jsx`<p a="a\"a\"a\"a" b='b\'b\'b\'b' />`).toEqual(
+			createElement("p", {a: 'a"a"a"a', b: "b'b'b'b"}),
+		);
+		expect(jsx`<p a="\\\"\'\a\b\\\"" />`).toEqual(
+			createElement("p", {a: `\\"'a\b\\"`}),
+		);
+		expect(jsx`<p a="hello\r\nworld" />`).toEqual(
+			createElement("p", {a: "hello\r\nworld"}),
+		);
+	});
 
-test("fragment shorthand", () => {
-	Assert.equal(
-		jsx`
+	test("fragment shorthand", () => {
+		expect(jsx`
 		<p>
 			Hello \
 			<>world</>
 		</p>
-	`,
-		createElement("p", null, "Hello ", createElement("", null, "world")),
-	);
-});
+	`).toEqual(
+			createElement("p", null, "Hello ", createElement("", null, "world")),
+		);
+	});
 
-test("tag expressions", () => {
-	const T1 = "tag1";
-	const T2 = "tag2";
-	Assert.equal(
-		jsx`<${T1}>Hello world</${T1}>`,
-		createElement(T1, null, "Hello world"),
-	);
-	Assert.equal(
-		jsx`
+	test("tag expressions", () => {
+		const T1 = "tag1";
+		const T2 = "tag2";
+		expect(jsx`<${T1}>Hello world</${T1}>`).toEqual(
+			createElement(T1, null, "Hello world"),
+		);
+		expect(jsx`
 		<${T1}>
 			<${T2}>
 				Hello world
 			</${T2}>
 		</${T1}>
-	`,
-		createElement(T1, null, createElement(T2, null, "Hello world")),
-	);
-});
+	`).toEqual(createElement(T1, null, createElement(T2, null, "Hello world")));
+	});
 
-test("children expressions", () => {
-	const ex1 = "Hello";
-	const ex2 = "world";
-	Assert.equal(
-		jsx`
+	test("children expressions", () => {
+		const ex1 = "Hello";
+		const ex2 = "world";
+		expect(jsx`
 		<div>${ex1} ${ex2}</div>
-	`,
-		createElement("div", null, "Hello", " ", "world"),
-	);
-	Assert.equal(
-		jsx`
+	`).toEqual(createElement("div", null, "Hello", " ", "world"));
+		expect(jsx`
 		<div>${ex1}${ex2}</div>
-	`,
-		createElement("div", null, "Hello", "world"),
-	);
+	`).toEqual(createElement("div", null, "Hello", "world"));
 
-	Assert.equal(
-		jsx`
+		expect(jsx`
 		<div>
 			<span>${ex1} ${ex2}</span>
 		</div>
-	`,
-		createElement(
-			"div",
-			null,
-			createElement("span", null, "Hello", " ", "world"),
-		),
-	);
-
-	Assert.equal(
-		jsx`
-		<div><span>${null} ${undefined} ${true} ${false} ${1} ${2}</span></div>
-	`,
-		createElement(
-			"div",
-			null,
+	`).toEqual(
 			createElement(
-				"span",
+				"div",
 				null,
-				...[null, " ", undefined, " ", true, " ", false, " ", 1, " ", 2],
+				createElement("span", null, "Hello", " ", "world"),
 			),
-		),
-	);
+		);
 
-	Assert.equal(
-		jsx`
+		expect(jsx`
+		<div><span>${null} ${undefined} ${true} ${false} ${1} ${2}</span></div>
+	`).toEqual(
+			createElement(
+				"div",
+				null,
+				createElement(
+					"span",
+					null,
+					...[null, " ", undefined, " ", true, " ", false, " ", 1, " ", 2],
+				),
+			),
+		);
+
+		expect(jsx`
 		${"Hello"} <span>world</span>
-	`,
-		createElement("", null, "Hello", " ", createElement("span", null, "world")),
-	);
-});
+	`).toEqual(
+			createElement(
+				"",
+				null,
+				"Hello",
+				" ",
+				createElement("span", null, "world"),
+			),
+		);
+	});
 
-test("shorthand boolean props", () => {
-	Assert.equal(
-		jsx`
+	test("shorthand boolean props", () => {
+		expect(jsx`
 		<label><input type="checkbox" checked name="attendance" disabled />Present</label>
-	`,
-		createElement(
-			"label",
-			null,
-			createElement("input", {
-				type: "checkbox",
-				checked: true,
-				name: "attendance",
-				disabled: true,
-			}),
-			"Present",
-		),
-	);
-});
+	`).toEqual(
+			createElement(
+				"label",
+				null,
+				createElement("input", {
+					type: "checkbox",
+					checked: true,
+					name: "attendance",
+					disabled: true,
+				}),
+				"Present",
+			),
+		);
+	});
 
-test("prop expressions", () => {
-	Assert.equal(
-		jsx`
+	test("prop expressions", () => {
+		expect(jsx`
 		<div class=${"greeting"} style = ${{color: "red"}}>
 			Hello world
 		</div>
-	`,
-		createElement(
-			"div",
-			{class: "greeting", style: {color: "red"}},
-			"Hello world",
-		),
-	);
-});
+	`).toEqual(
+			createElement(
+				"div",
+				{class: "greeting", style: {color: "red"}},
+				"Hello world",
+			),
+		);
+	});
 
-test("spread prop expressions", () => {
-	const props = {
-		style: "color: red;",
-	};
-	Assert.equal(
-		jsx`<div class="greeting" ...${props}>Hello world</div>`,
-		createElement(
-			"div",
-			{class: "greeting", style: "color: red;"},
-			"Hello world",
-		),
-	);
-	Assert.equal(
-		jsx`<div class="greeting" ... ${props}>Hello world</div>`,
-		createElement(
-			"div",
-			{class: "greeting", style: "color: red;"},
-			"Hello world",
-		),
-	);
-	Assert.equal(
-		jsx`<div class="greeting" ...
-	${props}>Hello world</div>`,
-		createElement(
-			"div",
-			{class: "greeting", style: "color: red;"},
-			"Hello world",
-		),
-	);
-});
+	test("spread prop expressions", () => {
+		const props = {
+			style: "color: red;",
+		};
+		expect(jsx`<div class="greeting" ...${props}>Hello world</div>`).toEqual(
+			createElement(
+				"div",
+				{class: "greeting", style: "color: red;"},
+				"Hello world",
+			),
+		);
+		expect(jsx`<div class="greeting" ... ${props}>Hello world</div>`).toEqual(
+			createElement(
+				"div",
+				{class: "greeting", style: "color: red;"},
+				"Hello world",
+			),
+		);
+		expect(jsx`<div class="greeting" ...
+	${props}>Hello world</div>`).toEqual(
+			createElement(
+				"div",
+				{class: "greeting", style: "color: red;"},
+				"Hello world",
+			),
+		);
+	});
 
-test("asymmetric closing tags", () => {
-	const Component = "C";
-	Assert.equal(
-		jsx`
+	test("asymmetric closing tags", () => {
+		const Component = "C";
+		expect(jsx`
 		<${Component}>Hello world<//>
-	`,
-		createElement(Component, null, "Hello world"),
-	);
+	`).toEqual(createElement(Component, null, "Hello world"));
 
-	Assert.equal(
-		jsx`
+		expect(jsx`
 		<${Component}>
 			Hello world
 		<//Component>
-	`,
-		createElement(Component, null, "Hello world"),
-	);
-});
+	`).toEqual(createElement(Component, null, "Hello world"));
+	});
 
-test("weird identifiers", () => {
-	Assert.equal(
-		jsx`
+	test("weird identifiers", () => {
+		expect(jsx`
 		<$a $b$ _c>
 			<-custom-element -prop="foo" _-_="bar" />
 			<__ key=${1}/>
 		</$a>
-	`,
-		createElement(
-			"$a",
-			{$b$: true, _c: true},
-			...[
-				createElement("-custom-element", {"-prop": "foo", "_-_": "bar"}),
-				createElement("__", {key: 1}),
-			],
-		),
-	);
-});
+	`).toEqual(
+			createElement(
+				"$a",
+				{$b$: true, _c: true},
+				...[
+					createElement("-custom-element", {"-prop": "foo", "_-_": "bar"}),
+					createElement("__", {key: 1}),
+				],
+			),
+		);
+	});
 
-test("comments", () => {
-	Assert.equal(
-		jsx`
+	test("comments", () => {
+		expect(jsx`
 		<div>
 			<!--<span>Hello</span>--><span>world</span>
 		</div>
-	`,
-		createElement("div", null, createElement("span", null, "world")),
-	);
+	`).toEqual(createElement("div", null, createElement("span", null, "world")));
 
-	Assert.equal(
-		jsx`
+		expect(jsx`
 		<div>
 			<!--<span>Hello</span>--> <!--<span>world</span>-->
 		</div>
-	`,
-		createElement("div", null, " "),
-	);
-});
+	`).toEqual(createElement("div", null, " "));
+	});
 
-test("comment expressions", () => {
-	Assert.equal(
-		jsx`
+	test("comment expressions", () => {
+		expect(jsx`
 		<div>
 			<!--
 			<${"C"} value=${true} />
 			-->
 			Hello<!-- world-->
 		</div>
-	`,
-		createElement("div", null, "Hello"),
-	);
-});
+	`).toEqual(createElement("div", null, "Hello"));
+	});
 
-test("prop string expressions", () => {
-	Assert.equal(
-		jsx`
+	test("prop string expressions", () => {
+		expect(jsx`
 		<p class="${undefined} ${null} ${"a"}-${{a: "1"}}-" />
-	`,
-		createElement("p", {class: "  a-[object Object]-"}),
-	);
-	Assert.equal(
-		jsx`
+	`).toEqual(createElement("p", {class: "  a-[object Object]-"}));
+		expect(jsx`
 		<p class="a${1}\${2}\a${3}\"" />
-	`,
-		createElement("p", {class: 'a1${2}a3"'}),
-	);
-	// Don’t think too hard about escaping.
-	Assert.equal(
-		jsx`
+	`).toEqual(createElement("p", {class: 'a1${2}a3"'}));
+		// Don’t think too hard about escaping.
+		expect(jsx`
 		<p class="a\\${1}\\${2}\\\a${3}\"" />
-	`,
-		createElement("p", {class: 'a\\1\\2\\a3"'}),
-	);
-	Assert.equal(
-		jsx`
+	`).toEqual(createElement("p", {class: 'a\\1\\2\\a3"'}));
+		expect(jsx`
 		<p class="a${true}${false}${null}${undefined}b" />
-	`,
-		createElement("p", {class: "ab"}),
-	);
-});
+	`).toEqual(createElement("p", {class: "ab"}));
+	});
 
-test("unbalanced tags", () => {
-	Assert.throws(() => {
-		jsx`<span>`;
-	}, 'Unmatched opening tag "span"');
-	Assert.throws(() => {
-		jsx`</span>`;
-	}, 'Unmatched closing tag "span"');
-	Assert.throws(() => {
-		jsx`<div>uhhh</span>`;
-	}, 'Unmatched closing tag "span", expected "div"');
-});
+	test("unbalanced tags", () => {
+		expect(() => {
+			jsx`<span>`;
+		}).toThrow('Unmatched opening tag "span"');
+		expect(() => {
+			jsx`</span>`;
+		}).toThrow('Unmatched closing tag "span"');
+		expect(() => {
+			jsx`<div>uhhh</span>`;
+		}).toThrow('Unmatched closing tag "span", expected "div"');
+	});
 
-test("invalid characters", () => {
-	Assert.throws(() => {
-		jsx`<<>`;
-	}, "Unexpected text `<`");
-	Assert.throws(() => {
-		jsx`<p<></p>`;
-	}, "Unexpected text `<`");
-	Assert.throws(() => {
-		jsx`<p><</p>`;
-	}, "Unexpected text `</`");
-	Assert.throws(() => {
-		jsx`<p</p>`;
-	}, "Unexpected text `</`");
-	Assert.throws(() => {
-		jsx`<p ///></p>`;
-	}, "Unexpected text `//`");
-	Assert.throws(() => {
-		jsx`<p /p></p>`;
-		// debatable, but whatever
-	}, "Unexpected text `/`");
-	Assert.throws(() => {
-		jsx`<e p p<></e>`;
-	}, "Unexpected text `<`");
-	Assert.throws(() => {
-		jsx`<p class</p>`;
-	}, "Unexpected text `</`");
-	Assert.throws(() => {
-		jsx`<p<`;
-	}, "Unexpected text `<`");
-	Assert.throws(() => {
-		jsx`<p class=<`;
-	}, "Unexpected text `<`");
-	Assert.throws(() => {
-		jsx`<p class==></p>`;
-	}, "Unexpected text `=></p>`");
-	Assert.throws(() => {
-		jsx`<p class=</p>`;
-	}, "Unexpected text `</p>`");
-	Assert.throws(() => {
-		jsx`<p></p text>`;
-	}, "Unexpected text `text`");
-	Assert.throws(() => {
-		jsx`<p></p text`;
-	}, "Unexpected text `text`");
-	Assert.throws(() => {
-		jsx`<p><///p>`;
-	}, "Unexpected text `/p`");
-	Assert.throws(() => {
-		jsx`<foo="bar">`;
-	}, 'Unexpected text `="`');
-	Assert.throws(() => {
-		jsx`<foo="\">`;
-		// debatable, but whatever
-	}, 'Unexpected text `="\\"`');
-});
+	test("invalid characters", () => {
+		expect(() => {
+			jsx`<<>`;
+		}).toThrow("Unexpected text `<`");
+		expect(() => {
+			jsx`<p<></p>`;
+		}).toThrow("Unexpected text `<`");
+		expect(() => {
+			jsx`<p><</p>`;
+		}).toThrow("Unexpected text `</`");
+		expect(() => {
+			jsx`<p</p>`;
+		}).toThrow("Unexpected text `</`");
+		expect(() => {
+			jsx`<p ///></p>`;
+		}).toThrow("Unexpected text `//`");
+		expect(() => {
+			jsx`<p /p></p>`;
+			// debatable, but whatever
+		}).toThrow("Unexpected text `/`");
+		expect(() => {
+			jsx`<e p p<></e>`;
+		}).toThrow("Unexpected text `<`");
+		expect(() => {
+			jsx`<p class</p>`;
+		}).toThrow("Unexpected text `</`");
+		expect(() => {
+			jsx`<p<`;
+		}).toThrow("Unexpected text `<`");
+		expect(() => {
+			jsx`<p class=<`;
+		}).toThrow("Unexpected text `<`");
+		expect(() => {
+			jsx`<p class==></p>`;
+		}).toThrow("Unexpected text `=></p>`");
+		expect(() => {
+			jsx`<p class=</p>`;
+		}).toThrow("Unexpected text `</p>`");
+		expect(() => {
+			jsx`<p></p text>`;
+		}).toThrow("Unexpected text `text`");
+		expect(() => {
+			jsx`<p></p text`;
+		}).toThrow("Unexpected text `text`");
+		expect(() => {
+			jsx`<p><///p>`;
+		}).toThrow("Unexpected text `/p`");
+		expect(() => {
+			jsx`<foo="bar">`;
+		}).toThrow('Unexpected text `="`');
+		expect(() => {
+			jsx`<foo="\">`;
+			// debatable, but whatever
+		}).toThrow('Unexpected text `="\\"`');
+	});
 
-// TODO: more information
-test("invalid expressions", () => {
-	const exp = {foo: "bar"};
-	Assert.throws(() => {
-		jsx`<div ${exp}>`;
-	}, "Unexpected expression");
-	Assert.throws(() => {
-		jsx`<${"foo"}${"bar"}>`;
-	}, "Unexpected expression");
-	Assert.throws(() => {
-		jsx`<p class${undefined} />`;
-	}, "Unexpected expression");
-});
+	// TODO: more information
+	test("invalid expressions", () => {
+		const exp = {foo: "bar"};
+		expect(() => {
+			jsx`<div ${exp}>`;
+		}).toThrow("Unexpected expression");
+		expect(() => {
+			jsx`<${"foo"}${"bar"}>`;
+		}).toThrow("Unexpected expression");
+		expect(() => {
+			jsx`<p class${undefined} />`;
+		}).toThrow("Unexpected expression");
+	});
 
-test("unbalanced tags with expressions", () => {
-	function C() {}
-	function D() {}
-	Assert.throws(() => {
-		jsx`<${C}>`;
-	}, "Unmatched opening tag C()");
-	Assert.throws(() => {
-		jsx`</${C}>`;
-	}, "Unmatched closing tag C()");
-	Assert.throws(() => {
-		jsx`<${C}></${D}>`;
-	}, "Unmatched closing tag D(), expected C()");
-});
+	test("unbalanced tags with expressions", () => {
+		function C() {}
+		function D() {}
+		expect(() => {
+			jsx`<${C}>`;
+		}).toThrow("Unmatched opening tag C()");
+		expect(() => {
+			jsx`</${C}>`;
+		}).toThrow("Unmatched closing tag C()");
+		expect(() => {
+			jsx`<${C}></${D}>`;
+		}).toThrow("Unmatched closing tag D(), expected C()");
+	});
 
-test("unicode characters", () => {
-	// Test that Unicode characters are preserved, not escaped
-	Assert.equal(
-		jsx`<span>–</span>`, // en dash (U+2013)
-		createElement("span", null, "–"),
-	);
-	Assert.equal(
-		jsx`<span>…</span>`, // ellipsis (U+2026)
-		createElement("span", null, "…"),
-	);
+	test("unicode characters", () => {
+		// Test that Unicode characters are preserved, not escaped
+		expect(jsx`<span>–</span>`).toEqual(
+			// en dash (U+2013)
+			createElement("span", null, "–"),
+		);
+		expect(jsx`<span>…</span>`).toEqual(
+			// ellipsis (U+2026)
+			createElement("span", null, "…"),
+		);
 
-	// Test Unicode with template expressions
-	const date = "January 1, 2024";
-	const result3 = jsx`<span>– Published ${date}</span>`;
-	const expected3 = createElement("span", null, "– Published ", date);
-	Assert.equal(result3, expected3);
+		// Test Unicode with template expressions
+		const date = "January 1, 2024";
+		const result3 = jsx`<span>– Published ${date}</span>`;
+		const expected3 = createElement("span", null, "– Published ", date);
+		expect(result3).toEqual(expected3);
 
-	const url = "/blog/post";
-	const result5 = jsx`<a href=${url}>Read more…</a>`;
-	const expected5 = createElement("a", {href: url}, "Read more…");
-	Assert.equal(result5, expected5);
+		const url = "/blog/post";
+		const result5 = jsx`<a href=${url}>Read more…</a>`;
+		const expected5 = createElement("a", {href: url}, "Read more…");
+		expect(result5).toEqual(expected5);
 
-	// Test complex nested template like BlogContent component
-	const author = "John Doe";
-	const authorURL = "/author/john";
-	const publishDateDisplay = "January 1, 2024";
-	const complexResult = jsx`
+		// Test complex nested template like BlogContent component
+		const author = "John Doe";
+		const authorURL = "/author/john";
+		const publishDateDisplay = "January 1, 2024";
+		const complexResult = jsx`
 		<p>
 			${author && jsx`By <a href=${authorURL} rel="author">${author}</a>`} \
 			${publishDateDisplay && jsx`<span>– Published ${publishDateDisplay}</span>`}
 		</p>
 	`;
 
-	// Check that the Unicode dash is preserved in the nested span component
-	// Based on the actual structure: complexResult.props.children[2] is the span
-	const spanChild = complexResult.props.children[2];
+		// Check that the Unicode dash is preserved in the nested span component
+		// Based on the actual structure: complexResult.props.children[2] is the span
+		const spanChild = complexResult.props.children[2];
 
-	// Verify the Unicode em dash is preserved
-	Assert.equal(spanChild.props.children[0], "– Published ");
+		// Verify the Unicode em dash is preserved
+		expect(spanChild.props.children[0]).toEqual("– Published ");
 
-	// Test that cache key generation preserves Unicode
-	const spans = {raw: ["<span>– Published ", "</span>"]};
-	const cacheKey = JSON.stringify(spans.raw);
-	Assert.ok(cacheKey.includes("– Published"));
-});
+		// Test that cache key generation preserves Unicode
+		const spans = {raw: ["<span>– Published ", "</span>"]};
+		const cacheKey = JSON.stringify(spans.raw);
+		expect(cacheKey.includes("– Published")).toBeTruthy();
+	});
 
-test("error messages include context", () => {
-	try {
-		jsx`<div>\n  </span>`;
-		Assert.unreachable("should have thrown");
-	} catch (e: any) {
-		Assert.instance(e, SyntaxError);
-		Assert.ok(e.message.includes("^"), "includes caret pointer");
-		Assert.ok(e.message.includes("|"), "includes context gutter");
-	}
-});
+	test("error messages include context", () => {
+		try {
+			jsx`<div>\n  </span>`;
+			throw new Error("should have thrown");
+		} catch (e: any) {
+			expect(e).toBeInstanceOf(SyntaxError);
+			expect(e.message.includes("^")).toBeTruthy() /* includes caret pointer */;
+			expect(
+				e.message.includes("|"),
+			).toBeTruthy() /* includes context gutter */;
+		}
+	});
 
-test("multiline error messages include context", () => {
-	try {
-		jsx`
+	test("multiline error messages include context", () => {
+		try {
+			jsx`
 			<div>
 				</span>
 			</div>
 		`;
-		Assert.unreachable("should have thrown");
-	} catch (e: any) {
-		Assert.instance(e, SyntaxError);
-		Assert.ok(e.message.includes("Unmatched closing tag"), "has base message");
-		Assert.ok(e.message.includes("^"), "includes caret pointer");
-		Assert.ok(e.message.includes("|"), "includes context gutter");
-	}
-});
+			throw new Error("should have thrown");
+		} catch (e: any) {
+			expect(e).toBeInstanceOf(SyntaxError);
+			expect(
+				e.message.includes("Unmatched closing tag"),
+			).toBeTruthy() /* has base message */;
+			expect(e.message.includes("^")).toBeTruthy() /* includes caret pointer */;
+			expect(
+				e.message.includes("|"),
+			).toBeTruthy() /* includes context gutter */;
+		}
+	});
 
-test("namespaced prop names", () => {
-	Assert.equal(
-		jsx`<div attr:foo="bar" />`,
-		createElement("div", {"attr:foo": "bar"}),
-	);
-	Assert.equal(
-		jsx`<input prop:value="x" />`,
-		createElement("input", {"prop:value": "x"}),
-	);
-	Assert.equal(
-		jsx`<use xlink:href="#icon" />`,
-		createElement("use", {"xlink:href": "#icon"}),
-	);
-	Assert.equal(
-		jsx`<svg xmlns:xlink="http://www.w3.org/1999/xlink" />`,
-		createElement("svg", {
-			"xmlns:xlink": "http://www.w3.org/1999/xlink",
-		}),
-	);
-	Assert.equal(
-		jsx`<div attr:foo=${"bar"} />`,
-		createElement("div", {"attr:foo": "bar"}),
-	);
-});
+	test("namespaced prop names", () => {
+		expect(jsx`<div attr:foo="bar" />`).toEqual(
+			createElement("div", {"attr:foo": "bar"}),
+		);
+		expect(jsx`<input prop:value="x" />`).toEqual(
+			createElement("input", {"prop:value": "x"}),
+		);
+		expect(jsx`<use xlink:href="#icon" />`).toEqual(
+			createElement("use", {"xlink:href": "#icon"}),
+		);
+		expect(jsx`<svg xmlns:xlink="http://www.w3.org/1999/xlink" />`).toEqual(
+			createElement("svg", {
+				"xmlns:xlink": "http://www.w3.org/1999/xlink",
+			}),
+		);
+		expect(jsx`<div attr:foo=${"bar"} />`).toEqual(
+			createElement("div", {"attr:foo": "bar"}),
+		);
+	});
 
-test("namespaced tag names", () => {
-	Assert.equal(
-		jsx`<svg:circle r="5" />`,
-		createElement("svg:circle", {r: "5"}),
-	);
-});
+	test("namespaced tag names", () => {
+		expect(jsx`<svg:circle r="5" />`).toEqual(
+			createElement("svg:circle", {r: "5"}),
+		);
+	});
 
-test("colons in text and attribute values", () => {
-	Assert.equal(jsx`<p>ratio 3:1</p>`, createElement("p", null, "ratio 3:1"));
-	Assert.equal(
-		jsx`<div style="color: red" href="https://example.com" />`,
-		createElement("div", {
-			style: "color: red",
-			href: "https://example.com",
-		}),
-	);
-});
+	test("colons in text and attribute values", () => {
+		expect(jsx`<p>ratio 3:1</p>`).toEqual(
+			createElement("p", null, "ratio 3:1"),
+		);
+		expect(jsx`<div style="color: red" href="https://example.com" />`).toEqual(
+			createElement("div", {
+				style: "color: red",
+				href: "https://example.com",
+			}),
+		);
+	});
 
-test("invalid namespaced names", () => {
-	Assert.throws(() => {
-		jsx`<div :foo="1" />`;
-	}, "Invalid prop name `:foo`");
-	Assert.throws(() => {
-		jsx`<div foo:="1" />`;
-	}, "Invalid prop name `foo:`");
-	Assert.throws(() => {
-		jsx`<:foo />`;
-	}, "Invalid tag name `:foo`");
-	Assert.throws(() => {
-		jsx`<foo: />`;
-	}, "Invalid tag name `foo:`");
-	Assert.throws(() => {
-		jsx`<div a:b:c="1" />`;
-	}, "Invalid prop name `a:b:c`");
+	test("invalid namespaced names", () => {
+		expect(() => {
+			jsx`<div :foo="1" />`;
+		}).toThrow("Invalid prop name `:foo`");
+		expect(() => {
+			jsx`<div foo:="1" />`;
+		}).toThrow("Invalid prop name `foo:`");
+		expect(() => {
+			jsx`<:foo />`;
+		}).toThrow("Invalid tag name `:foo`");
+		expect(() => {
+			jsx`<foo: />`;
+		}).toThrow("Invalid tag name `foo:`");
+		expect(() => {
+			jsx`<div a:b:c="1" />`;
+		}).toThrow("Invalid prop name `a:b:c`");
+	});
 });
-
-test.run();

--- a/test/keys.tsx
+++ b/test/keys.tsx
@@ -1,916 +1,907 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import * as Sinon from "sinon";
 
-import {createElement} from "../src/crank.js";
+import {createElement, Fragment} from "../src/crank.js";
 import type {Context} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("keys");
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+describe("keys", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-// TODO: write generative tests for this stuff
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+	// TODO: write generative tests for this stuff
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test("keys with no changes", () => {
-	renderer.render(
-		<div>
-			<span key="1">1</span>
-			<span key="2">2</span>
-			<span key="3">3</span>
-			<span key="4">4</span>
-			<span key="5">5</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></div>",
-	);
-	renderer.render(
-		<div>
-			<span key="1">1</span>
-			<span key="2">2</span>
-			<span key="3">3</span>
-			<span key="4">4</span>
-			<span key="5">5</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></div>",
-	);
-});
-
-test("no shared keys", () => {
-	renderer.render(
-		<div>
-			<span key="1">1</span>
-			<span key="2">2</span>
-			<span key="3">3</span>
-			<span key="4">4</span>
-			<span key="5">5</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></div>",
-	);
-	const span1 = document.body.firstChild!.childNodes[0];
-	const span2 = document.body.firstChild!.childNodes[1];
-	const span3 = document.body.firstChild!.childNodes[2];
-	const span4 = document.body.firstChild!.childNodes[3];
-	const span5 = document.body.firstChild!.childNodes[4];
-	renderer.render(
-		<div>
-			<span key="6">6</span>
-			<span key="7">7</span>
-			<span key="8">8</span>
-			<span key="9">9</span>
-			<span key="10">10</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>6</span><span>7</span><span>8</span><span>9</span><span>10</span></div>",
-	);
-	Assert.is.not(span1, document.body.firstChild!.childNodes[0]);
-	Assert.is.not(span2, document.body.firstChild!.childNodes[1]);
-	Assert.is.not(span3, document.body.firstChild!.childNodes[2]);
-	Assert.is.not(span4, document.body.firstChild!.childNodes[3]);
-	Assert.is.not(span5, document.body.firstChild!.childNodes[4]);
-});
-
-test("keyed child moves forward", () => {
-	renderer.render(
-		<div>
-			<span key="1">1</span>
-			<span>2</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>1</span><span>2</span></div>");
-	const span1 = document.body.firstChild!.firstChild;
-	renderer.render(
-		<div>
-			<span>0</span>
-			<span key="1">1</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>0</span><span>1</span></div>");
-	Assert.is(document.body.firstChild!.lastChild, span1);
-});
-
-test("keyed child moves backward", () => {
-	renderer.render(
-		<div>
-			<span>1</span>
-			<span key="2">2</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>1</span><span>2</span></div>");
-	const span2 = document.body.firstChild!.lastChild;
-	renderer.render(
-		<div>
-			<span key="2">2</span>
-			<span>3</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>2</span><span>3</span></div>");
-	Assert.is(document.body.firstChild!.firstChild, span2);
-});
-
-test("keyed child added between unkeyed children", () => {
-	renderer.render(
-		<div>
-			<span>1</span>
-			<span>3</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>1</span><span>3</span></div>");
-	const span3 = document.body.firstChild!.childNodes[1];
-	renderer.render(
-		<div>
-			<span>1</span>
-			<span key="2">2</span>
-			<span>3</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span></div>",
-	);
-	Assert.is(document.body.firstChild!.childNodes[2], span3);
-});
-
-test("keyed array", () => {
-	const spans = [
-		<span key="2">2</span>,
-		<span key="3">3</span>,
-		<span key="4">4</span>,
-	];
-	renderer.render(
-		<div>
-			<span>1</span>
-			{spans}
-			<span>5</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></div>",
-	);
-	const span1 = document.body.firstChild!.childNodes[0];
-	const span2 = document.body.firstChild!.childNodes[1];
-	const span3 = document.body.firstChild!.childNodes[2];
-	const span4 = document.body.firstChild!.childNodes[3];
-	const span5 = document.body.firstChild!.childNodes[4];
-	spans.splice(1, 1);
-	renderer.render(
-		<div>
-			<span>1</span>
-			{spans}
-			<span>5</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>4</span><span>5</span></div>",
-	);
-	Assert.is(document.body.firstChild!.childNodes[0], span1);
-	Assert.is(document.body.firstChild!.childNodes[1], span2);
-	Assert.is(document.body.firstChild!.childNodes[2], span4);
-	Assert.is(document.body.firstChild!.childNodes[3], span5);
-	Assert.is(document.body.contains(span3), false);
-});
-
-test("reversed keyed array", () => {
-	const spans = [
-		<span key="2">2</span>,
-		<span key="3">3</span>,
-		<span key="4">4</span>,
-		<span key="5">5</span>,
-		<span key="6">6</span>,
-	];
-	renderer.render(
-		<div>
-			<span>1</span>
-			{spans}
-			<span>7</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span><span>7</span></div>",
-	);
-	const span1 = document.body.firstChild!.childNodes[0];
-	const span2 = document.body.firstChild!.childNodes[1];
-	const span3 = document.body.firstChild!.childNodes[2];
-	const span4 = document.body.firstChild!.childNodes[3];
-	const span5 = document.body.firstChild!.childNodes[4];
-	const span6 = document.body.firstChild!.childNodes[5];
-	const span7 = document.body.firstChild!.childNodes[6];
-	spans.reverse();
-	renderer.render(
-		<div>
-			<span>1</span>
-			{spans}
-			<span>7</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>6</span><span>5</span><span>4</span><span>3</span><span>2</span><span>7</span></div>",
-	);
-	renderer.render(
-		<div>
-			<span>1</span>
-			{spans}
-			<span>7</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.firstChild!.childNodes[0], span1);
-	Assert.is(document.body.firstChild!.childNodes[1], span6);
-	Assert.is(document.body.firstChild!.childNodes[2], span5);
-	Assert.is(document.body.firstChild!.childNodes[3], span4);
-	Assert.is(document.body.firstChild!.childNodes[4], span3);
-	Assert.is(document.body.firstChild!.childNodes[5], span2);
-	Assert.is(document.body.firstChild!.childNodes[6], span7);
-	spans.reverse();
-	renderer.render(
-		<div>
-			<span>1</span>
-			{spans}
-			<span>7</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.firstChild!.childNodes[0], span1);
-	Assert.is(document.body.firstChild!.childNodes[1], span2);
-	Assert.is(document.body.firstChild!.childNodes[2], span3);
-	Assert.is(document.body.firstChild!.childNodes[3], span4);
-	Assert.is(document.body.firstChild!.childNodes[4], span5);
-	Assert.is(document.body.firstChild!.childNodes[5], span6);
-	Assert.is(document.body.firstChild!.childNodes[6], span7);
-});
-
-test("keyed child added", () => {
-	renderer.render(
-		<div>
-			<span key="2">2</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>2</span></div>");
-	const span2 = document.body.firstChild!.lastChild;
-	renderer.render(
-		<div>
-			<span key="1">1</span>
-			<span key="2">2</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>1</span><span>2</span></div>");
-	Assert.is(document.body.firstChild!.lastChild, span2);
-});
-
-test("unkeyed replaced with keyed", () => {
-	renderer.render(
-		<div>
-			<span>x</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>x</span></div>");
-	let span = document.body.firstChild!.firstChild;
-	renderer.render(
-		<div>
-			<span key="1">1</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	Assert.is.not(document.body.firstChild!.firstChild, span);
-	span = document.body.firstChild!.firstChild;
-	renderer.render(
-		<div>
-			<span>x</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>x</span></div>");
-	Assert.is.not(document.body.firstChild!.firstChild, span);
-});
-
-test("text and unkeyed and keyed children", () => {
-	renderer.render(
-		<div>
-			<span>Hello</span>
-			...
-			<span key="world">World</span>
-			...
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Hello</span>...<span>World</span>...</div>",
-	);
-	const world = document.body.firstChild!.childNodes[2];
-	Assert.is((world as any).outerHTML, "<span>World</span>");
-	renderer.render(
-		<div>
-			...
-			<span key="world">World</span>
-			...
-			<span>Hello</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div>...<span>World</span>...<span>Hello</span></div>",
-	);
-	Assert.is(document.body.firstChild!.childNodes[1], world);
-	renderer.render(
-		<div>
-			...
-			<span>Hello</span>
-			<span key="world">World</span>
-			...
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div>...<span>Hello</span><span>World</span>...</div>",
-	);
-	Assert.is(document.body.firstChild!.childNodes[2], world);
-});
-
-test("keyed children added before removed unkeyed child", () => {
-	renderer.render(
-		<div>
-			<div key="1">1</div>
-			<span>2</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><div>1</div><span>2</span></div>");
-	renderer.render(
-		<div>
-			<span key="1">1</span>
-			<span key="2">2</span>
-			<span key="3">3</span>
-			<span key="4">4</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span></div>",
-	);
-});
-
-test("same key, different tag", () => {
-	renderer.render(
-		<div>
-			<span>0</span>
-			<span key="1">1</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>0</span><span>1</span></div>");
-	renderer.render(
-		<div>
-			<div key="1">1</div>
-			<span>2</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><div>1</div><span>2</span></div>");
-});
-
-test("same key, different tag 2", () => {
-	renderer.render(
-		<div>
-			<span>0</span>
-			<span key="1">1</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>0</span><span>1</span></div>");
-	renderer.render(
-		<div>
-			<div key="1">1</div>
-			<span>0</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><div>1</div><span>0</span></div>");
-	renderer.render(
-		<div>
-			<span>0</span>
-			<span key="1">1</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>0</span><span>1</span></div>");
-	renderer.render(
-		<div>
-			<div key="1">1</div>
-			<span>0</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><div>1</div><span>0</span></div>");
-});
-
-test("unkeyed elements added in random spots", () => {
-	renderer.render(
-		<div>
-			<span key="1">1</span>
-			<span key="2">2</span>
-			<span key="3">3</span>
-			<span key="4">4</span>
-		</div>,
-		document.body,
-	);
-	const span1 = document.body.firstChild!.childNodes[0];
-	const span2 = document.body.firstChild!.childNodes[1];
-	const span3 = document.body.firstChild!.childNodes[2];
-	const span4 = document.body.firstChild!.childNodes[3];
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span></div>",
-	);
-	renderer.render(
-		<div>
-			<span>0.5</span>
-			<span key="1">1</span>
-			<span>1.5</span>
-			<span key="2">2</span>
-			<span>2.5</span>
-			<span key="3">3</span>
-			<span>3.5</span>
-			<span key="4">4</span>
-			<span>4.5</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>0.5</span><span>1</span><span>1.5</span><span>2</span><span>2.5</span><span>3</span><span>3.5</span><span>4</span><span>4.5</span></div>",
-	);
-	Assert.is(span1, document.body.firstChild!.childNodes[1]);
-	Assert.is(span2, document.body.firstChild!.childNodes[3]);
-	Assert.is(span3, document.body.firstChild!.childNodes[5]);
-	Assert.is(span4, document.body.firstChild!.childNodes[7]);
-	renderer.render(
-		<div>
-			<span key="1">1</span>
-			<span key="2">2</span>
-			<span key="3">3</span>
-			<span key="4">4</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span></div>",
-	);
-	Assert.is(span1, document.body.firstChild!.childNodes[0]);
-	Assert.is(span2, document.body.firstChild!.childNodes[1]);
-	Assert.is(span3, document.body.firstChild!.childNodes[2]);
-	Assert.is(span4, document.body.firstChild!.childNodes[3]);
-});
-
-test("moving a keyed item backwards", () => {
-	renderer.render(
-		<div>
-			<span key="1">1</span>
-			<span key="2">2</span>
-			<span key="3">3</span>
-			<span key="4">4</span>
-			<span key="5">5</span>
-			<span key="6">6</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></div>",
-	);
-	const span1 = document.body.firstChild!.childNodes[0];
-	const span2 = document.body.firstChild!.childNodes[1];
-	const span3 = document.body.firstChild!.childNodes[2];
-	const span4 = document.body.firstChild!.childNodes[3];
-	const span5 = document.body.firstChild!.childNodes[4];
-	const span6 = document.body.firstChild!.childNodes[5];
-	renderer.render(
-		<div>
-			<span key="1">1</span>
-			<span key="5">5</span>
-			<span key="2">2</span>
-			<span key="3">3</span>
-			<span key="4">4</span>
-			<span key="6">6</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>5</span><span>2</span><span>3</span><span>4</span><span>6</span></div>",
-	);
-	Assert.is(span1, document.body.firstChild!.childNodes[0]);
-	Assert.is(span2, document.body.firstChild!.childNodes[2]);
-	Assert.is(span3, document.body.firstChild!.childNodes[3]);
-	Assert.is(span4, document.body.firstChild!.childNodes[4]);
-	Assert.is(span5, document.body.firstChild!.childNodes[1]);
-	Assert.is(span6, document.body.firstChild!.childNodes[5]);
-	renderer.render(
-		<div>
-			<span key="1">1</span>
-			<span key="2">2</span>
-			<span key="3">3</span>
-			<span key="4">4</span>
-			<span key="5">5</span>
-			<span key="6">6</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></div>",
-	);
-	Assert.is(span1, document.body.firstChild!.childNodes[0]);
-	Assert.is(span2, document.body.firstChild!.childNodes[1]);
-	Assert.is(span3, document.body.firstChild!.childNodes[2]);
-	Assert.is(span4, document.body.firstChild!.childNodes[3]);
-	Assert.is(span5, document.body.firstChild!.childNodes[4]);
-	Assert.is(span6, document.body.firstChild!.childNodes[5]);
-});
-
-test("moving a keyed item forwards", () => {
-	renderer.render(
-		<div>
-			<span key="1">1</span>
-			<span key="2">2</span>
-			<span key="3">3</span>
-			<span key="4">4</span>
-			<span key="5">5</span>
-			<span key="6">6</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></div>",
-	);
-	const span1 = document.body.firstChild!.childNodes[0];
-	const span2 = document.body.firstChild!.childNodes[1];
-	const span3 = document.body.firstChild!.childNodes[2];
-	const span4 = document.body.firstChild!.childNodes[3];
-	const span5 = document.body.firstChild!.childNodes[4];
-	const span6 = document.body.firstChild!.childNodes[5];
-	renderer.render(
-		<div>
-			<span key="1">1</span>
-			<span key="3">3</span>
-			<span key="4">4</span>
-			<span key="5">5</span>
-			<span key="2">2</span>
-			<span key="6">6</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>3</span><span>4</span><span>5</span><span>2</span><span>6</span></div>",
-	);
-	Assert.is(span1, document.body.firstChild!.childNodes[0]);
-	Assert.is(span2, document.body.firstChild!.childNodes[4]);
-	Assert.is(span3, document.body.firstChild!.childNodes[1]);
-	Assert.is(span4, document.body.firstChild!.childNodes[2]);
-	Assert.is(span5, document.body.firstChild!.childNodes[3]);
-	Assert.is(span6, document.body.firstChild!.childNodes[5]);
-	renderer.render(
-		<div>
-			<span key="1">1</span>
-			<span key="2">2</span>
-			<span key="3">3</span>
-			<span key="4">4</span>
-			<span key="5">5</span>
-			<span key="6">6</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></div>",
-	);
-	Assert.is(span1, document.body.firstChild!.childNodes[0]);
-	Assert.is(span2, document.body.firstChild!.childNodes[1]);
-	Assert.is(span3, document.body.firstChild!.childNodes[2]);
-	Assert.is(span4, document.body.firstChild!.childNodes[3]);
-	Assert.is(span5, document.body.firstChild!.childNodes[4]);
-	Assert.is(span6, document.body.firstChild!.childNodes[5]);
-});
-test("swapping two keyed rows", () => {
-	renderer.render(
-		<div>
-			<span key="1">1</span>
-			<span key="2">2</span>
-			<span key="3">3</span>
-			<span key="4">4</span>
-			<span key="5">5</span>
-			<span key="6">6</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></div>",
-	);
-	const span1 = document.body.firstChild!.childNodes[0];
-	const span2 = document.body.firstChild!.childNodes[1];
-	const span3 = document.body.firstChild!.childNodes[2];
-	const span4 = document.body.firstChild!.childNodes[3];
-	const span5 = document.body.firstChild!.childNodes[4];
-	const span6 = document.body.firstChild!.childNodes[5];
-	renderer.render(
-		<div>
-			<span key="1">1</span>
-			<span key="5">5</span>
-			<span key="3">3</span>
-			<span key="4">4</span>
-			<span key="2">2</span>
-			<span key="6">6</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>5</span><span>3</span><span>4</span><span>2</span><span>6</span></div>",
-	);
-	Assert.is(span1, document.body.firstChild!.childNodes[0]);
-	Assert.is(span2, document.body.firstChild!.childNodes[4]);
-	Assert.is(span3, document.body.firstChild!.childNodes[2]);
-	Assert.is(span4, document.body.firstChild!.childNodes[3]);
-	Assert.is(span5, document.body.firstChild!.childNodes[1]);
-	Assert.is(span6, document.body.firstChild!.childNodes[5]);
-	renderer.render(
-		<div>
-			<span key="1">1</span>
-			<span key="2">2</span>
-			<span key="3">3</span>
-			<span key="4">4</span>
-			<span key="5">5</span>
-			<span key="6">6</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></div>",
-	);
-	Assert.is(span1, document.body.firstChild!.childNodes[0]);
-	Assert.is(span2, document.body.firstChild!.childNodes[1]);
-	Assert.is(span3, document.body.firstChild!.childNodes[2]);
-	Assert.is(span4, document.body.firstChild!.childNodes[3]);
-	Assert.is(span5, document.body.firstChild!.childNodes[4]);
-	Assert.is(span6, document.body.firstChild!.childNodes[5]);
-});
-
-test("duplicate keys", () => {
-	const mock = Sinon.stub(console, "error");
-	try {
+	test("keys with no changes", () => {
 		renderer.render(
 			<div>
 				<span key="1">1</span>
-				<span key="1">2</span>
-				<span key="1">3</span>
+				<span key="2">2</span>
+				<span key="3">3</span>
+				<span key="4">4</span>
+				<span key="5">5</span>
 			</div>,
 			document.body,
 		);
-		Assert.is(
-			document.body.innerHTML,
-			"<div><span>1</span><span>2</span><span>3</span></div>",
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></div>",
 		);
-
-		Assert.is(mock.callCount, 2);
 		renderer.render(
 			<div>
-				<span key="2">1</span>
-				<span key="1">2</span>
-				<span key="2">3</span>
+				<span key="1">1</span>
+				<span key="2">2</span>
+				<span key="3">3</span>
+				<span key="4">4</span>
+				<span key="5">5</span>
 			</div>,
 			document.body,
 		);
-		Assert.is(
-			document.body.innerHTML,
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></div>",
+		);
+	});
+
+	test("no shared keys", () => {
+		renderer.render(
+			<div>
+				<span key="1">1</span>
+				<span key="2">2</span>
+				<span key="3">3</span>
+				<span key="4">4</span>
+				<span key="5">5</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></div>",
+		);
+		const span1 = document.body.firstChild!.childNodes[0];
+		const span2 = document.body.firstChild!.childNodes[1];
+		const span3 = document.body.firstChild!.childNodes[2];
+		const span4 = document.body.firstChild!.childNodes[3];
+		const span5 = document.body.firstChild!.childNodes[4];
+		renderer.render(
+			<div>
+				<span key="6">6</span>
+				<span key="7">7</span>
+				<span key="8">8</span>
+				<span key="9">9</span>
+				<span key="10">10</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>6</span><span>7</span><span>8</span><span>9</span><span>10</span></div>",
+		);
+		expect(span1).not.toBe(document.body.firstChild!.childNodes[0]);
+		expect(span2).not.toBe(document.body.firstChild!.childNodes[1]);
+		expect(span3).not.toBe(document.body.firstChild!.childNodes[2]);
+		expect(span4).not.toBe(document.body.firstChild!.childNodes[3]);
+		expect(span5).not.toBe(document.body.firstChild!.childNodes[4]);
+	});
+
+	test("keyed child moves forward", () => {
+		renderer.render(
+			<div>
+				<span key="1">1</span>
+				<span>2</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span></div>",
+		);
+		const span1 = document.body.firstChild!.firstChild;
+		renderer.render(
+			<div>
+				<span>0</span>
+				<span key="1">1</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>0</span><span>1</span></div>",
+		);
+		expect(document.body.firstChild!.lastChild).toBe(span1);
+	});
+
+	test("keyed child moves backward", () => {
+		renderer.render(
+			<div>
+				<span>1</span>
+				<span key="2">2</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span></div>",
+		);
+		const span2 = document.body.firstChild!.lastChild;
+		renderer.render(
+			<div>
+				<span key="2">2</span>
+				<span>3</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>2</span><span>3</span></div>",
+		);
+		expect(document.body.firstChild!.firstChild).toBe(span2);
+	});
+
+	test("keyed child added between unkeyed children", () => {
+		renderer.render(
+			<div>
+				<span>1</span>
+				<span>3</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>3</span></div>",
+		);
+		const span3 = document.body.firstChild!.childNodes[1];
+		renderer.render(
+			<div>
+				<span>1</span>
+				<span key="2">2</span>
+				<span>3</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
 			"<div><span>1</span><span>2</span><span>3</span></div>",
 		);
+		expect(document.body.firstChild!.childNodes[2]).toBe(span3);
+	});
 
-		Assert.is(mock.callCount, 3);
-	} finally {
-		mock.restore();
-	}
-});
+	test("keyed array", () => {
+		const spans = [
+			<span key="2">2</span>,
+			<span key="3">3</span>,
+			<span key="4">4</span>,
+		];
+		renderer.render(
+			<div>
+				<span>1</span>
+				{spans}
+				<span>5</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></div>",
+		);
+		const span1 = document.body.firstChild!.childNodes[0];
+		const span2 = document.body.firstChild!.childNodes[1];
+		const span3 = document.body.firstChild!.childNodes[2];
+		const span4 = document.body.firstChild!.childNodes[3];
+		const span5 = document.body.firstChild!.childNodes[4];
+		spans.splice(1, 1);
+		renderer.render(
+			<div>
+				<span>1</span>
+				{spans}
+				<span>5</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>4</span><span>5</span></div>",
+		);
+		expect(document.body.firstChild!.childNodes[0]).toBe(span1);
+		expect(document.body.firstChild!.childNodes[1]).toBe(span2);
+		expect(document.body.firstChild!.childNodes[2]).toBe(span4);
+		expect(document.body.firstChild!.childNodes[3]).toBe(span5);
+		expect(document.body.contains(span3)).toBe(false);
+	});
 
-import {Fragment} from "../src/crank.js";
+	test("reversed keyed array", () => {
+		const spans = [
+			<span key="2">2</span>,
+			<span key="3">3</span>,
+			<span key="4">4</span>,
+			<span key="5">5</span>,
+			<span key="6">6</span>,
+		];
+		renderer.render(
+			<div>
+				<span>1</span>
+				{spans}
+				<span>7</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span><span>7</span></div>",
+		);
+		const span1 = document.body.firstChild!.childNodes[0];
+		const span2 = document.body.firstChild!.childNodes[1];
+		const span3 = document.body.firstChild!.childNodes[2];
+		const span4 = document.body.firstChild!.childNodes[3];
+		const span5 = document.body.firstChild!.childNodes[4];
+		const span6 = document.body.firstChild!.childNodes[5];
+		const span7 = document.body.firstChild!.childNodes[6];
+		spans.reverse();
+		renderer.render(
+			<div>
+				<span>1</span>
+				{spans}
+				<span>7</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>6</span><span>5</span><span>4</span><span>3</span><span>2</span><span>7</span></div>",
+		);
+		renderer.render(
+			<div>
+				<span>1</span>
+				{spans}
+				<span>7</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.firstChild!.childNodes[0]).toBe(span1);
+		expect(document.body.firstChild!.childNodes[1]).toBe(span6);
+		expect(document.body.firstChild!.childNodes[2]).toBe(span5);
+		expect(document.body.firstChild!.childNodes[3]).toBe(span4);
+		expect(document.body.firstChild!.childNodes[4]).toBe(span3);
+		expect(document.body.firstChild!.childNodes[5]).toBe(span2);
+		expect(document.body.firstChild!.childNodes[6]).toBe(span7);
+		spans.reverse();
+		renderer.render(
+			<div>
+				<span>1</span>
+				{spans}
+				<span>7</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.firstChild!.childNodes[0]).toBe(span1);
+		expect(document.body.firstChild!.childNodes[1]).toBe(span2);
+		expect(document.body.firstChild!.childNodes[2]).toBe(span3);
+		expect(document.body.firstChild!.childNodes[3]).toBe(span4);
+		expect(document.body.firstChild!.childNodes[4]).toBe(span5);
+		expect(document.body.firstChild!.childNodes[5]).toBe(span6);
+		expect(document.body.firstChild!.childNodes[6]).toBe(span7);
+	});
 
-// https://github.com/bikeshaving/crank/issues/267
-test("component unmounts with key", () => {
-	const fn = Sinon.fake();
-	function* Component(this: Context) {
-		this.cleanup(() => {
+	test("keyed child added", () => {
+		renderer.render(
+			<div>
+				<span key="2">2</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>2</span></div>");
+		const span2 = document.body.firstChild!.lastChild;
+		renderer.render(
+			<div>
+				<span key="1">1</span>
+				<span key="2">2</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span></div>",
+		);
+		expect(document.body.firstChild!.lastChild).toBe(span2);
+	});
+
+	test("unkeyed replaced with keyed", () => {
+		renderer.render(
+			<div>
+				<span>x</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>x</span></div>");
+		let span = document.body.firstChild!.firstChild;
+		renderer.render(
+			<div>
+				<span key="1">1</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		expect(document.body.firstChild!.firstChild).not.toBe(span);
+		span = document.body.firstChild!.firstChild;
+		renderer.render(
+			<div>
+				<span>x</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>x</span></div>");
+		expect(document.body.firstChild!.firstChild).not.toBe(span);
+	});
+
+	test("text and unkeyed and keyed children", () => {
+		renderer.render(
+			<div>
+				<span>Hello</span>
+				...
+				<span key="world">World</span>
+				...
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Hello</span>...<span>World</span>...</div>",
+		);
+		const world = document.body.firstChild!.childNodes[2];
+		expect((world as any).outerHTML).toBe("<span>World</span>");
+		renderer.render(
+			<div>
+				...
+				<span key="world">World</span>
+				...
+				<span>Hello</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div>...<span>World</span>...<span>Hello</span></div>",
+		);
+		expect(document.body.firstChild!.childNodes[1]).toBe(world);
+		renderer.render(
+			<div>
+				...
+				<span>Hello</span>
+				<span key="world">World</span>
+				...
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div>...<span>Hello</span><span>World</span>...</div>",
+		);
+		expect(document.body.firstChild!.childNodes[2]).toBe(world);
+	});
+
+	test("keyed children added before removed unkeyed child", () => {
+		renderer.render(
+			<div>
+				<div key="1">1</div>
+				<span>2</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><div>1</div><span>2</span></div>",
+		);
+		renderer.render(
+			<div>
+				<span key="1">1</span>
+				<span key="2">2</span>
+				<span key="3">3</span>
+				<span key="4">4</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span></div>",
+		);
+	});
+
+	test("same key, different tag", () => {
+		renderer.render(
+			<div>
+				<span>0</span>
+				<span key="1">1</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>0</span><span>1</span></div>",
+		);
+		renderer.render(
+			<div>
+				<div key="1">1</div>
+				<span>2</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><div>1</div><span>2</span></div>",
+		);
+	});
+
+	test("same key, different tag 2", () => {
+		renderer.render(
+			<div>
+				<span>0</span>
+				<span key="1">1</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>0</span><span>1</span></div>",
+		);
+		renderer.render(
+			<div>
+				<div key="1">1</div>
+				<span>0</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><div>1</div><span>0</span></div>",
+		);
+		renderer.render(
+			<div>
+				<span>0</span>
+				<span key="1">1</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>0</span><span>1</span></div>",
+		);
+		renderer.render(
+			<div>
+				<div key="1">1</div>
+				<span>0</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><div>1</div><span>0</span></div>",
+		);
+	});
+
+	test("unkeyed elements added in random spots", () => {
+		renderer.render(
+			<div>
+				<span key="1">1</span>
+				<span key="2">2</span>
+				<span key="3">3</span>
+				<span key="4">4</span>
+			</div>,
+			document.body,
+		);
+		const span1 = document.body.firstChild!.childNodes[0];
+		const span2 = document.body.firstChild!.childNodes[1];
+		const span3 = document.body.firstChild!.childNodes[2];
+		const span4 = document.body.firstChild!.childNodes[3];
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span></div>",
+		);
+		renderer.render(
+			<div>
+				<span>0.5</span>
+				<span key="1">1</span>
+				<span>1.5</span>
+				<span key="2">2</span>
+				<span>2.5</span>
+				<span key="3">3</span>
+				<span>3.5</span>
+				<span key="4">4</span>
+				<span>4.5</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>0.5</span><span>1</span><span>1.5</span><span>2</span><span>2.5</span><span>3</span><span>3.5</span><span>4</span><span>4.5</span></div>",
+		);
+		expect(span1).toBe(document.body.firstChild!.childNodes[1]);
+		expect(span2).toBe(document.body.firstChild!.childNodes[3]);
+		expect(span3).toBe(document.body.firstChild!.childNodes[5]);
+		expect(span4).toBe(document.body.firstChild!.childNodes[7]);
+		renderer.render(
+			<div>
+				<span key="1">1</span>
+				<span key="2">2</span>
+				<span key="3">3</span>
+				<span key="4">4</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span></div>",
+		);
+		expect(span1).toBe(document.body.firstChild!.childNodes[0]);
+		expect(span2).toBe(document.body.firstChild!.childNodes[1]);
+		expect(span3).toBe(document.body.firstChild!.childNodes[2]);
+		expect(span4).toBe(document.body.firstChild!.childNodes[3]);
+	});
+
+	test("moving a keyed item backwards", () => {
+		renderer.render(
+			<div>
+				<span key="1">1</span>
+				<span key="2">2</span>
+				<span key="3">3</span>
+				<span key="4">4</span>
+				<span key="5">5</span>
+				<span key="6">6</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></div>",
+		);
+		const span1 = document.body.firstChild!.childNodes[0];
+		const span2 = document.body.firstChild!.childNodes[1];
+		const span3 = document.body.firstChild!.childNodes[2];
+		const span4 = document.body.firstChild!.childNodes[3];
+		const span5 = document.body.firstChild!.childNodes[4];
+		const span6 = document.body.firstChild!.childNodes[5];
+		renderer.render(
+			<div>
+				<span key="1">1</span>
+				<span key="5">5</span>
+				<span key="2">2</span>
+				<span key="3">3</span>
+				<span key="4">4</span>
+				<span key="6">6</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>5</span><span>2</span><span>3</span><span>4</span><span>6</span></div>",
+		);
+		expect(span1).toBe(document.body.firstChild!.childNodes[0]);
+		expect(span2).toBe(document.body.firstChild!.childNodes[2]);
+		expect(span3).toBe(document.body.firstChild!.childNodes[3]);
+		expect(span4).toBe(document.body.firstChild!.childNodes[4]);
+		expect(span5).toBe(document.body.firstChild!.childNodes[1]);
+		expect(span6).toBe(document.body.firstChild!.childNodes[5]);
+		renderer.render(
+			<div>
+				<span key="1">1</span>
+				<span key="2">2</span>
+				<span key="3">3</span>
+				<span key="4">4</span>
+				<span key="5">5</span>
+				<span key="6">6</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></div>",
+		);
+		expect(span1).toBe(document.body.firstChild!.childNodes[0]);
+		expect(span2).toBe(document.body.firstChild!.childNodes[1]);
+		expect(span3).toBe(document.body.firstChild!.childNodes[2]);
+		expect(span4).toBe(document.body.firstChild!.childNodes[3]);
+		expect(span5).toBe(document.body.firstChild!.childNodes[4]);
+		expect(span6).toBe(document.body.firstChild!.childNodes[5]);
+	});
+
+	test("moving a keyed item forwards", () => {
+		renderer.render(
+			<div>
+				<span key="1">1</span>
+				<span key="2">2</span>
+				<span key="3">3</span>
+				<span key="4">4</span>
+				<span key="5">5</span>
+				<span key="6">6</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></div>",
+		);
+		const span1 = document.body.firstChild!.childNodes[0];
+		const span2 = document.body.firstChild!.childNodes[1];
+		const span3 = document.body.firstChild!.childNodes[2];
+		const span4 = document.body.firstChild!.childNodes[3];
+		const span5 = document.body.firstChild!.childNodes[4];
+		const span6 = document.body.firstChild!.childNodes[5];
+		renderer.render(
+			<div>
+				<span key="1">1</span>
+				<span key="3">3</span>
+				<span key="4">4</span>
+				<span key="5">5</span>
+				<span key="2">2</span>
+				<span key="6">6</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>3</span><span>4</span><span>5</span><span>2</span><span>6</span></div>",
+		);
+		expect(span1).toBe(document.body.firstChild!.childNodes[0]);
+		expect(span2).toBe(document.body.firstChild!.childNodes[4]);
+		expect(span3).toBe(document.body.firstChild!.childNodes[1]);
+		expect(span4).toBe(document.body.firstChild!.childNodes[2]);
+		expect(span5).toBe(document.body.firstChild!.childNodes[3]);
+		expect(span6).toBe(document.body.firstChild!.childNodes[5]);
+		renderer.render(
+			<div>
+				<span key="1">1</span>
+				<span key="2">2</span>
+				<span key="3">3</span>
+				<span key="4">4</span>
+				<span key="5">5</span>
+				<span key="6">6</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></div>",
+		);
+		expect(span1).toBe(document.body.firstChild!.childNodes[0]);
+		expect(span2).toBe(document.body.firstChild!.childNodes[1]);
+		expect(span3).toBe(document.body.firstChild!.childNodes[2]);
+		expect(span4).toBe(document.body.firstChild!.childNodes[3]);
+		expect(span5).toBe(document.body.firstChild!.childNodes[4]);
+		expect(span6).toBe(document.body.firstChild!.childNodes[5]);
+	});
+	test("swapping two keyed rows", () => {
+		renderer.render(
+			<div>
+				<span key="1">1</span>
+				<span key="2">2</span>
+				<span key="3">3</span>
+				<span key="4">4</span>
+				<span key="5">5</span>
+				<span key="6">6</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></div>",
+		);
+		const span1 = document.body.firstChild!.childNodes[0];
+		const span2 = document.body.firstChild!.childNodes[1];
+		const span3 = document.body.firstChild!.childNodes[2];
+		const span4 = document.body.firstChild!.childNodes[3];
+		const span5 = document.body.firstChild!.childNodes[4];
+		const span6 = document.body.firstChild!.childNodes[5];
+		renderer.render(
+			<div>
+				<span key="1">1</span>
+				<span key="5">5</span>
+				<span key="3">3</span>
+				<span key="4">4</span>
+				<span key="2">2</span>
+				<span key="6">6</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>5</span><span>3</span><span>4</span><span>2</span><span>6</span></div>",
+		);
+		expect(span1).toBe(document.body.firstChild!.childNodes[0]);
+		expect(span2).toBe(document.body.firstChild!.childNodes[4]);
+		expect(span3).toBe(document.body.firstChild!.childNodes[2]);
+		expect(span4).toBe(document.body.firstChild!.childNodes[3]);
+		expect(span5).toBe(document.body.firstChild!.childNodes[1]);
+		expect(span6).toBe(document.body.firstChild!.childNodes[5]);
+		renderer.render(
+			<div>
+				<span key="1">1</span>
+				<span key="2">2</span>
+				<span key="3">3</span>
+				<span key="4">4</span>
+				<span key="5">5</span>
+				<span key="6">6</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></div>",
+		);
+		expect(span1).toBe(document.body.firstChild!.childNodes[0]);
+		expect(span2).toBe(document.body.firstChild!.childNodes[1]);
+		expect(span3).toBe(document.body.firstChild!.childNodes[2]);
+		expect(span4).toBe(document.body.firstChild!.childNodes[3]);
+		expect(span5).toBe(document.body.firstChild!.childNodes[4]);
+		expect(span6).toBe(document.body.firstChild!.childNodes[5]);
+	});
+
+	test("duplicate keys", () => {
+		const mock = Sinon.stub(console, "error");
+		try {
+			renderer.render(
+				<div>
+					<span key="1">1</span>
+					<span key="1">2</span>
+					<span key="1">3</span>
+				</div>,
+				document.body,
+			);
+			expect(document.body.innerHTML).toBe(
+				"<div><span>1</span><span>2</span><span>3</span></div>",
+			);
+
+			expect(mock.callCount).toBe(2);
+			renderer.render(
+				<div>
+					<span key="2">1</span>
+					<span key="1">2</span>
+					<span key="2">3</span>
+				</div>,
+				document.body,
+			);
+			expect(document.body.innerHTML).toBe(
+				"<div><span>1</span><span>2</span><span>3</span></div>",
+			);
+
+			expect(mock.callCount).toBe(3);
+		} finally {
+			mock.restore();
+		}
+	});
+
+	// https://github.com/bikeshaving/crank/issues/267
+	test("component unmounts with key", () => {
+		const fn = Sinon.fake();
+		function* Component(this: Context) {
+			this.cleanup(() => {
+				fn();
+			});
+			for ({} of this) {
+				yield <div>Hello</div>;
+			}
+
 			fn();
-		});
-		for ({} of this) {
-			yield <div>Hello</div>;
 		}
 
-		fn();
-	}
+		renderer.render(
+			<div>{[<Fragment />, <Fragment />, <Component key="1" />]}</div>,
+			document.body,
+		);
+		renderer.render(<div>{[<Fragment />, <Fragment />]}</div>, document.body);
 
-	renderer.render(
-		<div>{[<Fragment />, <Fragment />, <Component key="1" />]}</div>,
-		document.body,
-	);
-	renderer.render(<div>{[<Fragment />, <Fragment />]}</div>, document.body);
+		expect(2).toBe(fn.callCount);
+	});
 
-	Assert.is(2, fn.callCount);
+	test("changing list", () => {
+		const fn = Sinon.fake();
+		function* Component(this: Context, {children}: {children?: any}) {
+			for ({children} of this) {
+				yield <p>{children}</p>;
+			}
+
+			fn(children);
+		}
+
+		renderer.render(
+			<div>
+				<Component key="1">1</Component>
+				<Component key="2">2</Component>
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><p>1</p><p>2</p></div>");
+
+		renderer.render(
+			<div>
+				<Component key="2">2</Component>
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><p>2</p></div>");
+
+		expect(1).toBe(fn.callCount);
+	});
+
+	// Keyed host elements reorder correctly via refresh
+	test("keyed host elements reorder via refresh", async () => {
+		let refresh: () => void;
+		function* List(this: Context) {
+			let reversed = false;
+			refresh = () => {
+				reversed = !reversed;
+				this.refresh();
+			};
+
+			for ({} of this) {
+				yield (
+					<div>
+						{reversed
+							? [
+									<span key="d">d</span>,
+									<span key="c">c</span>,
+									<span key="b">b</span>,
+									<span key="a">a</span>,
+								]
+							: [
+									<span key="a">a</span>,
+									<span key="b">b</span>,
+									<span key="c">c</span>,
+									<span key="d">d</span>,
+								]}
+					</div>
+				);
+			}
+		}
+
+		renderer.render(<List />, document.body);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>a</span><span>b</span><span>c</span><span>d</span></div>",
+		);
+
+		const spanA = document.body.firstChild!.childNodes[0];
+		const spanB = document.body.firstChild!.childNodes[1];
+		const spanC = document.body.firstChild!.childNodes[2];
+		const spanD = document.body.firstChild!.childNodes[3];
+
+		// Reverse via refresh
+		refresh!();
+		await new Promise((r) => setTimeout(r, 0));
+
+		// DOM should be reordered
+		expect(document.body.innerHTML).toBe(
+			"<div><span>d</span><span>c</span><span>b</span><span>a</span></div>",
+		);
+		// Same DOM nodes, just moved
+		expect(document.body.firstChild!.childNodes[0]).toBe(spanD);
+		expect(document.body.firstChild!.childNodes[1]).toBe(spanC);
+		expect(document.body.firstChild!.childNodes[2]).toBe(spanB);
+		expect(document.body.firstChild!.childNodes[3]).toBe(spanA);
+	});
+
+	// Bug: keyed generator components don't reorder via refresh
+	test("keyed generator components reorder via refresh", async () => {
+		const mounted: string[] = [];
+		function* ID(this: Context, {id}: {id: string}) {
+			mounted.push(id);
+			for ({id} of this) {
+				yield <span>{id}</span>;
+			}
+		}
+
+		let refresh: () => void;
+		function* List(this: Context) {
+			let reversed = false;
+			refresh = () => {
+				reversed = !reversed;
+				this.refresh();
+			};
+
+			for ({} of this) {
+				const order = reversed ? ["d", "c", "b", "a"] : ["a", "b", "c", "d"];
+				yield (
+					<div>
+						{order.map((k) => (
+							<ID key={k} id={k} />
+						))}
+					</div>
+				);
+			}
+		}
+
+		renderer.render(<List />, document.body);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>a</span><span>b</span><span>c</span><span>d</span></div>",
+		);
+		expect(mounted).toEqual(["a", "b", "c", "d"]);
+
+		const spanA = document.body.firstChild!.childNodes[0];
+		const spanB = document.body.firstChild!.childNodes[1];
+		const spanC = document.body.firstChild!.childNodes[2];
+		const spanD = document.body.firstChild!.childNodes[3];
+
+		// Reverse via refresh
+		refresh!();
+		await new Promise((r) => setTimeout(r, 0));
+
+		// Components should NOT be remounted
+		expect(mounted).toEqual(["a", "b", "c", "d"]);
+
+		// DOM should be reordered
+		expect(document.body.innerHTML).toBe(
+			"<div><span>d</span><span>c</span><span>b</span><span>a</span></div>",
+		);
+		// Same DOM nodes, just moved
+		expect(document.body.firstChild!.childNodes[0]).toBe(spanD);
+		expect(document.body.firstChild!.childNodes[1]).toBe(spanC);
+		expect(document.body.firstChild!.childNodes[2]).toBe(spanB);
+		expect(document.body.firstChild!.childNodes[3]).toBe(spanA);
+	});
 });
-
-test("changing list", () => {
-	const fn = Sinon.fake();
-	function* Component(this: Context, {children}: {children?: any}) {
-		for ({children} of this) {
-			yield <p>{children}</p>;
-		}
-
-		fn(children);
-	}
-
-	renderer.render(
-		<div>
-			<Component key="1">1</Component>
-			<Component key="2">2</Component>
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><p>1</p><p>2</p></div>");
-
-	renderer.render(
-		<div>
-			<Component key="2">2</Component>
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><p>2</p></div>");
-
-	Assert.is(1, fn.callCount);
-});
-
-// Keyed host elements reorder correctly via refresh
-test("keyed host elements reorder via refresh", async () => {
-	let refresh: () => void;
-	function* List(this: Context) {
-		let reversed = false;
-		refresh = () => {
-			reversed = !reversed;
-			this.refresh();
-		};
-
-		for ({} of this) {
-			yield (
-				<div>
-					{reversed
-						? [
-								<span key="d">d</span>,
-								<span key="c">c</span>,
-								<span key="b">b</span>,
-								<span key="a">a</span>,
-							]
-						: [
-								<span key="a">a</span>,
-								<span key="b">b</span>,
-								<span key="c">c</span>,
-								<span key="d">d</span>,
-							]}
-				</div>
-			);
-		}
-	}
-
-	renderer.render(<List />, document.body);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>a</span><span>b</span><span>c</span><span>d</span></div>",
-	);
-
-	const spanA = document.body.firstChild!.childNodes[0];
-	const spanB = document.body.firstChild!.childNodes[1];
-	const spanC = document.body.firstChild!.childNodes[2];
-	const spanD = document.body.firstChild!.childNodes[3];
-
-	// Reverse via refresh
-	refresh!();
-	await new Promise((r) => setTimeout(r, 0));
-
-	// DOM should be reordered
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>d</span><span>c</span><span>b</span><span>a</span></div>",
-	);
-	// Same DOM nodes, just moved
-	Assert.is(document.body.firstChild!.childNodes[0], spanD);
-	Assert.is(document.body.firstChild!.childNodes[1], spanC);
-	Assert.is(document.body.firstChild!.childNodes[2], spanB);
-	Assert.is(document.body.firstChild!.childNodes[3], spanA);
-});
-
-// Bug: keyed generator components don't reorder via refresh
-test("keyed generator components reorder via refresh", async () => {
-	const mounted: string[] = [];
-	function* ID(this: Context, {id}: {id: string}) {
-		mounted.push(id);
-		for ({id} of this) {
-			yield <span>{id}</span>;
-		}
-	}
-
-	let refresh: () => void;
-	function* List(this: Context) {
-		let reversed = false;
-		refresh = () => {
-			reversed = !reversed;
-			this.refresh();
-		};
-
-		for ({} of this) {
-			const order = reversed ? ["d", "c", "b", "a"] : ["a", "b", "c", "d"];
-			yield (
-				<div>
-					{order.map((k) => (
-						<ID key={k} id={k} />
-					))}
-				</div>
-			);
-		}
-	}
-
-	renderer.render(<List />, document.body);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>a</span><span>b</span><span>c</span><span>d</span></div>",
-	);
-	Assert.equal(mounted, ["a", "b", "c", "d"]);
-
-	const spanA = document.body.firstChild!.childNodes[0];
-	const spanB = document.body.firstChild!.childNodes[1];
-	const spanC = document.body.firstChild!.childNodes[2];
-	const spanD = document.body.firstChild!.childNodes[3];
-
-	// Reverse via refresh
-	refresh!();
-	await new Promise((r) => setTimeout(r, 0));
-
-	// Components should NOT be remounted
-	Assert.equal(mounted, ["a", "b", "c", "d"]);
-
-	// DOM should be reordered
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>d</span><span>c</span><span>b</span><span>a</span></div>",
-	);
-	// Same DOM nodes, just moved
-	Assert.is(document.body.firstChild!.childNodes[0], spanD);
-	Assert.is(document.body.firstChild!.childNodes[1], spanC);
-	Assert.is(document.body.firstChild!.childNodes[2], spanB);
-	Assert.is(document.body.firstChild!.childNodes[3], spanA);
-});
-
-test.run();

--- a/test/mathml.tsx
+++ b/test/mathml.tsx
@@ -1,270 +1,270 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import {createElement} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("mathml");
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+describe("mathml", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test("simple math element", () => {
-	renderer.render(<math>Hello world</math>, document.body);
-	const mathElement = document.body.firstChild as Element;
-	Assert.ok(mathElement instanceof Element);
-	// Check if MathMLElement is available in this environment
-	if (typeof MathMLElement !== "undefined") {
-		Assert.ok(mathElement instanceof MathMLElement);
-	}
-	Assert.is(mathElement.tagName, "math");
-	Assert.is(mathElement.namespaceURI, "http://www.w3.org/1998/Math/MathML");
-	Assert.ok(mathElement.firstChild instanceof Text);
-	Assert.is(mathElement.firstChild!.nodeValue, "Hello world");
-});
+	test("simple math element", () => {
+		renderer.render(<math>Hello world</math>, document.body);
+		const mathElement = document.body.firstChild as Element;
+		expect(mathElement instanceof Element).toBeTruthy();
+		// Check if MathMLElement is available in this environment
+		if (typeof MathMLElement !== "undefined") {
+			expect(mathElement instanceof MathMLElement).toBeTruthy();
+		}
+		expect(mathElement.tagName).toBe("math");
+		expect(mathElement.namespaceURI).toBe("http://www.w3.org/1998/Math/MathML");
+		expect(mathElement.firstChild instanceof Text).toBeTruthy();
+		expect(mathElement.firstChild!.nodeValue).toBe("Hello world");
+	});
 
-test("quadratic formula", () => {
-	renderer.render(
-		<math xmlns="http://www.w3.org/1998/Math/MathML">
-			<mrow>
-				<mi>x</mi>
-				<mo>=</mo>
-				<mfrac>
-					<mrow>
-						<mo>-</mo>
-						<mi>b</mi>
-						<mo>±</mo>
-						<msqrt>
-							<msup>
-								<mi>b</mi>
-								<mn>2</mn>
-							</msup>
-							<mo>-</mo>
-							<mn>4</mn>
-							<mi>a</mi>
-							<mi>c</mi>
-						</msqrt>
-					</mrow>
-					<mrow>
-						<mn>2</mn>
-						<mi>a</mi>
-					</mrow>
-				</mfrac>
-			</mrow>
-		</math>,
-		document.body,
-	);
-
-	const mathRoot = document.body.firstChild as Element;
-	Assert.ok(mathRoot instanceof Element);
-	if (typeof MathMLElement !== "undefined") {
-		Assert.ok(mathRoot instanceof MathMLElement);
-	}
-	Assert.is(mathRoot.tagName, "math");
-	Assert.is(mathRoot.namespaceURI, "http://www.w3.org/1998/Math/MathML");
-
-	// Check that child elements are also in MathML namespace
-	const mrow = mathRoot.firstChild as Element;
-	Assert.ok(mrow instanceof Element);
-	if (typeof MathMLElement !== "undefined") {
-		Assert.ok(mrow instanceof MathMLElement);
-	}
-	Assert.is(mrow.tagName, "mrow");
-	Assert.is(mrow.namespaceURI, "http://www.w3.org/1998/Math/MathML");
-
-	const mi = mrow.firstChild as Element;
-	Assert.ok(mi instanceof Element);
-	if (typeof MathMLElement !== "undefined") {
-		Assert.ok(mi instanceof MathMLElement);
-	}
-	Assert.is(mi.tagName, "mi");
-	Assert.is(mi.namespaceURI, "http://www.w3.org/1998/Math/MathML");
-	Assert.is(mi.textContent, "x");
-});
-
-test("mixed content with foreignObject-like behavior", () => {
-	renderer.render(
-		<math xmlns="http://www.w3.org/1998/Math/MathML">
-			<mrow>
-				<mi>f</mi>
-				<mo>=</mo>
-				<semantics>
-					<mrow>
-						<mi>x</mi>
-						<mo>+</mo>
-						<mn>1</mn>
-					</mrow>
-					<annotation-xml encoding="MathML-Content">
-						{/* This would contain Content MathML */}
-						<apply xmlns="http://www.w3.org/1998/Math/MathML">
-							<plus />
-							<ci>x</ci>
-							<cn>1</cn>
-						</apply>
-					</annotation-xml>
-				</semantics>
-			</mrow>
-		</math>,
-		document.body,
-	);
-
-	const mathRoot = document.body.firstChild as Element;
-	Assert.ok(mathRoot instanceof Element);
-	if (typeof MathMLElement !== "undefined") {
-		Assert.ok(mathRoot instanceof MathMLElement);
-	}
-	Assert.is(mathRoot.namespaceURI, "http://www.w3.org/1998/Math/MathML");
-
-	// Check semantics element
-	const semantics = mathRoot.querySelector("semantics");
-	Assert.ok(semantics instanceof Element);
-	if (typeof MathMLElement !== "undefined") {
-		Assert.ok(semantics instanceof MathMLElement);
-	}
-	Assert.is(semantics.namespaceURI, "http://www.w3.org/1998/Math/MathML");
-
-	// Check annotation-xml element
-	const annotationXml = mathRoot.querySelector("annotation-xml");
-	Assert.ok(annotationXml instanceof Element);
-	if (typeof MathMLElement !== "undefined") {
-		Assert.ok(annotationXml instanceof MathMLElement);
-	}
-	Assert.is(annotationXml.namespaceURI, "http://www.w3.org/1998/Math/MathML");
-});
-
-test("attributes work correctly", () => {
-	renderer.render(
-		<math xmlns="http://www.w3.org/1998/Math/MathML">
-			<mfrac linethickness="2px">
-				<mi>a</mi>
-				<mi>b</mi>
-			</mfrac>
-		</math>,
-		document.body,
-	);
-
-	const mfrac = document.body.firstChild!.firstChild as Element;
-	Assert.ok(mfrac instanceof Element);
-	if (typeof MathMLElement !== "undefined") {
-		Assert.ok(mfrac instanceof MathMLElement);
-	}
-	Assert.is(mfrac.tagName, "mfrac");
-	Assert.is(mfrac.getAttribute("linethickness"), "2px");
-});
-
-test("class attribute (not className)", () => {
-	renderer.render(
-		<math xmlns="http://www.w3.org/1998/Math/MathML">
-			<mi class="variable">x</mi>
-			<mo class="operator">+</mo>
-			<mn class="number">1</mn>
-		</math>,
-		document.body,
-	);
-
-	const mi = document.body.firstChild!.childNodes[0] as Element;
-	const mo = document.body.firstChild!.childNodes[1] as Element;
-	const mn = document.body.firstChild!.childNodes[2] as Element;
-
-	Assert.ok(mi instanceof Element);
-	if (typeof MathMLElement !== "undefined") {
-		Assert.ok(mi instanceof MathMLElement);
-	}
-	Assert.is(mi.tagName, "mi");
-	Assert.is(mi.getAttribute("class"), "variable");
-
-	Assert.ok(mo instanceof Element);
-	if (typeof MathMLElement !== "undefined") {
-		Assert.ok(mo instanceof MathMLElement);
-	}
-	Assert.is(mo.tagName, "mo");
-	Assert.is(mo.getAttribute("class"), "operator");
-
-	Assert.ok(mn instanceof Element);
-	if (typeof MathMLElement !== "undefined") {
-		Assert.ok(mn instanceof MathMLElement);
-	}
-	Assert.is(mn.tagName, "mn");
-	Assert.is(mn.getAttribute("class"), "number");
-});
-
-test("non-string attribute values", () => {
-	renderer.render(
-		<math xmlns="http://www.w3.org/1998/Math/MathML">
-			<mspace width={10} height={20.5} depth={null} />
-		</math>,
-		document.body,
-	);
-
-	const mspace = document.body.firstChild!.firstChild as Element;
-	Assert.ok(mspace instanceof Element);
-	if (typeof MathMLElement !== "undefined") {
-		Assert.ok(mspace instanceof MathMLElement);
-	}
-	Assert.is(mspace.tagName, "mspace");
-	Assert.is(mspace.getAttribute("width"), "10");
-	Assert.is(mspace.getAttribute("height"), "20.5");
-	Assert.is(mspace.getAttribute("depth"), null);
-});
-
-test("custom attributes and data attributes", () => {
-	renderer.render(
-		<math xmlns="http://www.w3.org/1998/Math/MathML">
-			<mi data-variable="x" customAttr="value">
-				x
-			</mi>
-		</math>,
-		document.body,
-	);
-
-	const mi = document.body.firstChild!.firstChild as Element;
-	Assert.ok(mi instanceof Element);
-	if (typeof MathMLElement !== "undefined") {
-		Assert.ok(mi instanceof MathMLElement);
-	}
-	Assert.is(mi.getAttribute("data-variable"), "x");
-	Assert.is(mi.getAttribute("customAttr"), "value");
-	Assert.is(mi.textContent, "x");
-});
-
-test("nested math elements", () => {
-	renderer.render(
-		<div>
-			<p>The solution is:</p>
+	test("quadratic formula", () => {
+		renderer.render(
 			<math xmlns="http://www.w3.org/1998/Math/MathML">
 				<mrow>
 					<mi>x</mi>
 					<mo>=</mo>
-					<mn>42</mn>
+					<mfrac>
+						<mrow>
+							<mo>-</mo>
+							<mi>b</mi>
+							<mo>±</mo>
+							<msqrt>
+								<msup>
+									<mi>b</mi>
+									<mn>2</mn>
+								</msup>
+								<mo>-</mo>
+								<mn>4</mn>
+								<mi>a</mi>
+								<mi>c</mi>
+							</msqrt>
+						</mrow>
+						<mrow>
+							<mn>2</mn>
+							<mi>a</mi>
+						</mrow>
+					</mfrac>
 				</mrow>
-			</math>
-			<p>That's the answer!</p>
-		</div>,
-		document.body,
-	);
+			</math>,
+			document.body,
+		);
 
-	const div = document.body.firstChild as Element;
-	Assert.ok(div instanceof HTMLElement);
-	Assert.is(div.tagName, "DIV");
+		const mathRoot = document.body.firstChild as Element;
+		expect(mathRoot instanceof Element).toBeTruthy();
+		if (typeof MathMLElement !== "undefined") {
+			expect(mathRoot instanceof MathMLElement).toBeTruthy();
+		}
+		expect(mathRoot.tagName).toBe("math");
+		expect(mathRoot.namespaceURI).toBe("http://www.w3.org/1998/Math/MathML");
 
-	const mathElement = div.childNodes[1] as Element;
-	Assert.ok(mathElement instanceof Element);
-	if (typeof MathMLElement !== "undefined") {
-		Assert.ok(mathElement instanceof MathMLElement);
-	}
-	Assert.is(mathElement.tagName, "math");
-	Assert.is(mathElement.namespaceURI, "http://www.w3.org/1998/Math/MathML");
+		// Check that child elements are also in MathML namespace
+		const mrow = mathRoot.firstChild as Element;
+		expect(mrow instanceof Element).toBeTruthy();
+		if (typeof MathMLElement !== "undefined") {
+			expect(mrow instanceof MathMLElement).toBeTruthy();
+		}
+		expect(mrow.tagName).toBe("mrow");
+		expect(mrow.namespaceURI).toBe("http://www.w3.org/1998/Math/MathML");
 
-	const mrow = mathElement.firstChild as Element;
-	if (typeof MathMLElement !== "undefined") {
-		Assert.ok(mrow instanceof MathMLElement);
-	}
-	Assert.is(mrow.namespaceURI, "http://www.w3.org/1998/Math/MathML");
+		const mi = mrow.firstChild as Element;
+		expect(mi instanceof Element).toBeTruthy();
+		if (typeof MathMLElement !== "undefined") {
+			expect(mi instanceof MathMLElement).toBeTruthy();
+		}
+		expect(mi.tagName).toBe("mi");
+		expect(mi.namespaceURI).toBe("http://www.w3.org/1998/Math/MathML");
+		expect(mi.textContent).toBe("x");
+	});
+
+	test("mixed content with foreignObject-like behavior", () => {
+		renderer.render(
+			<math xmlns="http://www.w3.org/1998/Math/MathML">
+				<mrow>
+					<mi>f</mi>
+					<mo>=</mo>
+					<semantics>
+						<mrow>
+							<mi>x</mi>
+							<mo>+</mo>
+							<mn>1</mn>
+						</mrow>
+						<annotation-xml encoding="MathML-Content">
+							{/* This would contain Content MathML */}
+							<apply xmlns="http://www.w3.org/1998/Math/MathML">
+								<plus />
+								<ci>x</ci>
+								<cn>1</cn>
+							</apply>
+						</annotation-xml>
+					</semantics>
+				</mrow>
+			</math>,
+			document.body,
+		);
+
+		const mathRoot = document.body.firstChild as Element;
+		expect(mathRoot instanceof Element).toBeTruthy();
+		if (typeof MathMLElement !== "undefined") {
+			expect(mathRoot instanceof MathMLElement).toBeTruthy();
+		}
+		expect(mathRoot.namespaceURI).toBe("http://www.w3.org/1998/Math/MathML");
+
+		// Check semantics element
+		const semantics = mathRoot.querySelector("semantics");
+		expect(semantics instanceof Element).toBeTruthy();
+		if (typeof MathMLElement !== "undefined") {
+			expect(semantics instanceof MathMLElement).toBeTruthy();
+		}
+		expect(semantics!.namespaceURI).toBe("http://www.w3.org/1998/Math/MathML");
+
+		// Check annotation-xml element
+		const annotationXml = mathRoot.querySelector("annotation-xml");
+		expect(annotationXml instanceof Element).toBeTruthy();
+		if (typeof MathMLElement !== "undefined") {
+			expect(annotationXml instanceof MathMLElement).toBeTruthy();
+		}
+		expect(annotationXml!.namespaceURI).toBe(
+			"http://www.w3.org/1998/Math/MathML",
+		);
+	});
+
+	test("attributes work correctly", () => {
+		renderer.render(
+			<math xmlns="http://www.w3.org/1998/Math/MathML">
+				<mfrac linethickness="2px">
+					<mi>a</mi>
+					<mi>b</mi>
+				</mfrac>
+			</math>,
+			document.body,
+		);
+
+		const mfrac = document.body.firstChild!.firstChild as Element;
+		expect(mfrac instanceof Element).toBeTruthy();
+		if (typeof MathMLElement !== "undefined") {
+			expect(mfrac instanceof MathMLElement).toBeTruthy();
+		}
+		expect(mfrac.tagName).toBe("mfrac");
+		expect(mfrac.getAttribute("linethickness")).toBe("2px");
+	});
+
+	test("class attribute (not className)", () => {
+		renderer.render(
+			<math xmlns="http://www.w3.org/1998/Math/MathML">
+				<mi class="variable">x</mi>
+				<mo class="operator">+</mo>
+				<mn class="number">1</mn>
+			</math>,
+			document.body,
+		);
+
+		const mi = document.body.firstChild!.childNodes[0] as Element;
+		const mo = document.body.firstChild!.childNodes[1] as Element;
+		const mn = document.body.firstChild!.childNodes[2] as Element;
+
+		expect(mi instanceof Element).toBeTruthy();
+		if (typeof MathMLElement !== "undefined") {
+			expect(mi instanceof MathMLElement).toBeTruthy();
+		}
+		expect(mi.tagName).toBe("mi");
+		expect(mi.getAttribute("class")).toBe("variable");
+
+		expect(mo instanceof Element).toBeTruthy();
+		if (typeof MathMLElement !== "undefined") {
+			expect(mo instanceof MathMLElement).toBeTruthy();
+		}
+		expect(mo.tagName).toBe("mo");
+		expect(mo.getAttribute("class")).toBe("operator");
+
+		expect(mn instanceof Element).toBeTruthy();
+		if (typeof MathMLElement !== "undefined") {
+			expect(mn instanceof MathMLElement).toBeTruthy();
+		}
+		expect(mn.tagName).toBe("mn");
+		expect(mn.getAttribute("class")).toBe("number");
+	});
+
+	test("non-string attribute values", () => {
+		renderer.render(
+			<math xmlns="http://www.w3.org/1998/Math/MathML">
+				<mspace width={10} height={20.5} depth={null} />
+			</math>,
+			document.body,
+		);
+
+		const mspace = document.body.firstChild!.firstChild as Element;
+		expect(mspace instanceof Element).toBeTruthy();
+		if (typeof MathMLElement !== "undefined") {
+			expect(mspace instanceof MathMLElement).toBeTruthy();
+		}
+		expect(mspace.tagName).toBe("mspace");
+		expect(mspace.getAttribute("width")).toBe("10");
+		expect(mspace.getAttribute("height")).toBe("20.5");
+		expect(mspace.getAttribute("depth")).toBe(null);
+	});
+
+	test("custom attributes and data attributes", () => {
+		renderer.render(
+			<math xmlns="http://www.w3.org/1998/Math/MathML">
+				<mi data-variable="x" customAttr="value">
+					x
+				</mi>
+			</math>,
+			document.body,
+		);
+
+		const mi = document.body.firstChild!.firstChild as Element;
+		expect(mi instanceof Element).toBeTruthy();
+		if (typeof MathMLElement !== "undefined") {
+			expect(mi instanceof MathMLElement).toBeTruthy();
+		}
+		expect(mi.getAttribute("data-variable")).toBe("x");
+		expect(mi.getAttribute("customAttr")).toBe("value");
+		expect(mi.textContent).toBe("x");
+	});
+
+	test("nested math elements", () => {
+		renderer.render(
+			<div>
+				<p>The solution is:</p>
+				<math xmlns="http://www.w3.org/1998/Math/MathML">
+					<mrow>
+						<mi>x</mi>
+						<mo>=</mo>
+						<mn>42</mn>
+					</mrow>
+				</math>
+				<p>That's the answer!</p>
+			</div>,
+			document.body,
+		);
+
+		const div = document.body.firstChild as Element;
+		expect(div instanceof HTMLElement).toBeTruthy();
+		expect(div.tagName).toBe("DIV");
+
+		const mathElement = div.childNodes[1] as Element;
+		expect(mathElement instanceof Element).toBeTruthy();
+		if (typeof MathMLElement !== "undefined") {
+			expect(mathElement instanceof MathMLElement).toBeTruthy();
+		}
+		expect(mathElement.tagName).toBe("math");
+		expect(mathElement.namespaceURI).toBe("http://www.w3.org/1998/Math/MathML");
+
+		const mrow = mathElement.firstChild as Element;
+		if (typeof MathMLElement !== "undefined") {
+			expect(mrow instanceof MathMLElement).toBeTruthy();
+		}
+		expect(mrow.namespaceURI).toBe("http://www.w3.org/1998/Math/MathML");
+	});
 });
-
-test.run();

--- a/test/portals.tsx
+++ b/test/portals.tsx
@@ -1,157 +1,154 @@
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 /// <ref lib="dom" />
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
 import * as Sinon from "sinon";
 import {createElement, Portal} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("portal");
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+describe("portal", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test("portal", () => {
-	const el1 = document.createElement("div");
-	const el2 = document.createElement("div");
-	renderer.render(
-		<div>
-			Hello world
-			<Portal root={el1}>Hello from a portal</Portal>
+	test("portal", () => {
+		const el1 = document.createElement("div");
+		const el2 = document.createElement("div");
+		renderer.render(
+			<div>
+				Hello world
+				<Portal root={el1}>Hello from a portal</Portal>
+				<Portal root={el2}>
+					<div>Hello from another portal</div>
+				</Portal>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div>Hello world</div>");
+		expect(el1.innerHTML).toBe("Hello from a portal");
+		expect(el2.innerHTML).toBe("<div>Hello from another portal</div>");
+
+		renderer.render(null, document.body);
+		expect(document.body.innerHTML).toBe("");
+		expect(el1.innerHTML).toBe("");
+		expect(el2.innerHTML).toBe("");
+	});
+
+	test("portal at root", () => {
+		const div = document.createElement("div");
+		renderer.render(
+			<Portal root={div}>
+				<div>Hello world</div>
+			</Portal>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("");
+		expect(div.innerHTML).toBe("<div>Hello world</div>");
+		renderer.render(null, document.body);
+		expect(document.body.innerHTML).toBe("");
+		expect(div.innerHTML).toBe("");
+	});
+
+	test("changing root", () => {
+		const el1 = document.createElement("div");
+		const el2 = document.createElement("div");
+		renderer.render(
+			<Portal root={el1}>
+				<div>Hello world</div>
+			</Portal>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("");
+		expect(el1.innerHTML).toBe("<div>Hello world</div>");
+		renderer.render(
 			<Portal root={el2}>
-				<div>Hello from another portal</div>
-			</Portal>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div>Hello world</div>");
-	Assert.is(el1.innerHTML, "Hello from a portal");
-	Assert.is(el2.innerHTML, "<div>Hello from another portal</div>");
+				<div>Hello world</div>
+			</Portal>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("");
+		expect(el1.innerHTML).toBe("");
+		expect(el2.innerHTML).toBe("<div>Hello world</div>");
+	});
 
-	renderer.render(null, document.body);
-	Assert.is(document.body.innerHTML, "");
-	Assert.is(el1.innerHTML, "");
-	Assert.is(el2.innerHTML, "");
+	test("portal targeting iframe body", () => {
+		// Create an iframe to get a separate document
+		// This tests that ownerDocument is used correctly across different documents
+		const iframe = document.createElement("iframe");
+		document.body.appendChild(iframe);
+		const iframeDoc = iframe.contentDocument!;
+
+		renderer.render(
+			<Portal root={iframeDoc.body}>
+				<div>Hello from iframe</div>
+			</Portal>,
+			document.body,
+		);
+
+		expect(iframeDoc.body.innerHTML).toBe("<div>Hello from iframe</div>");
+
+		renderer.render(null, document.body);
+		expect(iframeDoc.body.innerHTML).toBe("");
+
+		document.body.removeChild(iframe);
+	});
+
+	test("portal with rendered page and hydrate", () => {
+		const onclick = Sinon.fake();
+		document.body.innerHTML = `<div id="portal"><button>Click</button></div>`;
+		const portal = document.getElementById("portal")!;
+		const button = portal.firstChild as HTMLButtonElement;
+		renderer.render(
+			<div>
+				Hello world
+				<Portal root={portal} hydrate={true}>
+					<button onclick={onclick}>Click</button>
+				</Portal>
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			`<div>Hello world</div><div id="portal"><button>Click</button></div>`,
+		);
+		expect(portal.firstChild).toBe(button);
+		expect(portal.innerHTML).toBe(`<button>Click</button>`);
+		button.click();
+		expect(onclick.callCount).toBe(1);
+	});
+
+	test("portal out of SVG resets scope to HTML", () => {
+		const htmlRoot = document.createElement("div");
+		renderer.render(
+			<svg viewBox="0 0 100 100">
+				<Portal root={htmlRoot}>
+					<div>
+						<span>Hello from HTML</span>
+					</div>
+				</Portal>
+			</svg>,
+			document.body,
+		);
+		// Children should be created as HTML elements, not SVG elements
+		const div = htmlRoot.firstChild as Element;
+		expect(div instanceof HTMLDivElement).toBeTruthy();
+		expect(div.namespaceURI).toBe("http://www.w3.org/1999/xhtml");
+	});
+
+	test("portal into SVG root creates SVG children", () => {
+		const svgRoot = document.createElementNS("http://www.w3.org/2000/svg", "g");
+		renderer.render(
+			<Portal root={svgRoot}>
+				<rect width="100" height="100" />
+			</Portal>,
+			document.body,
+		);
+		const rect = svgRoot.firstChild as Element;
+		expect(rect.namespaceURI).toBe("http://www.w3.org/2000/svg");
+		expect(rect instanceof SVGElement).toBeTruthy();
+	});
 });
-
-test("portal at root", () => {
-	const div = document.createElement("div");
-	renderer.render(
-		<Portal root={div}>
-			<div>Hello world</div>
-		</Portal>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "");
-	Assert.is(div.innerHTML, "<div>Hello world</div>");
-	renderer.render(null, document.body);
-	Assert.is(document.body.innerHTML, "");
-	Assert.is(div.innerHTML, "");
-});
-
-test("changing root", () => {
-	const el1 = document.createElement("div");
-	const el2 = document.createElement("div");
-	renderer.render(
-		<Portal root={el1}>
-			<div>Hello world</div>
-		</Portal>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "");
-	Assert.is(el1.innerHTML, "<div>Hello world</div>");
-	renderer.render(
-		<Portal root={el2}>
-			<div>Hello world</div>
-		</Portal>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "");
-	Assert.is(el1.innerHTML, "");
-	Assert.is(el2.innerHTML, "<div>Hello world</div>");
-});
-
-test("portal targeting iframe body", () => {
-	// Create an iframe to get a separate document
-	// This tests that ownerDocument is used correctly across different documents
-	const iframe = document.createElement("iframe");
-	document.body.appendChild(iframe);
-	const iframeDoc = iframe.contentDocument!;
-
-	renderer.render(
-		<Portal root={iframeDoc.body}>
-			<div>Hello from iframe</div>
-		</Portal>,
-		document.body,
-	);
-
-	Assert.is(iframeDoc.body.innerHTML, "<div>Hello from iframe</div>");
-
-	renderer.render(null, document.body);
-	Assert.is(iframeDoc.body.innerHTML, "");
-
-	document.body.removeChild(iframe);
-});
-
-test("portal with rendered page and hydrate", () => {
-	const onclick = Sinon.fake();
-	document.body.innerHTML = `<div id="portal"><button>Click</button></div>`;
-	const portal = document.getElementById("portal")!;
-	const button = portal.firstChild as HTMLButtonElement;
-	renderer.render(
-		<div>
-			Hello world
-			<Portal root={portal} hydrate={true}>
-				<button onclick={onclick}>Click</button>
-			</Portal>
-		</div>,
-		document.body,
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		`<div>Hello world</div><div id="portal"><button>Click</button></div>`,
-	);
-	Assert.is(portal.firstChild, button);
-	Assert.is(portal.innerHTML, `<button>Click</button>`);
-	button.click();
-	Assert.is(onclick.callCount, 1);
-});
-
-test("portal out of SVG resets scope to HTML", () => {
-	const htmlRoot = document.createElement("div");
-	renderer.render(
-		<svg viewBox="0 0 100 100">
-			<Portal root={htmlRoot}>
-				<div>
-					<span>Hello from HTML</span>
-				</div>
-			</Portal>
-		</svg>,
-		document.body,
-	);
-	// Children should be created as HTML elements, not SVG elements
-	const div = htmlRoot.firstChild as Element;
-	Assert.ok(div instanceof HTMLDivElement);
-	Assert.is(div.namespaceURI, "http://www.w3.org/1999/xhtml");
-});
-
-test("portal into SVG root creates SVG children", () => {
-	const svgRoot = document.createElementNS("http://www.w3.org/2000/svg", "g");
-	renderer.render(
-		<Portal root={svgRoot}>
-			<rect width="100" height="100" />
-		</Portal>,
-		document.body,
-	);
-	const rect = svgRoot.firstChild as Element;
-	Assert.is(rect.namespaceURI, "http://www.w3.org/2000/svg");
-	Assert.ok(rect instanceof SVGElement);
-});
-
-test.run();

--- a/test/provisions.tsx
+++ b/test/provisions.tsx
@@ -1,21 +1,9 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import * as Sinon from "sinon";
 
 import {createElement, Fragment} from "../src/crank.js";
 import type {Children, Context, Element} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
-
-const test = suite("provisions");
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
-
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
 
 // TODO: test typings
 declare module "../src/crank.js" {
@@ -24,123 +12,132 @@ declare module "../src/crank.js" {
 	}
 }
 
-function* Provider(
-	this: Context,
-	_props: {message?: string},
-): Generator<Element> {
-	let i = 1;
-	for (const {children, message = "Hello "} of this) {
-		this.provide("greeting", message + i++);
-		yield <Fragment>{children}</Fragment>;
+describe("provisions", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
+
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
+
+	function* Provider(
+		this: Context,
+		_props: {message?: string},
+	): Generator<Element> {
+		let i = 1;
+		for (const {children, message = "Hello "} of this) {
+			this.provide("greeting", message + i++);
+			yield <Fragment>{children}</Fragment>;
+		}
 	}
-}
 
-function Nested(
-	this: Context,
-	{depth, children}: {depth: number; children: Children},
-): Element {
-	if (depth <= 0) {
-		return <Fragment>{children}</Fragment>;
-	} else {
-		return <Nested depth={depth - 1}>{children}</Nested>;
+	function Nested(
+		this: Context,
+		{depth, children}: {depth: number; children: Children},
+	): Element {
+		if (depth <= 0) {
+			return <Fragment>{children}</Fragment>;
+		} else {
+			return <Nested depth={depth - 1}>{children}</Nested>;
+		}
 	}
-}
 
-function Consumer(this: Context): Element {
-	const greeting = this.consume("greeting");
-	return <div>{greeting}</div>;
-}
+	function Consumer(this: Context): Element {
+		const greeting = this.consume("greeting");
+		return <div>{greeting}</div>;
+	}
 
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test("basic", () => {
-	renderer.render(
-		<Provider>
-			<Consumer />
-		</Provider>,
-		document.body,
-	);
+	test("basic", () => {
+		renderer.render(
+			<Provider>
+				<Consumer />
+			</Provider>,
+			document.body,
+		);
 
-	Assert.is(document.body.innerHTML, "<div>Hello 1</div>");
-});
+		expect(document.body.innerHTML).toBe("<div>Hello 1</div>");
+	});
 
-test("nested", () => {
-	renderer.render(
-		<Provider>
+	test("nested", () => {
+		renderer.render(
+			<Provider>
+				<Nested depth={10}>
+					<Consumer />
+				</Nested>
+			</Provider>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div>Hello 1</div>");
+	});
+
+	test("missing provider", () => {
+		renderer.render(
 			<Nested depth={10}>
 				<Consumer />
-			</Nested>
-		</Provider>,
-		document.body,
-	);
+			</Nested>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div></div>");
+	});
 
-	Assert.is(document.body.innerHTML, "<div>Hello 1</div>");
+	test("update", () => {
+		const Consumer1 = Sinon.fake(Consumer);
+		renderer.render(
+			<Provider>
+				<Nested depth={10}>
+					<Consumer1 />
+				</Nested>
+			</Provider>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div>Hello 1</div>");
+		renderer.render(
+			<Provider>
+				<Nested depth={10}>
+					<Consumer1 />
+				</Nested>
+			</Provider>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div>Hello 2</div>");
+		renderer.render(
+			<Provider>
+				<Nested depth={10}>
+					<Consumer1 />
+				</Nested>
+			</Provider>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div>Hello 3</div>");
+		expect(Consumer1.callCount).toBe(3);
+	});
+
+	test("overwritten", () => {
+		renderer.render(
+			<Provider>
+				<div>
+					<Provider message="Goodbye ">
+						<Consumer />
+					</Provider>
+				</div>
+				<Consumer />
+			</Provider>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><div>Goodbye 1</div></div><div>Hello 1</div>",
+		);
+	});
 });
-
-test("missing provider", () => {
-	renderer.render(
-		<Nested depth={10}>
-			<Consumer />
-		</Nested>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div></div>");
-});
-
-test("update", () => {
-	const Consumer1 = Sinon.fake(Consumer);
-	renderer.render(
-		<Provider>
-			<Nested depth={10}>
-				<Consumer1 />
-			</Nested>
-		</Provider>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div>Hello 1</div>");
-	renderer.render(
-		<Provider>
-			<Nested depth={10}>
-				<Consumer1 />
-			</Nested>
-		</Provider>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div>Hello 2</div>");
-	renderer.render(
-		<Provider>
-			<Nested depth={10}>
-				<Consumer1 />
-			</Nested>
-		</Provider>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div>Hello 3</div>");
-	Assert.is(Consumer1.callCount, 3);
-});
-
-test("overwritten", () => {
-	renderer.render(
-		<Provider>
-			<div>
-				<Provider message="Goodbye ">
-					<Consumer />
-				</Provider>
-			</div>
-			<Consumer />
-		</Provider>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><div>Goodbye 1</div></div><div>Hello 1</div>",
-	);
-});
-
-test.run();

--- a/test/races.tsx
+++ b/test/races.tsx
@@ -1,425 +1,454 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import * as Sinon from "sinon";
 
 import {createElement, Child, Context, Element} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("races");
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+describe("races", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test("async fn vs value", async () => {
-	async function Component(): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 200));
-		return <div>Async</div>;
-	}
-
-	const p = renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "");
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	renderer.render("Async component blown away", document.body);
-	Assert.is(document.body.innerHTML, "Async component blown away");
-	await p;
-	Assert.is(document.body.innerHTML, "Async component blown away");
-	await new Promise((resolve) => setTimeout(resolve, 300));
-	Assert.is(document.body.innerHTML, "Async component blown away");
-});
-
-test("fast vs slow", async () => {
-	async function Fast(): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 100));
-		return <span>Fast</span>;
-	}
-
-	async function Slow(): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 200));
-		return <span>Slow</span>;
-	}
-
-	const p1 = renderer.render(
-		<div>
-			<Fast />
-		</div>,
-		document.body,
-	);
-	const p2 = renderer.render(
-		<div>
-			<Slow />
-		</div>,
-		document.body,
-	);
-
-	await p1;
-	Assert.is(document.body.innerHTML, "<div><span>Fast</span></div>");
-
-	await p2;
-	Assert.is(document.body.innerHTML, "<div><span>Slow</span></div>");
-
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(document.body.innerHTML, "<div><span>Slow</span></div>");
-});
-
-test("slow vs fast", async () => {
-	async function Slow(): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 200));
-		return <span>Slow</span>;
-	}
-
-	async function Fast(): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 100));
-		return <span>Fast</span>;
-	}
-
-	const p1 = renderer.render(
-		<div>
-			<Slow />
-		</div>,
-		document.body,
-	);
-
-	const p2 = renderer.render(
-		<div>
-			<Fast />
-		</div>,
-		document.body,
-	);
-
-	await p1;
-	Assert.is(document.body.innerHTML, "<div><span>Fast</span></div>");
-	await p2;
-	Assert.is(document.body.innerHTML, "<div><span>Fast</span></div>");
-
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(document.body.innerHTML, "<div><span>Fast</span></div>");
-});
-
-test("async component vs intrinsic", async () => {
-	async function Component(): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 200));
-		return <div>Async</div>;
-	}
-
-	const p = renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "");
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	renderer.render(<div>Async component blown away</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div>Async component blown away</div>");
-	await p;
-	Assert.is(document.body.innerHTML, "<div>Async component blown away</div>");
-	await new Promise((resolve) => setTimeout(resolve, 200));
-	Assert.is(document.body.innerHTML, "<div>Async component blown away</div>");
-});
-
-test("intrinsic vs async component", async () => {
-	async function Component(): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 200));
-		return <div>Async</div>;
-	}
-
-	renderer.render(<div>This should be blown away</div>, document.body);
-	const p = renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>This should be blown away</div>");
-	await p;
-	Assert.is(document.body.innerHTML, "<div>Async</div>");
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(document.body.innerHTML, "<div>Async</div>");
-});
-
-test("slow vs fast in async generator updated via renderer.render", async () => {
-	const slowFn = Sinon.fake();
-	async function Slow(): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 200));
-		slowFn();
-		return <div>Slow</div>;
-	}
-
-	const fastFn = Sinon.fake();
-	async function Fast(): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 100));
-		fastFn();
-		return <div>Fast</div>;
-	}
-
-	async function* Component(this: Context): AsyncGenerator<Child> {
-		let i = 0;
-		for await (const _ of this) {
-			if (i % 2 === 0) {
-				yield <Slow />;
-			} else {
-				yield <Fast />;
-			}
-
-			i++;
-		}
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Slow</div>");
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Fast</div>");
-	const p = Promise.resolve(renderer.render(<Component />, document.body));
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Fast</div>");
-	await p;
-	Assert.is(document.body.innerHTML, "<div>Fast</div>");
-	await new Promise((resolve) => setTimeout(resolve, 200));
-	Assert.is(document.body.innerHTML, "<div>Fast</div>");
-	Assert.is(slowFn.callCount, 2);
-	Assert.is(fastFn.callCount, 2);
-});
-
-test("slow vs fast in async generator updated via refresh", async () => {
-	async function Slow(): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 200));
-		return <div>Slow</div>;
-	}
-
-	async function Fast(): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 100));
-		return <div>Fast</div>;
-	}
-
-	let ctx!: Context;
-	async function* Component(this: Context): AsyncGenerator<Child> {
-		ctx = this;
-		let i = 0;
-		for await (const _ of this) {
-			if (i % 2 === 0) {
-				yield <Slow />;
-			} else {
-				yield <Fast />;
-			}
-
-			i++;
-		}
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Slow</div>");
-	await ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div>Fast</div>");
-	const p = ctx.refresh();
-	await ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div>Fast</div>");
-	await p;
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(document.body.innerHTML, "<div>Fast</div>");
-});
-
-test("fast async function vs slow async function in async generator", async () => {
-	async function Fast({i}: {i: number}): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 100));
-		return <span>Fast {i}</span>;
-	}
-
-	async function Slow({i}: {i: number}): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 200));
-		return <span>Slow {i}</span>;
-	}
-
-	async function* Component(this: Context): AsyncGenerator<Child, any, any> {
-		let i = 0;
-		for await (const _ of this) {
-			yield (
-				<div>
-					Hello: <Fast i={i} />
-				</div>
-			);
-			yield (
-				<div>
-					Hello: <Slow i={i} />
-				</div>
-			);
-			i++;
-		}
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello: <span>Fast 0</span></div>");
-	await new Promise((resolve) => setTimeout(resolve, 300));
-	Assert.is(document.body.innerHTML, "<div>Hello: <span>Slow 0</span></div>");
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello: <span>Fast 1</span></div>");
-	await new Promise((resolve) => setTimeout(resolve, 300));
-	Assert.is(document.body.innerHTML, "<div>Hello: <span>Slow 1</span></div>");
-	await new Promise((resolve) => setTimeout(resolve, 300));
-	Assert.is(document.body.innerHTML, "<div>Hello: <span>Slow 1</span></div>");
-});
-
-test("fast async function vs slow async generator in async generator", async () => {
-	async function Fast({i}: {i: number}): Promise<Child> {
-		await new Promise((resolve) => setTimeout(resolve, 100));
-		return <span>Fast {i}</span>;
-	}
-
-	const slowFn = Sinon.fake();
-	async function* Slow(this: Context, {i}: {i: number}): AsyncGenerator<Child> {
-		slowFn();
-		for await ({i} of this) {
+	test("async fn vs value", async () => {
+		async function Component(): Promise<Element> {
 			await new Promise((resolve) => setTimeout(resolve, 200));
-			yield <span>Slow {i}</span>;
+			return <div>Async</div>;
 		}
-	}
 
-	async function* Component(this: Context): AsyncGenerator<Child> {
-		let i = 0;
-		for await ({} of this) {
-			yield (
-				<div>
-					Hello: <Fast i={i} />
-				</div>
-			);
-			yield (
-				<div>
-					Hello: <Slow i={i} />
-				</div>
-			);
-			i++;
-		}
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello: <span>Fast 0</span></div>");
-	await new Promise((resolve) => setTimeout(resolve, 300));
-	Assert.is(document.body.innerHTML, "<div>Hello: <span>Slow 0</span></div>");
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello: <span>Fast 1</span></div>");
-	await new Promise((resolve) => setTimeout(resolve, 300));
-	Assert.is(document.body.innerHTML, "<div>Hello: <span>Slow 1</span></div>");
-	await new Promise((resolve) => setTimeout(resolve, 300));
-	Assert.is(document.body.innerHTML, "<div>Hello: <span>Slow 1</span></div>");
-	Assert.is(slowFn.callCount, 1);
-});
-
-test("fast async generator vs slow async function", async () => {
-	async function* Fast(this: Context): AsyncGenerator<Element> {
+		const p = renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("");
 		await new Promise((resolve) => setTimeout(resolve, 100));
-		for await (const _ of this) {
-			yield <span>Fast</span>;
+		renderer.render("Async component blown away", document.body);
+		expect(document.body.innerHTML).toBe("Async component blown away");
+		await p;
+		expect(document.body.innerHTML).toBe("Async component blown away");
+		await new Promise((resolve) => setTimeout(resolve, 300));
+		expect(document.body.innerHTML).toBe("Async component blown away");
+	});
+
+	test("fast vs slow", async () => {
+		async function Fast(): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			return <span>Fast</span>;
 		}
-	}
 
-	async function Slow(): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 200));
-		return <span>Slow</span>;
-	}
-
-	const p1 = renderer.render(<Fast />, document.body);
-	const p2 = renderer.render(<Slow />, document.body);
-	await p1;
-	Assert.is(document.body.innerHTML, "<span>Fast</span>");
-	await p2;
-	Assert.is(document.body.innerHTML, "<span>Slow</span>");
-	await new Promise((resolve) => setTimeout(resolve, 200));
-	Assert.is(document.body.innerHTML, "<span>Slow</span>");
-});
-
-test("slow async generator vs fast async function", async () => {
-	async function* Slow(this: Context): AsyncGenerator<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 200));
-		for await (const _ of this) {
-			yield <span>Slow</span>;
+		async function Slow(): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 200));
+			return <span>Slow</span>;
 		}
-	}
 
-	async function Fast(): Promise<Element> {
+		const p1 = renderer.render(
+			<div>
+				<Fast />
+			</div>,
+			document.body,
+		);
+		const p2 = renderer.render(
+			<div>
+				<Slow />
+			</div>,
+			document.body,
+		);
+
+		await p1;
+		expect(document.body.innerHTML).toBe("<div><span>Fast</span></div>");
+
+		await p2;
+		expect(document.body.innerHTML).toBe("<div><span>Slow</span></div>");
+
 		await new Promise((resolve) => setTimeout(resolve, 100));
-		return <span>Fast</span>;
-	}
+		expect(document.body.innerHTML).toBe("<div><span>Slow</span></div>");
+	});
 
-	const p1 = renderer.render(<Slow />, document.body);
-	const p2 = renderer.render(<Fast />, document.body);
-	await p1;
-	Assert.is(document.body.innerHTML, "<span>Fast</span>");
-	await p2;
-	Assert.is(document.body.innerHTML, "<span>Fast</span>");
-	await new Promise((resolve) => setTimeout(resolve, 200));
-	Assert.is(document.body.innerHTML, "<span>Fast</span>");
-});
-
-test("sync generator with slow children vs fast async function", async () => {
-	async function Slow(): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 200));
-		return <span>Slow</span>;
-	}
-
-	async function Fast(): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 100));
-		return <span>Fast</span>;
-	}
-
-	function* SlowGen(): Generator<Element> {
-		while (true) {
-			yield <Slow />;
+	test("slow vs fast", async () => {
+		async function Slow(): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 200));
+			return <span>Slow</span>;
 		}
-	}
 
-	const p1 = renderer.render(<SlowGen />, document.body);
-	const p2 = renderer.render(<Fast />, document.body);
-	await p1;
-	Assert.is(document.body.innerHTML, "<span>Fast</span>");
-	await p2;
-	Assert.is(document.body.innerHTML, "<span>Fast</span>");
-	await new Promise((resolve) => setTimeout(resolve, 200));
-	Assert.is(document.body.innerHTML, "<span>Fast</span>");
-});
-
-test("sync generator with fast children vs fast async function", async () => {
-	async function Slow(): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 200));
-		return <span>Slow</span>;
-	}
-
-	async function Fast(): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 100));
-		return <span>Fast</span>;
-	}
-
-	function* FastGen(): Generator<Element> {
-		while (true) {
-			yield <Fast />;
+		async function Fast(): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			return <span>Fast</span>;
 		}
-	}
 
-	const p1 = renderer.render(<FastGen />, document.body);
-	const p2 = renderer.render(<Slow />, document.body);
-	await p1;
-	Assert.is(document.body.innerHTML, "<span>Fast</span>");
-	await p2;
-	Assert.is(document.body.innerHTML, "<span>Slow</span>");
-	await new Promise((resolve) => setTimeout(resolve, 200));
-	Assert.is(document.body.innerHTML, "<span>Slow</span>");
-});
+		const p1 = renderer.render(
+			<div>
+				<Slow />
+			</div>,
+			document.body,
+		);
 
-test("slow async component vs intrinsic with fast async children", async () => {
-	async function Slow(): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 200));
-		return <span>Slow</span>;
-	}
+		const p2 = renderer.render(
+			<div>
+				<Fast />
+			</div>,
+			document.body,
+		);
 
-	async function Fast(): Promise<Element> {
+		await p1;
+		expect(document.body.innerHTML).toBe("<div><span>Fast</span></div>");
+		await p2;
+		expect(document.body.innerHTML).toBe("<div><span>Fast</span></div>");
+
 		await new Promise((resolve) => setTimeout(resolve, 100));
-		return <span>Fast</span>;
-	}
-	const p1 = renderer.render(<Fast />, document.body);
-	const p2 = renderer.render(
-		<div>
-			<Slow />
-		</div>,
-		document.body,
-	);
-	await p1;
-	Assert.is(document.body.innerHTML, "<span>Fast</span>");
-	await p2;
-	Assert.is(document.body.innerHTML, "<div><span>Slow</span></div>");
-});
+		expect(document.body.innerHTML).toBe("<div><span>Fast</span></div>");
+	});
 
-test.run();
+	test("async component vs intrinsic", async () => {
+		async function Component(): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 200));
+			return <div>Async</div>;
+		}
+
+		const p = renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("");
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		renderer.render(<div>Async component blown away</div>, document.body);
+		expect(document.body.innerHTML).toBe(
+			"<div>Async component blown away</div>",
+		);
+		await p;
+		expect(document.body.innerHTML).toBe(
+			"<div>Async component blown away</div>",
+		);
+		await new Promise((resolve) => setTimeout(resolve, 200));
+		expect(document.body.innerHTML).toBe(
+			"<div>Async component blown away</div>",
+		);
+	});
+
+	test("intrinsic vs async component", async () => {
+		async function Component(): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 200));
+			return <div>Async</div>;
+		}
+
+		renderer.render(<div>This should be blown away</div>, document.body);
+		const p = renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe(
+			"<div>This should be blown away</div>",
+		);
+		await p;
+		expect(document.body.innerHTML).toBe("<div>Async</div>");
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe("<div>Async</div>");
+	});
+
+	test("slow vs fast in async generator updated via renderer.render", async () => {
+		const slowFn = Sinon.fake();
+		async function Slow(): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 200));
+			slowFn();
+			return <div>Slow</div>;
+		}
+
+		const fastFn = Sinon.fake();
+		async function Fast(): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			fastFn();
+			return <div>Fast</div>;
+		}
+
+		async function* Component(this: Context): AsyncGenerator<Child> {
+			let i = 0;
+			for await (const _ of this) {
+				if (i % 2 === 0) {
+					yield <Slow />;
+				} else {
+					yield <Fast />;
+				}
+
+				i++;
+			}
+		}
+
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Slow</div>");
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Fast</div>");
+		const p = Promise.resolve(renderer.render(<Component />, document.body));
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Fast</div>");
+		await p;
+		expect(document.body.innerHTML).toBe("<div>Fast</div>");
+		await new Promise((resolve) => setTimeout(resolve, 200));
+		expect(document.body.innerHTML).toBe("<div>Fast</div>");
+		expect(slowFn.callCount).toBe(2);
+		expect(fastFn.callCount).toBe(2);
+	});
+
+	test("slow vs fast in async generator updated via refresh", async () => {
+		async function Slow(): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 200));
+			return <div>Slow</div>;
+		}
+
+		async function Fast(): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			return <div>Fast</div>;
+		}
+
+		let ctx!: Context;
+		async function* Component(this: Context): AsyncGenerator<Child> {
+			ctx = this;
+			let i = 0;
+			for await (const _ of this) {
+				if (i % 2 === 0) {
+					yield <Slow />;
+				} else {
+					yield <Fast />;
+				}
+
+				i++;
+			}
+		}
+
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Slow</div>");
+		await ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div>Fast</div>");
+		const p = ctx.refresh();
+		await ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div>Fast</div>");
+		await p;
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe("<div>Fast</div>");
+	});
+
+	test("fast async function vs slow async function in async generator", async () => {
+		async function Fast({i}: {i: number}): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			return <span>Fast {i}</span>;
+		}
+
+		async function Slow({i}: {i: number}): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 200));
+			return <span>Slow {i}</span>;
+		}
+
+		async function* Component(this: Context): AsyncGenerator<Child, any, any> {
+			let i = 0;
+			for await (const _ of this) {
+				yield (
+					<div>
+						Hello: <Fast i={i} />
+					</div>
+				);
+				yield (
+					<div>
+						Hello: <Slow i={i} />
+					</div>
+				);
+				i++;
+			}
+		}
+
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe(
+			"<div>Hello: <span>Fast 0</span></div>",
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+		expect(document.body.innerHTML).toBe(
+			"<div>Hello: <span>Slow 0</span></div>",
+		);
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe(
+			"<div>Hello: <span>Fast 1</span></div>",
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+		expect(document.body.innerHTML).toBe(
+			"<div>Hello: <span>Slow 1</span></div>",
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+		expect(document.body.innerHTML).toBe(
+			"<div>Hello: <span>Slow 1</span></div>",
+		);
+	});
+
+	test("fast async function vs slow async generator in async generator", async () => {
+		async function Fast({i}: {i: number}): Promise<Child> {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			return <span>Fast {i}</span>;
+		}
+
+		const slowFn = Sinon.fake();
+		async function* Slow(
+			this: Context,
+			{i}: {i: number},
+		): AsyncGenerator<Child> {
+			slowFn();
+			for await ({i} of this) {
+				await new Promise((resolve) => setTimeout(resolve, 200));
+				yield <span>Slow {i}</span>;
+			}
+		}
+
+		async function* Component(this: Context): AsyncGenerator<Child> {
+			let i = 0;
+			for await ({} of this) {
+				yield (
+					<div>
+						Hello: <Fast i={i} />
+					</div>
+				);
+				yield (
+					<div>
+						Hello: <Slow i={i} />
+					</div>
+				);
+				i++;
+			}
+		}
+
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe(
+			"<div>Hello: <span>Fast 0</span></div>",
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+		expect(document.body.innerHTML).toBe(
+			"<div>Hello: <span>Slow 0</span></div>",
+		);
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe(
+			"<div>Hello: <span>Fast 1</span></div>",
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+		expect(document.body.innerHTML).toBe(
+			"<div>Hello: <span>Slow 1</span></div>",
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+		expect(document.body.innerHTML).toBe(
+			"<div>Hello: <span>Slow 1</span></div>",
+		);
+		expect(slowFn.callCount).toBe(1);
+	});
+
+	test("fast async generator vs slow async function", async () => {
+		async function* Fast(this: Context): AsyncGenerator<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			for await (const _ of this) {
+				yield <span>Fast</span>;
+			}
+		}
+
+		async function Slow(): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 200));
+			return <span>Slow</span>;
+		}
+
+		const p1 = renderer.render(<Fast />, document.body);
+		const p2 = renderer.render(<Slow />, document.body);
+		await p1;
+		expect(document.body.innerHTML).toBe("<span>Fast</span>");
+		await p2;
+		expect(document.body.innerHTML).toBe("<span>Slow</span>");
+		await new Promise((resolve) => setTimeout(resolve, 200));
+		expect(document.body.innerHTML).toBe("<span>Slow</span>");
+	});
+
+	test("slow async generator vs fast async function", async () => {
+		async function* Slow(this: Context): AsyncGenerator<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 200));
+			for await (const _ of this) {
+				yield <span>Slow</span>;
+			}
+		}
+
+		async function Fast(): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			return <span>Fast</span>;
+		}
+
+		const p1 = renderer.render(<Slow />, document.body);
+		const p2 = renderer.render(<Fast />, document.body);
+		await p1;
+		expect(document.body.innerHTML).toBe("<span>Fast</span>");
+		await p2;
+		expect(document.body.innerHTML).toBe("<span>Fast</span>");
+		await new Promise((resolve) => setTimeout(resolve, 200));
+		expect(document.body.innerHTML).toBe("<span>Fast</span>");
+	});
+
+	test("sync generator with slow children vs fast async function", async () => {
+		async function Slow(): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 200));
+			return <span>Slow</span>;
+		}
+
+		async function Fast(): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			return <span>Fast</span>;
+		}
+
+		function* SlowGen(): Generator<Element> {
+			while (true) {
+				yield <Slow />;
+			}
+		}
+
+		const p1 = renderer.render(<SlowGen />, document.body);
+		const p2 = renderer.render(<Fast />, document.body);
+		await p1;
+		expect(document.body.innerHTML).toBe("<span>Fast</span>");
+		await p2;
+		expect(document.body.innerHTML).toBe("<span>Fast</span>");
+		await new Promise((resolve) => setTimeout(resolve, 200));
+		expect(document.body.innerHTML).toBe("<span>Fast</span>");
+	});
+
+	test("sync generator with fast children vs fast async function", async () => {
+		async function Slow(): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 200));
+			return <span>Slow</span>;
+		}
+
+		async function Fast(): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			return <span>Fast</span>;
+		}
+
+		function* FastGen(): Generator<Element> {
+			while (true) {
+				yield <Fast />;
+			}
+		}
+
+		const p1 = renderer.render(<FastGen />, document.body);
+		const p2 = renderer.render(<Slow />, document.body);
+		await p1;
+		expect(document.body.innerHTML).toBe("<span>Fast</span>");
+		await p2;
+		expect(document.body.innerHTML).toBe("<span>Slow</span>");
+		await new Promise((resolve) => setTimeout(resolve, 200));
+		expect(document.body.innerHTML).toBe("<span>Slow</span>");
+	});
+
+	test("slow async component vs intrinsic with fast async children", async () => {
+		async function Slow(): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 200));
+			return <span>Slow</span>;
+		}
+
+		async function Fast(): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			return <span>Fast</span>;
+		}
+		const p1 = renderer.render(<Fast />, document.body);
+		const p2 = renderer.render(
+			<div>
+				<Slow />
+			</div>,
+			document.body,
+		);
+		await p1;
+		expect(document.body.innerHTML).toBe("<span>Fast</span>");
+		await p2;
+		expect(document.body.innerHTML).toBe("<div><span>Slow</span></div>");
+	});
+});

--- a/test/rearranging.tsx
+++ b/test/rearranging.tsx
@@ -1,203 +1,200 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
-
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import {createElement, Context, Fragment} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("rearranging");
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+describe("rearranging", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-let headerCtx: Context | undefined;
-function* Header(this: Context) {
-	headerCtx = this;
-	let i = 0;
-	for (const _ of this) {
-		const Header = `h${(i % 6) + 1}`;
-		yield <Header>{i}</Header>;
-		i++;
-	}
-}
-
-let asyncHeaderCtx: Context | undefined;
-async function* AsyncHeader(this: Context) {
-	asyncHeaderCtx = this;
-	let i = 0;
-	for await (const _ of this) {
-		const Header = `h${(i % 6) + 1}`;
-		yield <Header>{i}</Header>;
-		i++;
-	}
-}
-
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-	headerCtx = undefined;
-	asyncHeaderCtx = undefined;
-});
-
-test("changing children", () => {
-	renderer.render(<Header />, document.body);
-	Assert.is(document.body.innerHTML, "<h1>0</h1>");
-	headerCtx!.refresh();
-	Assert.is(document.body.innerHTML, "<h2>1</h2>");
-	headerCtx!.refresh();
-	Assert.is(document.body.innerHTML, "<h3>2</h3>");
-});
-
-test("changing children nested in a fragment", () => {
-	renderer.render(
-		<Fragment>
-			<Header />
-		</Fragment>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<h1>0</h1>");
-	headerCtx!.refresh();
-	Assert.is(document.body.innerHTML, "<h2>1</h2>");
-	headerCtx!.refresh();
-	Assert.is(document.body.innerHTML, "<h3>2</h3>");
-});
-
-test("changing children nested in a function component", () => {
-	let ctx!: Context;
-	function Component(this: Context) {
-		ctx = this;
-		return <Header />;
-	}
-
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<h1>0</h1>");
-	headerCtx!.refresh();
-	Assert.is(document.body.innerHTML, "<h2>1</h2>");
-	headerCtx!.refresh();
-	Assert.is(document.body.innerHTML, "<h3>2</h3>");
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<h4>3</h4>");
-});
-
-test("changing children nested in a generator component", () => {
-	let ctx!: Context;
-	function* Component(this: Context) {
-		ctx = this;
-		while (true) {
-			yield (
-				<Fragment>
-					<Header />
-				</Fragment>
-			);
+	let headerCtx: Context | undefined;
+	function* Header(this: Context) {
+		headerCtx = this;
+		let i = 0;
+		for (const _ of this) {
+			const Header = `h${(i % 6) + 1}`;
+			yield <Header>{i}</Header>;
+			i++;
 		}
 	}
 
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<h1>0</h1>");
-	headerCtx!.refresh();
-	Assert.is(document.body.innerHTML, "<h2>1</h2>");
-	headerCtx!.refresh();
-	Assert.is(document.body.innerHTML, "<h3>2</h3>");
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<h4>3</h4>");
-});
-
-test("changing children nested in a fragment in a generator component", () => {
-	let ctx!: Context;
-	function* Component(this: Context) {
-		ctx = this;
-		while (true) {
-			yield <Header />;
-		}
-	}
-
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<h1>0</h1>");
-	headerCtx!.refresh();
-	Assert.is(document.body.innerHTML, "<h2>1</h2>");
-	headerCtx!.refresh();
-	Assert.is(document.body.innerHTML, "<h3>2</h3>");
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<h4>3</h4>");
-});
-
-test("changing children nested in an async component", async () => {
-	let ctx!: Context;
-	async function Component(this: Context) {
-		ctx = this;
-		return <Header />;
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<h1>0</h1>");
-	headerCtx!.refresh();
-	Assert.is(document.body.innerHTML, "<h2>1</h2>");
-	headerCtx!.refresh();
-	Assert.is(document.body.innerHTML, "<h3>2</h3>");
-	await ctx.refresh();
-	Assert.is(document.body.innerHTML, "<h4>3</h4>");
-});
-
-test("changing children nested in an async generator component", async () => {
-	let ctx!: Context;
-	async function* Component(this: Context) {
-		ctx = this;
+	let asyncHeaderCtx: Context | undefined;
+	async function* AsyncHeader(this: Context) {
+		asyncHeaderCtx = this;
+		let i = 0;
 		for await (const _ of this) {
-			yield <Header />;
+			const Header = `h${(i % 6) + 1}`;
+			yield <Header>{i}</Header>;
+			i++;
 		}
 	}
 
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<h1>0</h1>");
-	headerCtx!.refresh();
-	Assert.is(document.body.innerHTML, "<h2>1</h2>");
-	headerCtx!.refresh();
-	Assert.is(document.body.innerHTML, "<h3>2</h3>");
-	await ctx.refresh();
-	Assert.is(document.body.innerHTML, "<h4>3</h4>");
-});
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+		headerCtx = undefined;
+		asyncHeaderCtx = undefined;
+	});
 
-test("changing children with a sibling in a fragment", () => {
-	function Sibling() {
-		return <p>Sibling</p>;
-	}
-	renderer.render([<Header />, <Sibling />], document.body);
+	test("changing children", () => {
+		renderer.render(<Header />, document.body);
+		expect(document.body.innerHTML).toBe("<h1>0</h1>");
+		headerCtx!.refresh();
+		expect(document.body.innerHTML).toBe("<h2>1</h2>");
+		headerCtx!.refresh();
+		expect(document.body.innerHTML).toBe("<h3>2</h3>");
+	});
 
-	Assert.is(document.body.innerHTML, "<h1>0</h1><p>Sibling</p>");
+	test("changing children nested in a fragment", () => {
+		renderer.render(
+			<Fragment>
+				<Header />
+			</Fragment>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<h1>0</h1>");
+		headerCtx!.refresh();
+		expect(document.body.innerHTML).toBe("<h2>1</h2>");
+		headerCtx!.refresh();
+		expect(document.body.innerHTML).toBe("<h3>2</h3>");
+	});
 
-	headerCtx!.refresh();
-	Assert.is(document.body.innerHTML, "<h2>1</h2><p>Sibling</p>");
-});
-
-test("changing children nested in multiple components", () => {
-	function Nested(this: Context, {count}: {count: number}) {
-		if (count <= 0) {
+	test("changing children nested in a function component", () => {
+		let ctx!: Context;
+		function Component(this: Context) {
+			ctx = this;
 			return <Header />;
 		}
 
-		return <Nested count={count - 1} />;
-	}
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<h1>0</h1>");
+		headerCtx!.refresh();
+		expect(document.body.innerHTML).toBe("<h2>1</h2>");
+		headerCtx!.refresh();
+		expect(document.body.innerHTML).toBe("<h3>2</h3>");
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<h4>3</h4>");
+	});
 
-	renderer.render(<Nested count={100} />, document.body);
-	Assert.is(document.body.innerHTML, "<h1>0</h1>");
-	headerCtx!.refresh();
-	Assert.is(document.body.innerHTML, "<h2>1</h2>");
-	headerCtx!.refresh();
-	Assert.is(document.body.innerHTML, "<h3>2</h3>");
+	test("changing children nested in a generator component", () => {
+		let ctx!: Context;
+		function* Component(this: Context) {
+			ctx = this;
+			while (true) {
+				yield (
+					<Fragment>
+						<Header />
+					</Fragment>
+				);
+			}
+		}
+
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<h1>0</h1>");
+		headerCtx!.refresh();
+		expect(document.body.innerHTML).toBe("<h2>1</h2>");
+		headerCtx!.refresh();
+		expect(document.body.innerHTML).toBe("<h3>2</h3>");
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<h4>3</h4>");
+	});
+
+	test("changing children nested in a fragment in a generator component", () => {
+		let ctx!: Context;
+		function* Component(this: Context) {
+			ctx = this;
+			while (true) {
+				yield <Header />;
+			}
+		}
+
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<h1>0</h1>");
+		headerCtx!.refresh();
+		expect(document.body.innerHTML).toBe("<h2>1</h2>");
+		headerCtx!.refresh();
+		expect(document.body.innerHTML).toBe("<h3>2</h3>");
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<h4>3</h4>");
+	});
+
+	test("changing children nested in an async component", async () => {
+		let ctx!: Context;
+		async function Component(this: Context) {
+			ctx = this;
+			return <Header />;
+		}
+
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<h1>0</h1>");
+		headerCtx!.refresh();
+		expect(document.body.innerHTML).toBe("<h2>1</h2>");
+		headerCtx!.refresh();
+		expect(document.body.innerHTML).toBe("<h3>2</h3>");
+		await ctx.refresh();
+		expect(document.body.innerHTML).toBe("<h4>3</h4>");
+	});
+
+	test("changing children nested in an async generator component", async () => {
+		let ctx!: Context;
+		async function* Component(this: Context) {
+			ctx = this;
+			for await (const _ of this) {
+				yield <Header />;
+			}
+		}
+
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<h1>0</h1>");
+		headerCtx!.refresh();
+		expect(document.body.innerHTML).toBe("<h2>1</h2>");
+		headerCtx!.refresh();
+		expect(document.body.innerHTML).toBe("<h3>2</h3>");
+		await ctx.refresh();
+		expect(document.body.innerHTML).toBe("<h4>3</h4>");
+	});
+
+	test("changing children with a sibling in a fragment", () => {
+		function Sibling() {
+			return <p>Sibling</p>;
+		}
+		renderer.render([<Header />, <Sibling />], document.body);
+
+		expect(document.body.innerHTML).toBe("<h1>0</h1><p>Sibling</p>");
+
+		headerCtx!.refresh();
+		expect(document.body.innerHTML).toBe("<h2>1</h2><p>Sibling</p>");
+	});
+
+	test("changing children nested in multiple components", () => {
+		function Nested(this: Context, {count}: {count: number}) {
+			if (count <= 0) {
+				return <Header />;
+			}
+
+			return <Nested count={count - 1} />;
+		}
+
+		renderer.render(<Nested count={100} />, document.body);
+		expect(document.body.innerHTML).toBe("<h1>0</h1>");
+		headerCtx!.refresh();
+		expect(document.body.innerHTML).toBe("<h2>1</h2>");
+		headerCtx!.refresh();
+		expect(document.body.innerHTML).toBe("<h3>2</h3>");
+	});
+
+	test("changing async generator component children", async () => {
+		await renderer.render(<AsyncHeader />, document.body);
+		expect(document.body.innerHTML).toBe("<h1>0</h1>");
+		await asyncHeaderCtx!.refresh();
+		expect(document.body.innerHTML).toBe("<h2>1</h2>");
+		await asyncHeaderCtx!.refresh();
+		expect(document.body.innerHTML).toBe("<h3>2</h3>");
+	});
 });
-
-test("changing async generator component children", async () => {
-	await renderer.render(<AsyncHeader />, document.body);
-	Assert.is(document.body.innerHTML, "<h1>0</h1>");
-	await asyncHeaderCtx!.refresh();
-	Assert.is(document.body.innerHTML, "<h2>1</h2>");
-	await asyncHeaderCtx!.refresh();
-	Assert.is(document.body.innerHTML, "<h3>2</h3>");
-});
-
-test.run();

--- a/test/refs.tsx
+++ b/test/refs.tsx
@@ -1,205 +1,203 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import * as Sinon from "sinon";
-
-const test = suite("refs");
 
 import {Children, Context, createElement, Element, Raw} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
 
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+describe("refs", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test("basic", () => {
-	const fn = Sinon.fake();
-	renderer.render(<div ref={fn}>Hello</div>, document.body);
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-	Assert.is(document.body.innerHTML, "<div>Hello</div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild);
-});
+	test("basic", () => {
+		const fn = Sinon.fake();
+		renderer.render(<div ref={fn}>Hello</div>, document.body);
 
-test("runs once", () => {
-	const fn = Sinon.fake();
-	renderer.render(<div ref={fn}>Hello</div>, document.body);
-	renderer.render(<div ref={fn}>Hello</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello</div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild);
-});
+		expect(document.body.innerHTML).toBe("<div>Hello</div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild);
+	});
 
-test("child", () => {
-	const fn = Sinon.fake();
-	renderer.render(
-		<div>
-			<span ref={fn}>Hello</span>
-		</div>,
-		document.body,
-	);
+	test("runs once", () => {
+		const fn = Sinon.fake();
+		renderer.render(<div ref={fn}>Hello</div>, document.body);
+		renderer.render(<div ref={fn}>Hello</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello</div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild);
+	});
 
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-});
-
-test("Raw element", () => {
-	const fn = Sinon.fake();
-	renderer.render(
-		<Raw value="<div>Hello world</div>" ref={fn} />,
-		document.body,
-	);
-
-	Assert.is(fn.callCount, 1);
-
-	const refArgs = fn.lastCall.args;
-	Assert.is(refArgs.length, 1);
-	Assert.ok(refArgs[0] instanceof Node);
-});
-
-test("function component ref passing", () => {
-	const fn = Sinon.fake();
-	function Component({ref}: {ref: unknown}): Element {
-		return <span ref={ref}>Hello</span>;
-	}
-
-	renderer.render(
-		<div>
-			<Component ref={fn} />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-});
-
-test("generator component ref passing", () => {
-	const fn = Sinon.fake();
-	function* Component({ref}: {ref: unknown}): Generator<Element> {
-		while (true) {
-			yield <span ref={ref}>Hello</span>;
-		}
-	}
-
-	renderer.render(
-		<div>
-			<Component ref={fn} />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-});
-
-test("async function component ref passing", async () => {
-	const fn = Sinon.fake();
-	async function Component({ref}: {ref: unknown}): Promise<Element> {
-		return <span ref={ref}>Hello</span>;
-	}
-
-	await renderer.render(
-		<div>
-			<Component ref={fn} />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-});
-
-test("async generator component", async () => {
-	const fn = Sinon.fake();
-	async function* Component(
-		this: Context,
-		{ref}: {ref: unknown},
-	): AsyncGenerator<Element> {
-		for await ({ref} of this) {
-			yield <span ref={ref}>Hello</span>;
-		}
-	}
-
-	await renderer.render(
-		<div>
-			<Component ref={fn} />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-});
-
-test("transcluded in function component", async () => {
-	function Child({children}: {children: Children}): Children {
-		return children;
-	}
-
-	const fn = Sinon.fake();
-	function Parent(): Element {
-		return (
+	test("child", () => {
+		const fn = Sinon.fake();
+		renderer.render(
 			<div>
-				<Child>
-					<span ref={fn}>Hello</span>
-				</Child>
-			</div>
+				<span ref={fn}>Hello</span>
+			</div>,
+			document.body,
 		);
-	}
 
-	renderer.render(<Parent />, document.body);
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+	});
 
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-});
+	test("Raw element", () => {
+		const fn = Sinon.fake();
+		renderer.render(
+			<Raw value="<div>Hello world</div>" ref={fn} />,
+			document.body,
+		);
 
-test("transcluded in async function component", async () => {
-	async function Child({children}: {children: Children}): Promise<Children> {
-		await new Promise((resolve) => setTimeout(resolve, 1));
-		return children;
-	}
+		expect(fn.callCount).toBe(1);
 
-	const fn = Sinon.fake();
-	function Parent(): Element {
-		return (
+		const refArgs = fn.lastCall.args;
+		expect(refArgs.length).toBe(1);
+		expect(refArgs[0] instanceof Node).toBeTruthy();
+	});
+
+	test("function component ref passing", () => {
+		const fn = Sinon.fake();
+		function Component({ref}: {ref: unknown}): Element {
+			return <span ref={ref}>Hello</span>;
+		}
+
+		renderer.render(
 			<div>
-				<Child>
-					<span ref={fn}>Hello</span>
-				</Child>
-			</div>
+				<Component ref={fn} />
+			</div>,
+			document.body,
 		);
-	}
 
-	const p = renderer.render(<Parent />, document.body);
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+	});
 
-	Assert.is(fn.callCount, 0);
-	await p;
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
+	test("generator component ref passing", () => {
+		const fn = Sinon.fake();
+		function* Component({ref}: {ref: unknown}): Generator<Element> {
+			while (true) {
+				yield <span ref={ref}>Hello</span>;
+			}
+		}
+
+		renderer.render(
+			<div>
+				<Component ref={fn} />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+	});
+
+	test("async function component ref passing", async () => {
+		const fn = Sinon.fake();
+		async function Component({ref}: {ref: unknown}): Promise<Element> {
+			return <span ref={ref}>Hello</span>;
+		}
+
+		await renderer.render(
+			<div>
+				<Component ref={fn} />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+	});
+
+	test("async generator component", async () => {
+		const fn = Sinon.fake();
+		async function* Component(
+			this: Context,
+			{ref}: {ref: unknown},
+		): AsyncGenerator<Element> {
+			for await ({ref} of this) {
+				yield <span ref={ref}>Hello</span>;
+			}
+		}
+
+		await renderer.render(
+			<div>
+				<Component ref={fn} />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+	});
+
+	test("transcluded in function component", async () => {
+		function Child({children}: {children: Children}): Children {
+			return children;
+		}
+
+		const fn = Sinon.fake();
+		function Parent(): Element {
+			return (
+				<div>
+					<Child>
+						<span ref={fn}>Hello</span>
+					</Child>
+				</div>
+			);
+		}
+
+		renderer.render(<Parent />, document.body);
+
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+	});
+
+	test("transcluded in async function component", async () => {
+		async function Child({children}: {children: Children}): Promise<Children> {
+			await new Promise((resolve) => setTimeout(resolve, 1));
+			return children;
+		}
+
+		const fn = Sinon.fake();
+		function Parent(): Element {
+			return (
+				<div>
+					<Child>
+						<span ref={fn}>Hello</span>
+					</Child>
+				</div>
+			);
+		}
+
+		const p = renderer.render(<Parent />, document.body);
+
+		expect(fn.callCount).toBe(0);
+		await p;
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+	});
+
+	test("it works with hydrate", async () => {
+		const container = document.createElement("div");
+		container.innerHTML = "<div>Hello</div>";
+		const div = container.firstChild;
+		const fn = Sinon.fake();
+		const div1 = renderer.hydrate(<div ref={fn}>Hello</div>, container);
+		expect(container.innerHTML).toBe("<div>Hello</div>");
+		expect(div).toBe(div1);
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(div);
+	});
 });
-
-test("it works with hydrate", async () => {
-	const container = document.createElement("div");
-	container.innerHTML = "<div>Hello</div>";
-	const div = container.firstChild;
-	const fn = Sinon.fake();
-	const div1 = renderer.hydrate(<div ref={fn}>Hello</div>, container);
-	Assert.is(container.innerHTML, "<div>Hello</div>");
-	Assert.is(div, div1);
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], div);
-});
-
-test.run();

--- a/test/reuse.tsx
+++ b/test/reuse.tsx
@@ -1,111 +1,114 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import * as Sinon from "sinon";
 
 import {createElement} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("reuse");
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+describe("reuse", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test("reused intrinsic", () => {
-	const el = <span>1</span>;
-	renderer.render(
-		<div>
-			{el}
-			{el}
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>1</span><span>1</span></div>");
-});
-
-test("reused intrinsic with element in between", () => {
-	const el = <span>1</span>;
-	renderer.render(
-		<div>
-			{el}
-			<span>2</span>
-			{el}
-		</div>,
-		document.body,
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>1</span></div>",
-	);
-});
-
-test("reused function component", () => {
-	const fn = Sinon.fake();
-	function Component() {
-		fn();
-		return <span>1</span>;
-	}
-
-	const el = <Component />;
-	renderer.render(
-		<div>
-			{el}
-			{el}
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>1</span><span>1</span></div>");
-	Assert.is(fn.callCount, 2);
-});
-
-test("reused generator component", () => {
-	const fn = Sinon.fake();
-	function* Component() {
-		fn();
-		while (true) {
-			yield <span>1</span>;
-		}
-	}
-
-	const el = <Component />;
-	renderer.render(
-		<div>
-			{el}
-			{el}
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>1</span><span>1</span></div>");
-	Assert.is(fn.callCount, 2);
-});
-
-test("toggle reused element", () => {
-	function* Component() {
-		let toggle = true;
+	test("reused intrinsic", () => {
 		const el = <span>1</span>;
-		while (true) {
-			yield toggle ? el : <span>2</span>;
-			toggle = !toggle;
+		renderer.render(
+			<div>
+				{el}
+				{el}
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>1</span></div>",
+		);
+	});
+
+	test("reused intrinsic with element in between", () => {
+		const el = <span>1</span>;
+		renderer.render(
+			<div>
+				{el}
+				<span>2</span>
+				{el}
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>1</span></div>",
+		);
+	});
+
+	test("reused function component", () => {
+		const fn = Sinon.fake();
+		function Component() {
+			fn();
+			return <span>1</span>;
 		}
-	}
 
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<span>1</span>");
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<span>2</span>");
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<span>1</span>");
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<span>2</span>");
+		const el = <Component />;
+		renderer.render(
+			<div>
+				{el}
+				{el}
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>1</span></div>",
+		);
+		expect(fn.callCount).toBe(2);
+	});
+
+	test("reused generator component", () => {
+		const fn = Sinon.fake();
+		function* Component() {
+			fn();
+			while (true) {
+				yield <span>1</span>;
+			}
+		}
+
+		const el = <Component />;
+		renderer.render(
+			<div>
+				{el}
+				{el}
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>1</span></div>",
+		);
+		expect(fn.callCount).toBe(2);
+	});
+
+	test("toggle reused element", () => {
+		function* Component() {
+			let toggle = true;
+			const el = <span>1</span>;
+			while (true) {
+				yield toggle ? el : <span>2</span>;
+				toggle = !toggle;
+			}
+		}
+
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<span>1</span>");
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<span>2</span>");
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<span>1</span>");
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<span>2</span>");
+	});
 });
-
-test.run();

--- a/test/schedule.tsx
+++ b/test/schedule.tsx
@@ -1,5 +1,4 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import * as Sinon from "sinon";
 import {hangs} from "./utils.js";
 import {
@@ -12,1249 +11,1238 @@ import {
 } from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("schedule");
-interface ResolvingComponent {
-	(props?: Record<string, any>): any;
-	resolves: Array<Function>;
-}
-
-const AsyncComponent = async function ({
-	children,
-}: {
-	children: Children;
-}): Promise<Children> {
-	await new Promise((resolve) => AsyncComponent.resolves.push(resolve));
-	return children;
-} as ResolvingComponent;
-
-AsyncComponent.resolves = [];
-
-const AsyncMountingComponent = function* (
-	this: Context,
-	{children}: {children: Children},
-): Generator<Children> {
-	this.schedule(
-		() =>
-			new Promise((resolve) => AsyncMountingComponent.resolves.push(resolve)),
-	);
-	for ({children} of this) {
-		yield children;
+describe("schedule", () => {
+	interface ResolvingComponent {
+		(props?: Record<string, any>): any;
+		resolves: Array<Function>;
 	}
-} as unknown as ResolvingComponent;
-AsyncMountingComponent.resolves = [];
 
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+	const AsyncComponent = async function ({
+		children,
+	}: {
+		children: Children;
+	}): Promise<Children> {
+		await new Promise((resolve) => AsyncComponent.resolves.push(resolve));
+		return children;
+	} as ResolvingComponent;
 
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
 	AsyncComponent.resolves = [];
+
+	const AsyncMountingComponent = function* (
+		this: Context,
+		{children}: {children: Children},
+	): Generator<Children> {
+		this.schedule(
+			() =>
+				new Promise((resolve) => AsyncMountingComponent.resolves.push(resolve)),
+		);
+		for ({children} of this) {
+			yield children;
+		}
+	} as unknown as ResolvingComponent;
 	AsyncMountingComponent.resolves = [];
-});
 
-test("function once", () => {
-	let i = 0;
-	const fn = Sinon.fake();
-	function Component(this: Context): Element {
-		if (i === 0) {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
+
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+		AsyncComponent.resolves = [];
+		AsyncMountingComponent.resolves = [];
+	});
+
+	test("function once", () => {
+		let i = 0;
+		const fn = Sinon.fake();
+		function Component(this: Context): Element {
+			if (i === 0) {
+				this.schedule(fn);
+			}
+
+			return <span>{i++}</span>;
+		}
+
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+		expect(fn.callCount).toBe(1);
+
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+		expect(fn.callCount).toBe(1);
+	});
+
+	test("function every", () => {
+		let i = 0;
+		const fn = Sinon.fake();
+		function Component(this: Context): Element {
 			this.schedule(fn);
+			return <span>{i++}</span>;
 		}
 
-		return <span>{i++}</span>;
-	}
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+		expect(fn.callCount).toBe(1);
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-	Assert.is(fn.callCount, 1);
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+		expect(fn.callCount).toBe(2);
+	});
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-	Assert.is(fn.callCount, 1);
-});
-
-test("function every", () => {
-	let i = 0;
-	const fn = Sinon.fake();
-	function Component(this: Context): Element {
-		this.schedule(fn);
-		return <span>{i++}</span>;
-	}
-
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-	Assert.is(fn.callCount, 1);
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-	Assert.is(fn.callCount, 2);
-});
-
-test("generator once", () => {
-	const fn = Sinon.fake();
-	function* Component(this: Context): Generator<Element> {
-		this.schedule(fn);
-		let i = 0;
-		for ({} of this) {
-			yield <span>{i++}</span>;
-		}
-	}
-
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	Assert.is(fn.callCount, 1);
-
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	Assert.is(fn.callCount, 1);
-});
-
-test("generator every", () => {
-	const fn = Sinon.fake();
-	function* Component(this: Context): Generator<Element> {
-		let i = 0;
-		for ({} of this) {
+	test("generator once", () => {
+		const fn = Sinon.fake();
+		function* Component(this: Context): Generator<Element> {
 			this.schedule(fn);
-			yield <span>{i++}</span>;
+			let i = 0;
+			for ({} of this) {
+				yield <span>{i++}</span>;
+			}
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		expect(fn.callCount).toBe(1);
 
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-	Assert.is(fn.callCount, 1);
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		expect(fn.callCount).toBe(1);
+	});
 
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-	Assert.is(fn.callCount, 2);
-});
+	test("generator every", () => {
+		const fn = Sinon.fake();
+		function* Component(this: Context): Generator<Element> {
+			let i = 0;
+			for ({} of this) {
+				this.schedule(fn);
+				yield <span>{i++}</span>;
+			}
+		}
 
-test("async function once", async () => {
-	let i = 0;
-	const fn = Sinon.fake();
-	async function Component(this: Context): Promise<Element> {
-		if (i === 0) {
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+		expect(fn.callCount).toBe(1);
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+		expect(fn.callCount).toBe(2);
+	});
+
+	test("async function once", async () => {
+		let i = 0;
+		const fn = Sinon.fake();
+		async function Component(this: Context): Promise<Element> {
+			if (i === 0) {
+				this.schedule(fn);
+			}
+
+			await new Promise((resolve) => setTimeout(resolve, 1));
+			return <span>{i++}</span>;
+		}
+
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+		expect(fn.callCount).toBe(1);
+
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		expect(fn.callCount).toBe(1);
+	});
+
+	test("async function every", async () => {
+		let i = 0;
+		const fn = Sinon.fake();
+		async function Component(this: Context): Promise<Element> {
 			this.schedule(fn);
+			await new Promise((resolve) => setTimeout(resolve, 1));
+			return <span>{i++}</span>;
 		}
 
-		await new Promise((resolve) => setTimeout(resolve, 1));
-		return <span>{i++}</span>;
-	}
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+		expect(fn.callCount).toBe(1);
 
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-	Assert.is(fn.callCount, 1);
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		expect(fn.callCount).toBe(2);
+	});
 
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	Assert.is(fn.callCount, 1);
-});
-
-test("async function every", async () => {
-	let i = 0;
-	const fn = Sinon.fake();
-	async function Component(this: Context): Promise<Element> {
-		this.schedule(fn);
-		await new Promise((resolve) => setTimeout(resolve, 1));
-		return <span>{i++}</span>;
-	}
-
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-	Assert.is(fn.callCount, 1);
-
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	Assert.is(fn.callCount, 2);
-});
-
-test("async generator once", async () => {
-	const fn = Sinon.fake();
-	async function* Component(this: Context): AsyncGenerator<Element> {
-		this.schedule(fn);
-		let i = 0;
-		for await (const _ of this) {
-			yield <span>{i++}</span>;
-		}
-	}
-
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	Assert.is(fn.callCount, 1);
-
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	Assert.is(fn.callCount, 1);
-});
-
-test("async generator every", async () => {
-	const fn = Sinon.fake();
-	async function* Component(this: Context): AsyncGenerator<Element> {
-		let i = 0;
-		for await (const _ of this) {
+	test("async generator once", async () => {
+		const fn = Sinon.fake();
+		async function* Component(this: Context): AsyncGenerator<Element> {
 			this.schedule(fn);
-			yield <span>{i++}</span>;
+			let i = 0;
+			for await (const _ of this) {
+				yield <span>{i++}</span>;
+			}
 		}
-	}
 
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-	Assert.is(fn.callCount, 1);
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		expect(fn.callCount).toBe(1);
 
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-	Assert.is(fn.callCount, 2);
-});
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		expect(fn.callCount).toBe(1);
+	});
 
-test("multiple calls, same fn", () => {
-	const fn = Sinon.fake();
-	function* Component(this: Context): Generator<Element> {
-		this.schedule(fn);
-		this.schedule(fn);
-		for ({} of this) {
-			yield <span>Hello</span>;
+	test("async generator every", async () => {
+		const fn = Sinon.fake();
+		async function* Component(this: Context): AsyncGenerator<Element> {
+			let i = 0;
+			for await (const _ of this) {
+				this.schedule(fn);
+				yield <span>{i++}</span>;
+			}
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+		expect(fn.callCount).toBe(1);
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	const span = document.body.firstChild!.firstChild;
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], span);
-});
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+		expect(fn.callCount).toBe(2);
+	});
 
-test("multiple calls, different fns", () => {
-	const fn1 = Sinon.fake();
-	const fn2 = Sinon.fake();
-	function* Component(this: Context): Generator<Element> {
-		this.schedule(fn1);
-		this.schedule(fn2);
-		for ({} of this) {
-			yield <span>Hello</span>;
+	test("multiple calls, same fn", () => {
+		const fn = Sinon.fake();
+		function* Component(this: Context): Generator<Element> {
+			this.schedule(fn);
+			this.schedule(fn);
+			for ({} of this) {
+				yield <span>Hello</span>;
+			}
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	const span = document.body.firstChild!.firstChild;
-	Assert.is(fn1.callCount, 1);
-	Assert.is(fn1.lastCall.args[0], span);
-	Assert.is(fn2.callCount, 1);
-	Assert.is(fn2.lastCall.args[0], span);
-});
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		const span = document.body.firstChild!.firstChild;
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(span);
+	});
 
-test("multiple calls across updates", () => {
-	const fn1 = Sinon.fake();
-	const fn2 = Sinon.fake();
-	function* Component(this: Context): Generator<Element> {
-		let i = 0;
-		for ({} of this) {
+	test("multiple calls, different fns", () => {
+		const fn1 = Sinon.fake();
+		const fn2 = Sinon.fake();
+		function* Component(this: Context): Generator<Element> {
 			this.schedule(fn1);
 			this.schedule(fn2);
-			this.schedule(fn2);
-			yield <span>{i++}</span>;
-		}
-	}
-
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>0</span></div>");
-	const span = document.body.firstChild!.firstChild;
-
-	Assert.is(fn1.callCount, 1);
-	Assert.is(fn2.callCount, 1);
-	Assert.is(fn1.lastCall.args[0], span);
-	Assert.is(fn2.lastCall.args[0], span);
-
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	Assert.is(fn1.callCount, 2);
-	Assert.is(fn2.callCount, 2);
-	Assert.is(fn1.lastCall.args[0], span);
-	Assert.is(fn2.lastCall.args[0], span);
-
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>2</span></div>");
-	Assert.is(fn1.callCount, 3);
-	Assert.is(fn2.callCount, 3);
-	Assert.is(fn1.lastCall.args[0], span);
-	Assert.is(fn2.lastCall.args[0], span);
-});
-
-test("refresh", () => {
-	const mock = Sinon.fake();
-	function* Component(this: Context): Generator<Element> {
-		let i = 0;
-		for ({} of this) {
-			mock();
-			if (i % 2 === 0) {
-				this.schedule(() => this.refresh());
+			for ({} of this) {
+				yield <span>Hello</span>;
 			}
-			yield <span>{i++}</span>;
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>3</span></div>");
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>5</span></div>");
-	Assert.is(mock.callCount, 6);
-});
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-test("refresh copy", () => {
-	function* Component(this: Context): Generator<Element> {
-		this.schedule(() => this.refresh());
-		const span = (yield <span />) as HTMLSpanElement;
-		for ({} of this) {
-			span.className = "manual";
-			span.textContent = "Hello world";
-			yield <Copy />;
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		const span = document.body.firstChild!.firstChild;
+		expect(fn1.callCount).toBe(1);
+		expect(fn1.lastCall.args[0]).toBe(span);
+		expect(fn2.callCount).toBe(1);
+		expect(fn2.lastCall.args[0]).toBe(span);
+	});
+
+	test("multiple calls across updates", () => {
+		const fn1 = Sinon.fake();
+		const fn2 = Sinon.fake();
+		function* Component(this: Context): Generator<Element> {
+			let i = 0;
+			for ({} of this) {
+				this.schedule(fn1);
+				this.schedule(fn2);
+				this.schedule(fn2);
+				yield <span>{i++}</span>;
+			}
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		'<div><span class="manual">Hello world</span></div>',
-	);
-});
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-test("refresh copy alternating", () => {
-	function* Component(this: Context): Generator<Element> {
-		let i = 0;
-		let span: HTMLSpanElement | undefined;
-		for ({} of this) {
-			if (span === undefined) {
-				this.schedule(() => this.refresh());
-				span = (yield <span />) as HTMLSpanElement;
-			} else {
+		expect(document.body.innerHTML).toBe("<div><span>0</span></div>");
+		const span = document.body.firstChild!.firstChild;
+
+		expect(fn1.callCount).toBe(1);
+		expect(fn2.callCount).toBe(1);
+		expect(fn1.lastCall.args[0]).toBe(span);
+		expect(fn2.lastCall.args[0]).toBe(span);
+
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		expect(fn1.callCount).toBe(2);
+		expect(fn2.callCount).toBe(2);
+		expect(fn1.lastCall.args[0]).toBe(span);
+		expect(fn2.lastCall.args[0]).toBe(span);
+
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><span>2</span></div>");
+		expect(fn1.callCount).toBe(3);
+		expect(fn2.callCount).toBe(3);
+		expect(fn1.lastCall.args[0]).toBe(span);
+		expect(fn2.lastCall.args[0]).toBe(span);
+	});
+
+	test("refresh", () => {
+		const mock = Sinon.fake();
+		function* Component(this: Context): Generator<Element> {
+			let i = 0;
+			for ({} of this) {
+				mock();
+				if (i % 2 === 0) {
+					this.schedule(() => this.refresh());
+				}
+				yield <span>{i++}</span>;
+			}
+		}
+
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>3</span></div>");
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>5</span></div>");
+		expect(mock.callCount).toBe(6);
+	});
+
+	test("refresh copy", () => {
+		function* Component(this: Context): Generator<Element> {
+			this.schedule(() => this.refresh());
+			const span = (yield <span />) as HTMLSpanElement;
+			for ({} of this) {
 				span.className = "manual";
-				span.textContent = (i++).toString();
-				span = undefined;
+				span.textContent = "Hello world";
 				yield <Copy />;
 			}
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			'<div><span class="manual">Hello world</span></div>',
+		);
+	});
 
-	Assert.is(
-		document.body.innerHTML,
-		'<div><span class="manual">0</span></div>',
-	);
-});
-
-test("component child", () => {
-	const fn = Sinon.fake();
-	function Child(): Element {
-		return <span>Hello</span>;
-	}
-
-	function* Component(this: Context): Generator<Element> {
-		this.schedule(fn);
-		for ({} of this) {
-			yield <Child />;
+	test("refresh copy alternating", () => {
+		function* Component(this: Context): Generator<Element> {
+			let i = 0;
+			let span: HTMLSpanElement | undefined;
+			for ({} of this) {
+				if (span === undefined) {
+					this.schedule(() => this.refresh());
+					span = (yield <span />) as HTMLSpanElement;
+				} else {
+					span.className = "manual";
+					span.textContent = (i++).toString();
+					span = undefined;
+					yield <Copy />;
+				}
+			}
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
+		expect(document.body.innerHTML).toBe(
+			'<div><span class="manual">0</span></div>',
+		);
+	});
 
-	Assert.is(fn.callCount, 1);
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-});
+	test("component child", () => {
+		const fn = Sinon.fake();
+		function Child(): Element {
+			return <span>Hello</span>;
+		}
 
-test("fragment child", () => {
-	const fn = Sinon.fake();
-	function* Component(this: Context): Generator<Element> {
-		this.schedule(fn);
-		for ({} of this) {
-			yield (
+		function* Component(this: Context): Generator<Element> {
+			this.schedule(fn);
+			for ({} of this) {
+				yield <Child />;
+			}
+		}
+
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+	});
+
+	test("fragment child", () => {
+		const fn = Sinon.fake();
+		function* Component(this: Context): Generator<Element> {
+			this.schedule(fn);
+			for ({} of this) {
+				yield (
+					<Fragment>
+						<span>1</span>
+						<span>2</span>
+						<span>3</span>
+					</Fragment>
+				);
+			}
+		}
+
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span></div>",
+		);
+
+		expect(fn.callCount).toBe(1);
+		expect(fn.lastCall.args[0]).toEqual(
+			Array.from(document.body.firstChild!.childNodes),
+		);
+	});
+
+	test("async children once", async () => {
+		const fn = Sinon.fake();
+		async function Child({children}: {children: Children}): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+			return <span>{children}</span>;
+		}
+
+		function* Component(this: Context): Generator<Element> {
+			this.schedule(fn);
+			for ({} of this) {
+				yield <Child>async</Child>;
+			}
+		}
+
+		const p = renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(fn.callCount).toBe(0);
+		await p;
+		expect(document.body.innerHTML).toBe("<div><span>async</span></div>");
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+		expect(fn.callCount).toBe(1);
+	});
+
+	test("async children every", async () => {
+		const fn = Sinon.fake();
+		async function Child({children}: {children: Children}): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+			return <span>{children}</span>;
+		}
+
+		function* Component(this: Context): Generator<Element> {
+			let i = 0;
+			for ({} of this) {
+				this.schedule(fn);
+				yield <Child>async {i++}</Child>;
+			}
+		}
+
+		let p = renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(fn.callCount).toBe(0);
+		await p;
+		expect(document.body.innerHTML).toBe("<div><span>async 0</span></div>");
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+		expect(fn.callCount).toBe(1);
+		p = renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(fn.callCount).toBe(1);
+		await p;
+		expect(document.body.innerHTML).toBe("<div><span>async 1</span></div>");
+		expect(fn.lastCall.args[0]).toBe(document.body.firstChild!.firstChild);
+		expect(fn.callCount).toBe(2);
+	});
+
+	test("hanging child", async () => {
+		const fn = Sinon.fake();
+		async function Hanging(): Promise<never> {
+			await new Promise(() => {});
+			throw new Error("This should never be reached");
+		}
+
+		function* Component(this: Context): Generator<Element> {
+			this.schedule(fn);
+			for ({} of this) {
+				yield <Hanging />;
+			}
+		}
+
+		const p = renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+
+		await hangs(p);
+		expect(fn.callCount).toBe(0);
+		expect(document.body.innerHTML).toBe("");
+		renderer.render(<div />, document.body);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		expect(fn.callCount).toBe(0);
+		await p;
+		expect(fn.callCount).toBe(0);
+	});
+
+	// https://github.com/bikeshaving/crank/issues/199
+	test("refresh with component", () => {
+		function Component({children}: {children: Children}) {
+			return <p>{children}</p>;
+		}
+
+		function* Parent(this: Context) {
+			this.schedule(() => this.refresh());
+			yield <p>Render 1</p>;
+			yield <Component>Render 2</Component>;
+		}
+
+		renderer.render(<Parent />, document.body);
+		expect(document.body.innerHTML).toBe("<p>Render 2</p>");
+	});
+
+	test("refresh with async component", async () => {
+		async function Component({children}: {children: Children}) {
+			await new Promise((resolve) => setTimeout(resolve, 1));
+			return <p>{children}</p>;
+		}
+
+		function* Parent(this: Context) {
+			this.schedule(() => this.refresh());
+			yield <p>Render 1</p>;
+			yield <Component>Render 2</Component>;
+		}
+
+		const result = renderer.render(
+			<Parent />,
+			document.body,
+		) as Promise<HTMLElement>;
+
+		expect((await result).outerHTML).toBe("<p>Render 2</p>");
+		expect(document.body.innerHTML).toBe("<p>Render 2</p>");
+	});
+
+	test("async mount defers insertion", async () => {
+		const result = renderer.render(
+			<div>
+				<AsyncMountingComponent>
+					<span>Hello world</span>
+				</AsyncMountingComponent>
+			</div>,
+			document.body,
+		) as Promise<HTMLElement>;
+
+		expect(document.body.innerHTML).toBe("<div></div>");
+		AsyncMountingComponent.resolves[0]();
+		expect((await result).outerHTML).toBe(
+			"<div><span>Hello world</span></div>",
+		);
+	});
+
+	test("async mount with host fallback", async () => {
+		renderer.render(
+			<div>
+				<span>Hello world</span>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Hello world</span></div>");
+		const result = renderer.render(
+			<div>
+				<AsyncMountingComponent>
+					<span>Hello from component</span>
+				</AsyncMountingComponent>
+			</div>,
+			document.body,
+		) as Promise<HTMLElement>;
+
+		expect(document.body.innerHTML).toBe("<div><span>Hello world</span></div>");
+		AsyncMountingComponent.resolves[0]();
+		expect((await result).outerHTML).toBe(
+			"<div><span>Hello from component</span></div>",
+		);
+	});
+
+	// TODO: async updating
+	test("async schedule does not work after initial render", async () => {
+		let resolve!: Function;
+		function* Component(this: Context): Generator<Element> {
+			let i = 0;
+			for ({} of this) {
+				this.schedule(() => new Promise((r) => (resolve = r)));
+				yield <span key={i}>Render {i++}</span>;
+			}
+		}
+
+		const result1 = renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		await hangs(result1);
+		expect(document.body.innerHTML).toBe("<div></div>");
+
+		resolve();
+		await result1;
+		expect(document.body.innerHTML).toBe("<div><span>Render 0</span></div>");
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<div><span>Render 0</span></div>");
+
+		const result2 = renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		) as Promise<HTMLElement>;
+
+		expect((await result2).outerHTML).toBe("<div><span>Render 1</span></div>");
+		expect(document.body.innerHTML).toBe("<div><span>Render 1</span></div>");
+	});
+
+	test("async mount with refresh", async () => {
+		let resolve!: Function;
+		function* Component(this: Context): Generator<Element> {
+			let i = 0;
+			for ({} of this) {
+				this.schedule(async () => {
+					await new Promise((r) => (resolve = r));
+					this.refresh();
+				});
+				yield <span>Render {i++}</span>;
+			}
+		}
+
+		const result = renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		) as Promise<HTMLElement>;
+
+		expect(document.body.innerHTML).toBe("<div></div>");
+		expect(result).toBeInstanceOf(Promise);
+		resolve();
+		expect((await result).outerHTML).toBe("<div><span>Render 1</span></div>");
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<div><span>Render 1</span></div>");
+	});
+
+	test("async mounting with component fallback", async () => {
+		function Fallback(): Element {
+			return (
 				<Fragment>
-					<span>1</span>
-					<span>2</span>
-					<span>3</span>
+					<span>Loading...</span>
+					<button>Cancel</button>
 				</Fragment>
 			);
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span></div>",
-	);
-
-	Assert.is(fn.callCount, 1);
-	Assert.equal(
-		fn.lastCall.args[0],
-		Array.from(document.body.firstChild!.childNodes),
-	);
-});
-
-test("async children once", async () => {
-	const fn = Sinon.fake();
-	async function Child({children}: {children: Children}): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 5));
-		return <span>{children}</span>;
-	}
-
-	function* Component(this: Context): Generator<Element> {
-		this.schedule(fn);
-		for ({} of this) {
-			yield <Child>async</Child>;
-		}
-	}
-
-	const p = renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(fn.callCount, 0);
-	await p;
-	Assert.is(document.body.innerHTML, "<div><span>async</span></div>");
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-	Assert.is(fn.callCount, 1);
-});
-
-test("async children every", async () => {
-	const fn = Sinon.fake();
-	async function Child({children}: {children: Children}): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 5));
-		return <span>{children}</span>;
-	}
-
-	function* Component(this: Context): Generator<Element> {
-		let i = 0;
-		for ({} of this) {
-			this.schedule(fn);
-			yield <Child>async {i++}</Child>;
-		}
-	}
-
-	let p = renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(fn.callCount, 0);
-	await p;
-	Assert.is(document.body.innerHTML, "<div><span>async 0</span></div>");
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-	Assert.is(fn.callCount, 1);
-	p = renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(fn.callCount, 1);
-	await p;
-	Assert.is(document.body.innerHTML, "<div><span>async 1</span></div>");
-	Assert.is(fn.lastCall.args[0], document.body.firstChild!.firstChild);
-	Assert.is(fn.callCount, 2);
-});
-
-test("hanging child", async () => {
-	const fn = Sinon.fake();
-	async function Hanging(): Promise<never> {
-		await new Promise(() => {});
-		throw new Error("This should never be reached");
-	}
-
-	function* Component(this: Context): Generator<Element> {
-		this.schedule(fn);
-		for ({} of this) {
-			yield <Hanging />;
-		}
-	}
-
-	const p = renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	await hangs(p);
-	Assert.is(fn.callCount, 0);
-	Assert.is(document.body.innerHTML, "");
-	renderer.render(<div />, document.body);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	Assert.is(fn.callCount, 0);
-	await p;
-	Assert.is(fn.callCount, 0);
-});
-
-// https://github.com/bikeshaving/crank/issues/199
-test("refresh with component", () => {
-	function Component({children}: {children: Children}) {
-		return <p>{children}</p>;
-	}
-
-	function* Parent(this: Context) {
-		this.schedule(() => this.refresh());
-		yield <p>Render 1</p>;
-		yield <Component>Render 2</Component>;
-	}
-
-	renderer.render(<Parent />, document.body);
-	Assert.is(document.body.innerHTML, "<p>Render 2</p>");
-});
-
-test("refresh with async component", async () => {
-	async function Component({children}: {children: Children}) {
-		await new Promise((resolve) => setTimeout(resolve, 1));
-		return <p>{children}</p>;
-	}
-
-	function* Parent(this: Context) {
-		this.schedule(() => this.refresh());
-		yield <p>Render 1</p>;
-		yield <Component>Render 2</Component>;
-	}
-
-	const result = renderer.render(
-		<Parent />,
-		document.body,
-	) as Promise<HTMLElement>;
-
-	Assert.is((await result).outerHTML, "<p>Render 2</p>");
-	Assert.is(document.body.innerHTML, "<p>Render 2</p>");
-});
-
-test("async mount defers insertion", async () => {
-	const result = renderer.render(
-		<div>
-			<AsyncMountingComponent>
-				<span>Hello world</span>
-			</AsyncMountingComponent>
-		</div>,
-		document.body,
-	) as Promise<HTMLElement>;
-
-	Assert.is(document.body.innerHTML, "<div></div>");
-	AsyncMountingComponent.resolves[0]();
-	Assert.is((await result).outerHTML, "<div><span>Hello world</span></div>");
-});
-
-test("async mount with host fallback", async () => {
-	renderer.render(
-		<div>
-			<span>Hello world</span>
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Hello world</span></div>");
-	const result = renderer.render(
-		<div>
-			<AsyncMountingComponent>
-				<span>Hello from component</span>
-			</AsyncMountingComponent>
-		</div>,
-		document.body,
-	) as Promise<HTMLElement>;
-
-	Assert.is(document.body.innerHTML, "<div><span>Hello world</span></div>");
-	AsyncMountingComponent.resolves[0]();
-	Assert.is(
-		(await result).outerHTML,
-		"<div><span>Hello from component</span></div>",
-	);
-});
-
-// TODO: async updating
-test("async schedule does not work after initial render", async () => {
-	let resolve!: Function;
-	function* Component(this: Context): Generator<Element> {
-		let i = 0;
-		for ({} of this) {
-			this.schedule(() => new Promise((r) => (resolve = r)));
-			yield <span key={i}>Render {i++}</span>;
-		}
-	}
-
-	const result1 = renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	await hangs(result1);
-	Assert.is(document.body.innerHTML, "<div></div>");
-
-	resolve();
-	await result1;
-	Assert.is(document.body.innerHTML, "<div><span>Render 0</span></div>");
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<div><span>Render 0</span></div>");
-
-	const result2 = renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	) as Promise<HTMLElement>;
-
-	Assert.is((await result2).outerHTML, "<div><span>Render 1</span></div>");
-	Assert.is(document.body.innerHTML, "<div><span>Render 1</span></div>");
-});
-
-test("async mount with refresh", async () => {
-	let resolve!: Function;
-	function* Component(this: Context): Generator<Element> {
-		let i = 0;
-		for ({} of this) {
-			this.schedule(async () => {
-				await new Promise((r) => (resolve = r));
-				this.refresh();
-			});
-			yield <span>Render {i++}</span>;
-		}
-	}
-
-	const result = renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	) as Promise<HTMLElement>;
-
-	Assert.is(document.body.innerHTML, "<div></div>");
-	Assert.instance(result, Promise);
-	resolve();
-	Assert.is((await result).outerHTML, "<div><span>Render 1</span></div>");
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<div><span>Render 1</span></div>");
-});
-
-test("async mounting with component fallback", async () => {
-	function Fallback(): Element {
-		return (
-			<Fragment>
-				<span>Loading...</span>
-				<button>Cancel</button>
-			</Fragment>
-		);
-	}
-
-	// Initial render with fallback
-	renderer.render(
-		<div>
-			<Fallback />
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Loading...</span><button>Cancel</button></div>",
-	);
-
-	// Replace with async component - should show fallback while scheduling
-	const result2 = renderer.render(
-		<div>
-			<AsyncMountingComponent>
-				<span>Loaded content</span>
-			</AsyncMountingComponent>
-		</div>,
-		document.body,
-	) as Promise<HTMLElement>;
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Loading...</span><button>Cancel</button></div>",
-	);
-
-	AsyncMountingComponent.resolves[0]();
-	Assert.is(
-		(await result2).outerHTML,
-		"<div><span>Loaded content</span></div>",
-	);
-});
-
-test("async mount replacing async mount component fallback", async () => {
-	function SchedulingComponent1(
-		this: Context,
-		...args: any
-	): Generator<Children> {
-		return AsyncMountingComponent.apply(this, args) as any;
-	}
-
-	function SchedulingComponent2(
-		this: Context,
-		...args: any
-	): Generator<Children> {
-		return AsyncMountingComponent.apply(this, args);
-	}
-
-	const result1 = renderer.render(
-		<div>
-			<SchedulingComponent1>
-				<span>Component 1</span>
-			</SchedulingComponent1>
-		</div>,
-		document.body,
-	) as Promise<HTMLElement>;
-	Assert.is(document.body.innerHTML, "<div></div>");
-	await hangs(result1);
-	// Replace with second scheduling component before first resolves
-	const result2 = renderer.render(
-		<div>
-			<SchedulingComponent2>
-				<span>Component 2</span>
-			</SchedulingComponent2>
-		</div>,
-		document.body,
-	) as Promise<HTMLElement>;
-	Assert.is(document.body.innerHTML, "<div></div>");
-	await hangs(result2);
-
-	// Resolve second component (should render)
-	AsyncMountingComponent.resolves[1]();
-	// result1 should resolve once SchedulingComponent2 resolves (because
-	// component was unmounted)
-	Assert.is((await result1).outerHTML, "<div><span>Component 2</span></div>");
-	Assert.is((await result2).outerHTML, "<div><span>Component 2</span></div>");
-});
-
-test("async mount inside async component", async () => {
-	let scheduleResolve!: Function;
-
-	async function AsyncComponent(this: Context): Promise<Element> {
-		this.schedule(() => new Promise((r) => (scheduleResolve = r)));
-		await new Promise((resolve) => setTimeout(resolve, 1));
-		return <span>Async Function Component</span>;
-	}
-
-	const renderPromise = renderer.render(
-		<div>
-			<AsyncComponent />
-		</div>,
-		document.body,
-	);
-
-	// Should be completely empty while async function is pending
-	Assert.is(document.body.innerHTML, "");
-
-	// Schedule resolves, component should appear
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(document.body.innerHTML, "<div></div>");
-	await hangs(renderPromise);
-	Assert.is(document.body.innerHTML, "<div></div>");
-
-	scheduleResolve();
-	Assert.is(document.body.innerHTML, "<div></div>");
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Async Function Component</span></div>",
-	);
-
-	await renderPromise;
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Async Function Component</span></div>",
-	);
-});
-
-test("async mount replacing async component fallback that has already resolved", async () => {
-	const result1 = renderer.render(
-		<div>
-			<AsyncComponent>
-				<span>Async Component</span>
-			</AsyncComponent>
-		</div>,
-		document.body,
-	);
-
-	Assert.instance(result1, Promise);
-	Assert.is(document.body.innerHTML, "");
-	AsyncComponent.resolves[0]();
-	await result1;
-	Assert.is(document.body.innerHTML, "<div><span>Async Component</span></div>");
-
-	const result2 = renderer.render(
-		<div>
-			<AsyncMountingComponent>
-				<span>Scheduling Component</span>
-			</AsyncMountingComponent>
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>Async Component</span></div>");
-	Assert.instance(result2, Promise);
-
-	await hangs(result2);
-	Assert.is(document.body.innerHTML, "<div><span>Async Component</span></div>");
-
-	AsyncMountingComponent.resolves[0]();
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Scheduling Component</span></div>",
-	);
-});
-
-test("async mount replacing async component fallback that is pending and resolves", async () => {
-	const result1 = renderer.render(
-		<div>
-			<AsyncComponent>
-				<span>Async Component</span>
-			</AsyncComponent>
-		</div>,
-		document.body,
-	) as unknown as Promise<HTMLElement>;
-
-	Assert.instance(result1, Promise);
-	Assert.is(document.body.innerHTML, "");
-	const result2 = renderer.render(
-		<div>
-			<AsyncMountingComponent>
-				<span>Scheduling Component</span>
-			</AsyncMountingComponent>
-		</div>,
-		document.body,
-	) as unknown as Promise<HTMLElement>;
-
-	Assert.is(document.body.innerHTML, "<div></div>");
-	Assert.instance(result2, Promise);
-	AsyncComponent.resolves[0]();
-	Assert.is(
-		(await result1).outerHTML,
-		"<div><span>Async Component</span></div>",
-	);
-	await hangs(result2);
-	Assert.is(document.body.innerHTML, "<div><span>Async Component</span></div>");
-
-	AsyncMountingComponent.resolves[0]();
-	await new Promise((resolve) => setTimeout(resolve));
-
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Scheduling Component</span></div>",
-	);
-
-	Assert.is(await result2, document.body.firstChild);
-});
-
-test("async mount replacing async component fallback that is pending and doesn't resolve", async () => {
-	// Use AsyncComponent that never resolves by not calling its resolve
-	const result1 = renderer.render(
-		<div>
-			<AsyncComponent>
-				<span>Async Component</span>
-			</AsyncComponent>
-		</div>,
-		document.body,
-	) as unknown as Promise<HTMLElement>;
-
-	Assert.instance(result1, Promise);
-	Assert.is(document.body.innerHTML, "");
-	const result2 = renderer.render(
-		<div>
-			<AsyncMountingComponent>
-				<span>Scheduling Component</span>
-			</AsyncMountingComponent>
-		</div>,
-		document.body,
-	) as unknown as Promise<HTMLElement>;
-
-	Assert.is(document.body.innerHTML, "<div></div>");
-	Assert.instance(result2, Promise);
-	await hangs(result1);
-	await hangs(result2);
-	Assert.is(document.body.innerHTML, "<div></div>");
-
-	AsyncMountingComponent.resolves[0]();
-	Assert.is(
-		(await result2).outerHTML,
-		"<div><span>Scheduling Component</span></div>",
-	);
-
-	Assert.is(
-		(await result1).outerHTML,
-		"<div><span>Scheduling Component</span></div>",
-	);
-
-	Assert.is(await result1, document.body.firstChild);
-	Assert.is(await result2, document.body.firstChild);
-});
-
-test("async mount replacing async tree", async () => {
-	const result1 = renderer.render(
-		<div>
-			<span>
-				<AsyncComponent>Async Component</AsyncComponent>
-			</span>
-		</div>,
-		document.body,
-	) as Promise<HTMLElement>;
-
-	Assert.instance(result1, Promise);
-	Assert.is(document.body.innerHTML, "");
-	const result2 = renderer.render(
-		<div>
-			<AsyncMountingComponent>
-				<span>Scheduling Component</span>
-			</AsyncMountingComponent>
-		</div>,
-		document.body,
-	) as Promise<HTMLElement>;
-
-	Assert.is(document.body.innerHTML, "<div></div>");
-	Assert.instance(result2, Promise);
-	AsyncComponent.resolves[0]();
-	Assert.is(
-		(await result1).outerHTML,
-		"<div><span>Async Component</span></div>",
-	);
-	AsyncMountingComponent.resolves[0]();
-	Assert.is(
-		(await result2).outerHTML,
-		"<div><span>Scheduling Component</span></div>",
-	);
-});
-
-test("async mount replacing multiple async fallbacks", async () => {
-	const result1 = renderer.render(
-		<div>
-			<span>
-				<AsyncComponent>Render 1</AsyncComponent>
-			</span>
-		</div>,
-		document.body,
-	) as Promise<HTMLElement>;
-
-	const result2 = renderer.render(
-		<div>
-			<AsyncComponent>
-				<span>Render 2</span>
-			</AsyncComponent>
-		</div>,
-		document.body,
-	) as Promise<HTMLElement>;
-
-	const result3 = renderer.render(
-		<div>
-			<Fragment>
-				<span>
-					<AsyncComponent>Render 3</AsyncComponent>
-				</span>
-			</Fragment>
-		</div>,
-		document.body,
-	) as Promise<HTMLElement>;
-
-	const result4 = renderer.render(
-		<div>
-			<AsyncMountingComponent>
-				<span>Scheduling Component</span>
-			</AsyncMountingComponent>
-		</div>,
-		document.body,
-	) as Promise<HTMLElement>;
-
-	Assert.instance(result1, Promise);
-	Assert.instance(result2, Promise);
-	Assert.instance(result3, Promise);
-	Assert.instance(result4, Promise);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	Assert.is(AsyncComponent.resolves.length, 3);
-	AsyncComponent.resolves[1]();
-	Assert.is((await result1).outerHTML, "<div><span>Render 2</span></div>");
-	Assert.is((await result2).outerHTML, "<div><span>Render 2</span></div>");
-	await hangs(result3);
-	Assert.is(document.body.innerHTML, "<div><span>Render 2</span></div>");
-	AsyncMountingComponent.resolves[0]();
-	Assert.is(
-		(await result3).outerHTML,
-		"<div><span>Scheduling Component</span></div>",
-	);
-	Assert.is(
-		(await result4).outerHTML,
-		"<div><span>Scheduling Component</span></div>",
-	);
-});
-
-test("async mount replacing stateful component", async () => {
-	let statefulCtx: Context;
-	function* StatefulComponent(this: Context): Generator<Element> {
-		statefulCtx = this;
-		let i = 0;
-		for ({} of this) {
-			yield <span>Stateful {i++}</span>;
-		}
-	}
-
-	// Initial render with stateful component
-	renderer.render(
-		<div>
+		// Initial render with fallback
+		renderer.render(
 			<div>
-				<StatefulComponent />
-			</div>
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><div><span>Stateful 0</span></div></div>",
-	);
+				<Fallback />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Loading...</span><button>Cancel</button></div>",
+		);
 
-	// Replace with async component - should show nothing while scheduling
-	const result2 = renderer.render(
-		<div>
-			<AsyncMountingComponent>
-				<span>Scheduling Component</span>
-			</AsyncMountingComponent>
-		</div>,
-		document.body,
-	) as Promise<HTMLElement>;
-	Assert.is(
-		document.body.innerHTML,
-		"<div><div><span>Stateful 0</span></div></div>",
-	);
-	await hangs(result2);
-	statefulCtx!.refresh();
-	Assert.is(
-		document.body.innerHTML,
-		"<div><div><span>Stateful 1</span></div></div>",
-	);
-	statefulCtx!.refresh();
-	Assert.is(
-		document.body.innerHTML,
-		"<div><div><span>Stateful 2</span></div></div>",
-	);
+		// Replace with async component - should show fallback while scheduling
+		const result2 = renderer.render(
+			<div>
+				<AsyncMountingComponent>
+					<span>Loaded content</span>
+				</AsyncMountingComponent>
+			</div>,
+			document.body,
+		) as Promise<HTMLElement>;
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Loading...</span><button>Cancel</button></div>",
+		);
 
-	AsyncMountingComponent.resolves[0]();
-	Assert.is(
-		(await result2).outerHTML,
-		"<div><span>Scheduling Component</span></div>",
-	);
-});
+		AsyncMountingComponent.resolves[0]();
+		expect((await result2).outerHTML).toBe(
+			"<div><span>Loaded content</span></div>",
+		);
+	});
 
-test("hanging schedule causes commits to queue", async () => {
-	// Initial render with hanging schedule - defers mounting
-	const result1 = renderer.render(
-		<div>
-			<AsyncMountingComponent>
-				<span>First</span>
-			</AsyncMountingComponent>
-		</div>,
-		document.body,
-	) as Promise<HTMLElement>;
+	test("async mount replacing async mount component fallback", async () => {
+		function SchedulingComponent1(
+			this: Context,
+			...args: any
+		): Generator<Children> {
+			return AsyncMountingComponent.apply(this, args) as any;
+		}
 
-	Assert.instance(result1, Promise);
-	Assert.is(document.body.innerHTML, "<div></div>"); // Should be empty while scheduling
-	await hangs(result1); // Confirm it's hanging
+		function SchedulingComponent2(
+			this: Context,
+			...args: any
+		): Generator<Children> {
+			return AsyncMountingComponent.apply(this, args);
+		}
 
-	// Second render - completes synchronously (non-initial render ignores schedule)
-	const result2 = renderer.render(
-		<div>
-			<AsyncMountingComponent>
-				<span>Second</span>
-			</AsyncMountingComponent>
-		</div>,
-		document.body,
-	) as Promise<HTMLElement>;
+		const result1 = renderer.render(
+			<div>
+				<SchedulingComponent1>
+					<span>Component 1</span>
+				</SchedulingComponent1>
+			</div>,
+			document.body,
+		) as Promise<HTMLElement>;
+		expect(document.body.innerHTML).toBe("<div></div>");
+		await hangs(result1);
+		// Replace with second scheduling component before first resolves
+		const result2 = renderer.render(
+			<div>
+				<SchedulingComponent2>
+					<span>Component 2</span>
+				</SchedulingComponent2>
+			</div>,
+			document.body,
+		) as Promise<HTMLElement>;
+		expect(document.body.innerHTML).toBe("<div></div>");
+		await hangs(result2);
 
-	// Should complete synchronously, not return a promise
-	Assert.instance(result2, Promise);
-	await hangs(result2);
-	Assert.is(document.body.innerHTML, "<div></div>"); // Should still be empty
-	AsyncMountingComponent.resolves[0](); // Resolve the initial hanging schedule
+		// Resolve second component (should render)
+		AsyncMountingComponent.resolves[1]();
+		// result1 should resolve once SchedulingComponent2 resolves (because
+		// component was unmounted)
+		expect((await result1).outerHTML).toBe(
+			"<div><span>Component 2</span></div>",
+		);
+		expect((await result2).outerHTML).toBe(
+			"<div><span>Component 2</span></div>",
+		);
+	});
 
-	Assert.is((await result1).outerHTML, "<div><span>First</span></div>"); // Should render first component
-	Assert.is((await result2).outerHTML, "<div><span>Second</span></div>"); // Should render second component
-});
+	test("async mount inside async component", async () => {
+		let scheduleResolve!: Function;
 
-test("schedule refresh with an async component", async () => {
-	function* Component(this: Context) {
-		for ({} of this) {
-			this.schedule(() => this.refresh());
-			yield <span>Render 1</span>;
-			yield (
+		async function AsyncComponent(this: Context): Promise<Element> {
+			this.schedule(() => new Promise((r) => (scheduleResolve = r)));
+			await new Promise((resolve) => setTimeout(resolve, 1));
+			return <span>Async Function Component</span>;
+		}
+
+		const renderPromise = renderer.render(
+			<div>
+				<AsyncComponent />
+			</div>,
+			document.body,
+		);
+
+		// Should be completely empty while async function is pending
+		expect(document.body.innerHTML).toBe("");
+
+		// Schedule resolves, component should appear
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe("<div></div>");
+		await hangs(renderPromise);
+		expect(document.body.innerHTML).toBe("<div></div>");
+
+		scheduleResolve();
+		expect(document.body.innerHTML).toBe("<div></div>");
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Async Function Component</span></div>",
+		);
+
+		await renderPromise;
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Async Function Component</span></div>",
+		);
+	});
+
+	test("async mount replacing async component fallback that has already resolved", async () => {
+		const result1 = renderer.render(
+			<div>
+				<AsyncComponent>
+					<span>Async Component</span>
+				</AsyncComponent>
+			</div>,
+			document.body,
+		);
+
+		expect(result1).toBeInstanceOf(Promise);
+		expect(document.body.innerHTML).toBe("");
+		AsyncComponent.resolves[0]();
+		await result1;
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Async Component</span></div>",
+		);
+
+		const result2 = renderer.render(
+			<div>
+				<AsyncMountingComponent>
+					<span>Scheduling Component</span>
+				</AsyncMountingComponent>
+			</div>,
+			document.body,
+		);
+
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Async Component</span></div>",
+		);
+		expect(result2).toBeInstanceOf(Promise);
+
+		await hangs(result2);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Async Component</span></div>",
+		);
+
+		AsyncMountingComponent.resolves[0]();
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Scheduling Component</span></div>",
+		);
+	});
+
+	test("async mount replacing async component fallback that is pending and resolves", async () => {
+		const result1 = renderer.render(
+			<div>
+				<AsyncComponent>
+					<span>Async Component</span>
+				</AsyncComponent>
+			</div>,
+			document.body,
+		) as unknown as Promise<HTMLElement>;
+
+		expect(result1).toBeInstanceOf(Promise);
+		expect(document.body.innerHTML).toBe("");
+		const result2 = renderer.render(
+			<div>
+				<AsyncMountingComponent>
+					<span>Scheduling Component</span>
+				</AsyncMountingComponent>
+			</div>,
+			document.body,
+		) as unknown as Promise<HTMLElement>;
+
+		expect(document.body.innerHTML).toBe("<div></div>");
+		expect(result2).toBeInstanceOf(Promise);
+		AsyncComponent.resolves[0]();
+		expect((await result1).outerHTML).toBe(
+			"<div><span>Async Component</span></div>",
+		);
+		await hangs(result2);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Async Component</span></div>",
+		);
+
+		AsyncMountingComponent.resolves[0]();
+		await new Promise((resolve) => setTimeout(resolve));
+
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Scheduling Component</span></div>",
+		);
+
+		expect(await result2).toBe(document.body.firstChild);
+	});
+
+	test("async mount replacing async component fallback that is pending and doesn't resolve", async () => {
+		// Use AsyncComponent that never resolves by not calling its resolve
+		const result1 = renderer.render(
+			<div>
+				<AsyncComponent>
+					<span>Async Component</span>
+				</AsyncComponent>
+			</div>,
+			document.body,
+		) as unknown as Promise<HTMLElement>;
+
+		expect(result1).toBeInstanceOf(Promise);
+		expect(document.body.innerHTML).toBe("");
+		const result2 = renderer.render(
+			<div>
+				<AsyncMountingComponent>
+					<span>Scheduling Component</span>
+				</AsyncMountingComponent>
+			</div>,
+			document.body,
+		) as unknown as Promise<HTMLElement>;
+
+		expect(document.body.innerHTML).toBe("<div></div>");
+		expect(result2).toBeInstanceOf(Promise);
+		await hangs(result1);
+		await hangs(result2);
+		expect(document.body.innerHTML).toBe("<div></div>");
+
+		AsyncMountingComponent.resolves[0]();
+		expect((await result2).outerHTML).toBe(
+			"<div><span>Scheduling Component</span></div>",
+		);
+
+		expect((await result1).outerHTML).toBe(
+			"<div><span>Scheduling Component</span></div>",
+		);
+
+		expect(await result1).toBe(document.body.firstChild);
+		expect(await result2).toBe(document.body.firstChild);
+	});
+
+	test("async mount replacing async tree", async () => {
+		const result1 = renderer.render(
+			<div>
+				<span>
+					<AsyncComponent>Async Component</AsyncComponent>
+				</span>
+			</div>,
+			document.body,
+		) as Promise<HTMLElement>;
+
+		expect(result1).toBeInstanceOf(Promise);
+		expect(document.body.innerHTML).toBe("");
+		const result2 = renderer.render(
+			<div>
+				<AsyncMountingComponent>
+					<span>Scheduling Component</span>
+				</AsyncMountingComponent>
+			</div>,
+			document.body,
+		) as Promise<HTMLElement>;
+
+		expect(document.body.innerHTML).toBe("<div></div>");
+		expect(result2).toBeInstanceOf(Promise);
+		AsyncComponent.resolves[0]();
+		expect((await result1).outerHTML).toBe(
+			"<div><span>Async Component</span></div>",
+		);
+		AsyncMountingComponent.resolves[0]();
+		expect((await result2).outerHTML).toBe(
+			"<div><span>Scheduling Component</span></div>",
+		);
+	});
+
+	test("async mount replacing multiple async fallbacks", async () => {
+		const result1 = renderer.render(
+			<div>
+				<span>
+					<AsyncComponent>Render 1</AsyncComponent>
+				</span>
+			</div>,
+			document.body,
+		) as Promise<HTMLElement>;
+
+		const result2 = renderer.render(
+			<div>
 				<AsyncComponent>
 					<span>Render 2</span>
 				</AsyncComponent>
-			);
-		}
-	}
-	const result1 = renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	) as Promise<HTMLElement>;
-	await hangs(result1);
-	AsyncComponent.resolves[0]();
-	Assert.is((await result1).outerHTML, "<div><span>Render 2</span></div>");
-});
+			</div>,
+			document.body,
+		) as Promise<HTMLElement>;
 
-test.run();
+		const result3 = renderer.render(
+			<div>
+				<Fragment>
+					<span>
+						<AsyncComponent>Render 3</AsyncComponent>
+					</span>
+				</Fragment>
+			</div>,
+			document.body,
+		) as Promise<HTMLElement>;
+
+		const result4 = renderer.render(
+			<div>
+				<AsyncMountingComponent>
+					<span>Scheduling Component</span>
+				</AsyncMountingComponent>
+			</div>,
+			document.body,
+		) as Promise<HTMLElement>;
+
+		expect(result1).toBeInstanceOf(Promise);
+		expect(result2).toBeInstanceOf(Promise);
+		expect(result3).toBeInstanceOf(Promise);
+		expect(result4).toBeInstanceOf(Promise);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		expect(AsyncComponent.resolves.length).toBe(3);
+		AsyncComponent.resolves[1]();
+		expect((await result1).outerHTML).toBe("<div><span>Render 2</span></div>");
+		expect((await result2).outerHTML).toBe("<div><span>Render 2</span></div>");
+		await hangs(result3);
+		expect(document.body.innerHTML).toBe("<div><span>Render 2</span></div>");
+		AsyncMountingComponent.resolves[0]();
+		expect((await result3).outerHTML).toBe(
+			"<div><span>Scheduling Component</span></div>",
+		);
+		expect((await result4).outerHTML).toBe(
+			"<div><span>Scheduling Component</span></div>",
+		);
+	});
+
+	test("async mount replacing stateful component", async () => {
+		let statefulCtx: Context;
+		function* StatefulComponent(this: Context): Generator<Element> {
+			statefulCtx = this;
+			let i = 0;
+			for ({} of this) {
+				yield <span>Stateful {i++}</span>;
+			}
+		}
+
+		// Initial render with stateful component
+		renderer.render(
+			<div>
+				<div>
+					<StatefulComponent />
+				</div>
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><div><span>Stateful 0</span></div></div>",
+		);
+
+		// Replace with async component - should show nothing while scheduling
+		const result2 = renderer.render(
+			<div>
+				<AsyncMountingComponent>
+					<span>Scheduling Component</span>
+				</AsyncMountingComponent>
+			</div>,
+			document.body,
+		) as Promise<HTMLElement>;
+		expect(document.body.innerHTML).toBe(
+			"<div><div><span>Stateful 0</span></div></div>",
+		);
+		await hangs(result2);
+		statefulCtx!.refresh();
+		expect(document.body.innerHTML).toBe(
+			"<div><div><span>Stateful 1</span></div></div>",
+		);
+		statefulCtx!.refresh();
+		expect(document.body.innerHTML).toBe(
+			"<div><div><span>Stateful 2</span></div></div>",
+		);
+
+		AsyncMountingComponent.resolves[0]();
+		expect((await result2).outerHTML).toBe(
+			"<div><span>Scheduling Component</span></div>",
+		);
+	});
+
+	test("hanging schedule causes commits to queue", async () => {
+		// Initial render with hanging schedule - defers mounting
+		const result1 = renderer.render(
+			<div>
+				<AsyncMountingComponent>
+					<span>First</span>
+				</AsyncMountingComponent>
+			</div>,
+			document.body,
+		) as Promise<HTMLElement>;
+
+		expect(result1).toBeInstanceOf(Promise);
+		expect(document.body.innerHTML).toBe("<div></div>"); // Should be empty while scheduling
+		await hangs(result1); // Confirm it's hanging
+
+		// Second render - completes synchronously (non-initial render ignores schedule)
+		const result2 = renderer.render(
+			<div>
+				<AsyncMountingComponent>
+					<span>Second</span>
+				</AsyncMountingComponent>
+			</div>,
+			document.body,
+		) as Promise<HTMLElement>;
+
+		// Should complete synchronously, not return a promise
+		expect(result2).toBeInstanceOf(Promise);
+		await hangs(result2);
+		expect(document.body.innerHTML).toBe("<div></div>"); // Should still be empty
+		AsyncMountingComponent.resolves[0](); // Resolve the initial hanging schedule
+
+		expect((await result1).outerHTML).toBe("<div><span>First</span></div>"); // Should render first component
+		expect((await result2).outerHTML).toBe("<div><span>Second</span></div>"); // Should render second component
+	});
+
+	test("schedule refresh with an async component", async () => {
+		function* Component(this: Context) {
+			for ({} of this) {
+				this.schedule(() => this.refresh());
+				yield <span>Render 1</span>;
+				yield (
+					<AsyncComponent>
+						<span>Render 2</span>
+					</AsyncComponent>
+				);
+			}
+		}
+		const result1 = renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		) as Promise<HTMLElement>;
+		await hangs(result1);
+		AsyncComponent.resolves[0]();
+		expect((await result1).outerHTML).toBe("<div><span>Render 2</span></div>");
+	});
+});

--- a/test/suspense.tsx
+++ b/test/suspense.tsx
@@ -1,5 +1,4 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import * as Sinon from "sinon";
 
 import {createElement} from "../src/crank.js";
@@ -7,932 +6,896 @@ import type {Context, Element} from "../src/crank.js";
 import {Suspense, SuspenseList} from "../src/async.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("suspense");
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+describe("suspense", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-async function Child({timeout}: {timeout?: number}): Promise<Element> {
-	await new Promise((resolve) => setTimeout(resolve, timeout));
-	return <span>Child {timeout}</span>;
-}
-
-test("basic", async () => {
-	await renderer.render(
-		<Suspense fallback={<span>Loading...</span>} timeout={100}>
-			<Child timeout={200} />
-		</Suspense>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<span>Loading...</span>");
-	await new Promise((resolve) => setTimeout(resolve, 200));
-	Assert.is(document.body.innerHTML, "<span>Child 200</span>");
-
-	await renderer.render(
-		<Suspense fallback={<span>Loading...</span>} timeout={100}>
-			<Child timeout={200} />
-		</Suspense>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<span>Loading...</span>");
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(document.body.innerHTML, "<span>Child 200</span>");
-});
-
-test("no loading", async () => {
-	await renderer.render(
-		<Suspense fallback={<span>Loading...</span>} timeout={100}>
-			<Child timeout={0} />
-		</Suspense>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<span>Child 0</span>");
-	await new Promise((resolve) => setTimeout(resolve, 500));
-	Assert.is(document.body.innerHTML, "<span>Child 0</span>");
-});
-
-test("suspense with refresh", async () => {
-	let ctx!: Context;
-	async function* App(this: Context) {
-		ctx = this;
-		for await (const _ of this) {
-			yield (
-				<Suspense fallback={<span>Loading...</span>} timeout={100}>
-					<Child timeout={200} />
-				</Suspense>
-			);
-		}
+	async function Child({timeout}: {timeout?: number}): Promise<Element> {
+		await new Promise((resolve) => setTimeout(resolve, timeout));
+		return <span>Child {timeout}</span>;
 	}
 
-	await renderer.render(<App />, document.body);
-
-	Assert.is(document.body.innerHTML, "<span>Loading...</span>");
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(document.body.innerHTML, "<span>Child 200</span>");
-	await ctx.refresh();
-	Assert.is(document.body.innerHTML, "<span>Loading...</span>");
-	await new Promise((resolve) => setTimeout(resolve, 120));
-	Assert.is(document.body.innerHTML, "<span>Child 200</span>");
-});
-
-test("suspense with concurrent refresh", async () => {
-	let ctx!: Context;
-	async function* App(this: Context) {
-		ctx = this;
-		for await (const _ of this) {
-			yield (
-				<Suspense fallback={<span>Loading...</span>} timeout={100}>
-					<Child timeout={200} />
-				</Suspense>
-			);
-		}
-	}
-
-	await renderer.render(<App />, document.body);
-
-	Assert.is(document.body.innerHTML, "<span>Loading...</span>");
-	await new Promise((resolve) => setTimeout(resolve, 120));
-	Assert.is(document.body.innerHTML, "<span>Child 200</span>");
-	const refreshP = ctx.refresh();
-	ctx.refresh();
-	await refreshP;
-	Assert.is(document.body.innerHTML, "<span>Loading...</span>");
-	await new Promise((resolve) => setTimeout(resolve, 120));
-	Assert.is(document.body.innerHTML, "<span>Child 200</span>");
-});
-
-test("suspense with concurrent refresh in timeout", async () => {
-	let ctx!: Context;
-	async function* App(this: Context) {
-		ctx = this;
-		for await (const _ of this) {
-			yield (
-				<Suspense fallback={<span>Loading...</span>} timeout={100}>
-					<Child timeout={200} />
-				</Suspense>
-			);
-		}
-	}
-
-	await renderer.render(<App />, document.body);
-
-	Assert.is(document.body.innerHTML, "<span>Loading...</span>");
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(document.body.innerHTML, "<span>Child 200</span>");
-	const refreshP = ctx.refresh();
-	setTimeout(() => ctx.refresh());
-	await refreshP;
-	Assert.is(document.body.innerHTML, "<span>Loading...</span>");
-	await new Promise((resolve) => setTimeout(resolve, 110));
-	Assert.is(document.body.innerHTML, "<span>Child 200</span>");
-});
-
-test("suspense with concurrent refresh after refresh fulfills", async () => {
-	let ctx!: Context;
-	async function* App(this: Context) {
-		ctx = this;
-		for await (const _ of this) {
-			yield (
-				<Suspense fallback={<span>Loading...</span>} timeout={100}>
-					<Child timeout={200} />
-				</Suspense>
-			);
-		}
-	}
-
-	await renderer.render(<App />, document.body);
-
-	Assert.is(document.body.innerHTML, "<span>Loading...</span>");
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(document.body.innerHTML, "<span>Child 200</span>");
-	const refreshP = ctx.refresh();
-	ctx.refresh();
-	await refreshP;
-	Assert.is(document.body.innerHTML, "<span>Loading...</span>");
-	await new Promise((resolve) => setTimeout(resolve, 110));
-	Assert.is(document.body.innerHTML, "<span>Child 200</span>");
-});
-
-test("suspense preserves state on refresh", async () => {
-	let ctx!: Context;
-	const mock = Sinon.stub();
-	async function* StatefulChild(this: Context) {
-		mock();
-		let count = 0;
-		for ({} of this) {
-			await new Promise((resolve) => setTimeout(resolve, 200));
-			yield <span>Render {count++}</span>;
-		}
-	}
-
-	async function* App(this: Context) {
-		ctx = this;
-		for await (const _ of this) {
-			yield (
-				<Suspense fallback={<span>Loading...</span>} timeout={100}>
-					<StatefulChild />
-				</Suspense>
-			);
-		}
-	}
-
-	await renderer.render(<App />, document.body);
-	Assert.is(document.body.innerHTML, "<span>Loading...</span>");
-	await new Promise((resolve) => setTimeout(resolve, 120));
-	Assert.is(document.body.innerHTML, "<span>Render 0</span>");
-	await ctx.refresh();
-	Assert.is(document.body.innerHTML, "<span>Loading...</span>");
-	await new Promise((resolve) => setTimeout(resolve, 120));
-	Assert.is(document.body.innerHTML, "<span>Render 1</span>");
-	Assert.is(mock.callCount, 1);
-});
-
-test("suspenselist basic together mode", async () => {
-	const result = renderer.render(
-		<SuspenseList revealOrder="together">
-			<Suspense fallback={<span>Loading A...</span>} timeout={50}>
-				<Child timeout={100} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>} timeout={50}>
+	test("basic", async () => {
+		await renderer.render(
+			<Suspense fallback={<span>Loading...</span>} timeout={100}>
 				<Child timeout={200} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	) as Promise<Array<HTMLElement>>;
+			</Suspense>,
+			document.body,
+		);
 
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(document.body.innerHTML, "");
+		expect(document.body.innerHTML).toBe("<span>Loading...</span>");
+		await new Promise((resolve) => setTimeout(resolve, 200));
+		expect(document.body.innerHTML).toBe("<span>Child 200</span>");
 
-	Assert.equal(
-		(await result).map((el) => el.outerHTML),
-		["<span>Child 100</span>", "<span>Child 200</span>"],
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Child 100</span><span>Child 200</span>",
-	);
-});
+		await renderer.render(
+			<Suspense fallback={<span>Loading...</span>} timeout={100}>
+				<Child timeout={200} />
+			</Suspense>,
+			document.body,
+		);
 
-test("suspenselist together with mixed sync/async children", async () => {
-	const result = renderer.render(
-		<SuspenseList revealOrder="together">
-			<span>Sync child</span>
-			<Suspense fallback={<span>Loading...</span>} timeout={50}>
-				<Child timeout={100} />
-			</Suspense>
-			<span>Another sync</span>
-		</SuspenseList>,
-		document.body,
-	) as Promise<Array<HTMLElement>>;
+		expect(document.body.innerHTML).toBe("<span>Loading...</span>");
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe("<span>Child 200</span>");
+	});
 
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(document.body.innerHTML, "");
+	test("no loading", async () => {
+		await renderer.render(
+			<Suspense fallback={<span>Loading...</span>} timeout={100}>
+				<Child timeout={0} />
+			</Suspense>,
+			document.body,
+		);
 
-	Assert.equal(
-		(await result).map((el) => el.outerHTML),
-		[
+		expect(document.body.innerHTML).toBe("<span>Child 0</span>");
+		await new Promise((resolve) => setTimeout(resolve, 500));
+		expect(document.body.innerHTML).toBe("<span>Child 0</span>");
+	});
+
+	test("suspense with refresh", async () => {
+		let ctx!: Context;
+		async function* App(this: Context) {
+			ctx = this;
+			for await (const _ of this) {
+				yield (
+					<Suspense fallback={<span>Loading...</span>} timeout={100}>
+						<Child timeout={200} />
+					</Suspense>
+				);
+			}
+		}
+
+		await renderer.render(<App />, document.body);
+
+		expect(document.body.innerHTML).toBe("<span>Loading...</span>");
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe("<span>Child 200</span>");
+		await ctx.refresh();
+		expect(document.body.innerHTML).toBe("<span>Loading...</span>");
+		await new Promise((resolve) => setTimeout(resolve, 120));
+		expect(document.body.innerHTML).toBe("<span>Child 200</span>");
+	});
+
+	test("suspense with concurrent refresh", async () => {
+		let ctx!: Context;
+		async function* App(this: Context) {
+			ctx = this;
+			for await (const _ of this) {
+				yield (
+					<Suspense fallback={<span>Loading...</span>} timeout={100}>
+						<Child timeout={200} />
+					</Suspense>
+				);
+			}
+		}
+
+		await renderer.render(<App />, document.body);
+
+		expect(document.body.innerHTML).toBe("<span>Loading...</span>");
+		await new Promise((resolve) => setTimeout(resolve, 120));
+		expect(document.body.innerHTML).toBe("<span>Child 200</span>");
+		const refreshP = ctx.refresh();
+		ctx.refresh();
+		await refreshP;
+		expect(document.body.innerHTML).toBe("<span>Loading...</span>");
+		await new Promise((resolve) => setTimeout(resolve, 120));
+		expect(document.body.innerHTML).toBe("<span>Child 200</span>");
+	});
+
+	test("suspense with concurrent refresh in timeout", async () => {
+		let ctx!: Context;
+		async function* App(this: Context) {
+			ctx = this;
+			for await (const _ of this) {
+				yield (
+					<Suspense fallback={<span>Loading...</span>} timeout={100}>
+						<Child timeout={200} />
+					</Suspense>
+				);
+			}
+		}
+
+		await renderer.render(<App />, document.body);
+
+		expect(document.body.innerHTML).toBe("<span>Loading...</span>");
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe("<span>Child 200</span>");
+		const refreshP = ctx.refresh();
+		setTimeout(() => ctx.refresh());
+		await refreshP;
+		expect(document.body.innerHTML).toBe("<span>Loading...</span>");
+		await new Promise((resolve) => setTimeout(resolve, 110));
+		expect(document.body.innerHTML).toBe("<span>Child 200</span>");
+	});
+
+	test("suspense with concurrent refresh after refresh fulfills", async () => {
+		let ctx!: Context;
+		async function* App(this: Context) {
+			ctx = this;
+			for await (const _ of this) {
+				yield (
+					<Suspense fallback={<span>Loading...</span>} timeout={100}>
+						<Child timeout={200} />
+					</Suspense>
+				);
+			}
+		}
+
+		await renderer.render(<App />, document.body);
+
+		expect(document.body.innerHTML).toBe("<span>Loading...</span>");
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe("<span>Child 200</span>");
+		const refreshP = ctx.refresh();
+		ctx.refresh();
+		await refreshP;
+		expect(document.body.innerHTML).toBe("<span>Loading...</span>");
+		await new Promise((resolve) => setTimeout(resolve, 110));
+		expect(document.body.innerHTML).toBe("<span>Child 200</span>");
+	});
+
+	test("suspense preserves state on refresh", async () => {
+		let ctx!: Context;
+		const mock = Sinon.stub();
+		async function* StatefulChild(this: Context) {
+			mock();
+			let count = 0;
+			for ({} of this) {
+				await new Promise((resolve) => setTimeout(resolve, 200));
+				yield <span>Render {count++}</span>;
+			}
+		}
+
+		async function* App(this: Context) {
+			ctx = this;
+			for await (const _ of this) {
+				yield (
+					<Suspense fallback={<span>Loading...</span>} timeout={100}>
+						<StatefulChild />
+					</Suspense>
+				);
+			}
+		}
+
+		await renderer.render(<App />, document.body);
+		expect(document.body.innerHTML).toBe("<span>Loading...</span>");
+		await new Promise((resolve) => setTimeout(resolve, 120));
+		expect(document.body.innerHTML).toBe("<span>Render 0</span>");
+		await ctx.refresh();
+		expect(document.body.innerHTML).toBe("<span>Loading...</span>");
+		await new Promise((resolve) => setTimeout(resolve, 120));
+		expect(document.body.innerHTML).toBe("<span>Render 1</span>");
+		expect(mock.callCount).toBe(1);
+	});
+
+	test("suspenselist basic together mode", async () => {
+		const result = renderer.render(
+			<SuspenseList revealOrder="together">
+				<Suspense fallback={<span>Loading A...</span>} timeout={50}>
+					<Child timeout={100} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>} timeout={50}>
+					<Child timeout={200} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		) as Promise<Array<HTMLElement>>;
+
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe("");
+
+		expect((await result).map((el) => el.outerHTML)).toEqual([
+			"<span>Child 100</span>",
+			"<span>Child 200</span>",
+		]);
+		expect(document.body.innerHTML).toBe(
+			"<span>Child 100</span><span>Child 200</span>",
+		);
+	});
+
+	test("suspenselist together with mixed sync/async children", async () => {
+		const result = renderer.render(
+			<SuspenseList revealOrder="together">
+				<span>Sync child</span>
+				<Suspense fallback={<span>Loading...</span>} timeout={50}>
+					<Child timeout={100} />
+				</Suspense>
+				<span>Another sync</span>
+			</SuspenseList>,
+			document.body,
+		) as Promise<Array<HTMLElement>>;
+
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe("");
+
+		expect((await result).map((el) => el.outerHTML)).toEqual([
 			"<span>Sync child</span>",
 			"<span>Child 100</span>",
 			"<span>Another sync</span>",
-		],
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Sync child</span><span>Child 100</span><span>Another sync</span>",
-	);
-});
+		]);
+		expect(document.body.innerHTML).toBe(
+			"<span>Sync child</span><span>Child 100</span><span>Another sync</span>",
+		);
+	});
 
-test("nested suspenselist together", async () => {
-	const result = renderer.render(
-		<SuspenseList revealOrder="together">
-			<Suspense fallback={<span>Loading outer...</span>} timeout={50}>
-				<SuspenseList revealOrder="together">
-					<Suspense fallback={<span>Loading inner 1...</span>} timeout={50}>
-						<Child timeout={100} />
-					</Suspense>
-					<Suspense fallback={<span>Loading inner 2...</span>} timeout={50}>
-						<Child timeout={150} />
-					</Suspense>
-				</SuspenseList>
-			</Suspense>
-			<span>Outer sync</span>
-		</SuspenseList>,
-		document.body,
-	) as Promise<Array<HTMLElement>>;
+	test("nested suspenselist together", async () => {
+		const result = renderer.render(
+			<SuspenseList revealOrder="together">
+				<Suspense fallback={<span>Loading outer...</span>} timeout={50}>
+					<SuspenseList revealOrder="together">
+						<Suspense fallback={<span>Loading inner 1...</span>} timeout={50}>
+							<Child timeout={100} />
+						</Suspense>
+						<Suspense fallback={<span>Loading inner 2...</span>} timeout={50}>
+							<Child timeout={150} />
+						</Suspense>
+					</SuspenseList>
+				</Suspense>
+				<span>Outer sync</span>
+			</SuspenseList>,
+			document.body,
+		) as Promise<Array<HTMLElement>>;
 
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(document.body.innerHTML, "");
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe("");
 
-	Assert.equal(
-		(await result).map((el) => el.outerHTML),
-		[
+		expect((await result).map((el) => el.outerHTML)).toEqual([
 			"<span>Child 100</span>",
 			"<span>Child 150</span>",
 			"<span>Outer sync</span>",
-		],
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Child 100</span><span>Child 150</span><span>Outer sync</span>",
-	);
-});
+		]);
+		expect(document.body.innerHTML).toBe(
+			"<span>Child 100</span><span>Child 150</span><span>Outer sync</span>",
+		);
+	});
 
-test("suspenselist forwards mode fast-slow", async () => {
-	renderer.render(
-		<SuspenseList revealOrder="forwards">
-			<Suspense fallback={<span>Loading A...</span>} timeout={50}>
-				<Child timeout={100} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>} timeout={50}>
-				<Child timeout={200} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	);
+	test("suspenselist forwards mode fast-slow", async () => {
+		renderer.render(
+			<SuspenseList revealOrder="forwards">
+				<Suspense fallback={<span>Loading A...</span>} timeout={50}>
+					<Child timeout={100} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>} timeout={50}>
+					<Child timeout={200} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		);
 
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(document.body.innerHTML, "<span>Loading A...</span>");
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe("<span>Loading A...</span>");
 
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Child 100</span><span>Loading B...</span>",
-	);
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe(
+			"<span>Child 100</span><span>Loading B...</span>",
+		);
 
-	await new Promise((resolve) => setTimeout(resolve, 120));
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Child 100</span><span>Child 200</span>",
-	);
-});
+		await new Promise((resolve) => setTimeout(resolve, 120));
+		expect(document.body.innerHTML).toBe(
+			"<span>Child 100</span><span>Child 200</span>",
+		);
+	});
 
-test("suspenselist forwards mode slow-fast", async () => {
-	renderer.render(
-		<SuspenseList revealOrder="forwards">
-			<Suspense fallback={<span>Loading A...</span>} timeout={50}>
-				<Child timeout={200} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>} timeout={50}>
-				<Child timeout={100} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	) as Promise<Array<HTMLElement>>;
+	test("suspenselist forwards mode slow-fast", async () => {
+		renderer.render(
+			<SuspenseList revealOrder="forwards">
+				<Suspense fallback={<span>Loading A...</span>} timeout={50}>
+					<Child timeout={200} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>} timeout={50}>
+					<Child timeout={100} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		) as Promise<Array<HTMLElement>>;
 
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(document.body.innerHTML, "<span>Loading A...</span>");
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe("<span>Loading A...</span>");
 
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(document.body.innerHTML, "<span>Loading A...</span>");
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe("<span>Loading A...</span>");
 
-	await new Promise((resolve) => setTimeout(resolve, 120));
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Child 200</span><span>Child 100</span>",
-	);
-});
+		await new Promise((resolve) => setTimeout(resolve, 120));
+		expect(document.body.innerHTML).toBe(
+			"<span>Child 200</span><span>Child 100</span>",
+		);
+	});
 
-test("suspenselist backwards mode fast-slow", async () => {
-	renderer.render(
-		<SuspenseList revealOrder="backwards">
-			<Suspense fallback={<span>Loading A...</span>} timeout={50}>
-				<Child timeout={100} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>} timeout={50}>
-				<Child timeout={200} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	) as Promise<Array<HTMLElement>>;
+	test("suspenselist backwards mode fast-slow", async () => {
+		renderer.render(
+			<SuspenseList revealOrder="backwards">
+				<Suspense fallback={<span>Loading A...</span>} timeout={50}>
+					<Child timeout={100} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>} timeout={50}>
+					<Child timeout={200} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		) as Promise<Array<HTMLElement>>;
 
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(document.body.innerHTML, "<span>Loading B...</span>");
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe("<span>Loading B...</span>");
 
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(document.body.innerHTML, "<span>Loading B...</span>");
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe("<span>Loading B...</span>");
 
-	await new Promise((resolve) => setTimeout(resolve, 120));
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Child 100</span><span>Child 200</span>",
-	);
-});
+		await new Promise((resolve) => setTimeout(resolve, 120));
+		expect(document.body.innerHTML).toBe(
+			"<span>Child 100</span><span>Child 200</span>",
+		);
+	});
 
-test("suspenselist backwards mode slow-fast", async () => {
-	renderer.render(
-		<SuspenseList revealOrder="backwards" timeout={50}>
-			<Suspense fallback={<span>Loading A...</span>}>
-				<Child timeout={200} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>}>
-				<Child timeout={100} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	) as Promise<Array<HTMLElement>>;
+	test("suspenselist backwards mode slow-fast", async () => {
+		renderer.render(
+			<SuspenseList revealOrder="backwards" timeout={50}>
+				<Suspense fallback={<span>Loading A...</span>}>
+					<Child timeout={200} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>}>
+					<Child timeout={100} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		) as Promise<Array<HTMLElement>>;
 
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(document.body.innerHTML, "<span>Loading B...</span>");
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe("<span>Loading B...</span>");
 
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Loading A...</span><span>Child 100</span>",
-	);
-	await new Promise((resolve) => setTimeout(resolve, 120));
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Child 200</span><span>Child 100</span>",
-	);
-});
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe(
+			"<span>Loading A...</span><span>Child 100</span>",
+		);
+		await new Promise((resolve) => setTimeout(resolve, 120));
+		expect(document.body.innerHTML).toBe(
+			"<span>Child 200</span><span>Child 100</span>",
+		);
+	});
 
-test("suspenselist forwards collapsed - at most one fallback", async () => {
-	renderer.render(
-		<SuspenseList revealOrder="forwards" tail="collapsed">
-			<Suspense fallback={<span>Loading A...</span>}>
-				<Child timeout={100} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>}>
-				<Child timeout={300} />
-			</Suspense>
-			<Suspense fallback={<span>Loading C...</span>}>
-				<Child timeout={200} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	) as Promise<Array<HTMLElement>>;
+	test("suspenselist forwards collapsed - at most one fallback", async () => {
+		renderer.render(
+			<SuspenseList revealOrder="forwards" tail="collapsed">
+				<Suspense fallback={<span>Loading A...</span>}>
+					<Child timeout={100} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>}>
+					<Child timeout={300} />
+				</Suspense>
+				<Suspense fallback={<span>Loading C...</span>}>
+					<Child timeout={200} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		) as Promise<Array<HTMLElement>>;
 
-	// After fallback timeouts (50ms), should show all fallbacks initially
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(document.body.innerHTML, "<span>Loading A...</span>");
+		// After fallback timeouts (50ms), should show all fallbacks initially
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe("<span>Loading A...</span>");
 
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Child 100</span><span>Loading B...</span>",
-	);
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe(
+			"<span>Child 100</span><span>Loading B...</span>",
+		);
 
-	// After C ready (200ms), still waiting for B
-	await new Promise((resolve) => setTimeout(resolve, 120));
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Child 100</span><span>Loading B...</span>",
-	);
+		// After C ready (200ms), still waiting for B
+		await new Promise((resolve) => setTimeout(resolve, 120));
+		expect(document.body.innerHTML).toBe(
+			"<span>Child 100</span><span>Loading B...</span>",
+		);
 
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Child 100</span><span>Child 300</span><span>Child 200</span>",
-	);
-});
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe(
+			"<span>Child 100</span><span>Child 300</span><span>Child 200</span>",
+		);
+	});
 
-test("suspenselist backwards collapsed - at most one fallback", async () => {
-	renderer.render(
-		<SuspenseList revealOrder="backwards" tail="collapsed" timeout={50}>
-			<Suspense fallback={<span>Loading A...</span>}>
-				<Child timeout={200} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>}>
-				<Child timeout={300} />
-			</Suspense>
-			<Suspense fallback={<span>Loading C...</span>}>
-				<Child timeout={100} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	) as Promise<Array<HTMLElement>>;
+	test("suspenselist backwards collapsed - at most one fallback", async () => {
+		renderer.render(
+			<SuspenseList revealOrder="backwards" tail="collapsed" timeout={50}>
+				<Suspense fallback={<span>Loading A...</span>}>
+					<Child timeout={200} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>}>
+					<Child timeout={300} />
+				</Suspense>
+				<Suspense fallback={<span>Loading C...</span>}>
+					<Child timeout={100} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		) as Promise<Array<HTMLElement>>;
 
-	Assert.is(document.body.innerHTML, "");
+		expect(document.body.innerHTML).toBe("");
 
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(document.body.innerHTML, "<span>Loading C...</span>");
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe("<span>Loading C...</span>");
 
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Loading B...</span><span>Child 100</span>",
-	);
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe(
+			"<span>Loading B...</span><span>Child 100</span>",
+		);
 
-	await new Promise((resolve) => setTimeout(resolve, 120));
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Loading B...</span><span>Child 100</span>",
-	);
+		await new Promise((resolve) => setTimeout(resolve, 120));
+		expect(document.body.innerHTML).toBe(
+			"<span>Loading B...</span><span>Child 100</span>",
+		);
 
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Child 200</span><span>Child 300</span><span>Child 100</span>",
-	);
-});
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe(
+			"<span>Child 200</span><span>Child 300</span><span>Child 100</span>",
+		);
+	});
 
-test("suspenselist forwards hidden - no fallbacks", async () => {
-	renderer.render(
-		<SuspenseList revealOrder="forwards" tail="hidden" timeout={50}>
-			<Suspense fallback={<span>Loading A...</span>}>
-				<Child timeout={100} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>}>
-				<Child timeout={300} />
-			</Suspense>
-			<Suspense fallback={<span>Loading C...</span>}>
-				<Child timeout={200} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	);
+	test("suspenselist forwards hidden - no fallbacks", async () => {
+		renderer.render(
+			<SuspenseList revealOrder="forwards" tail="hidden" timeout={50}>
+				<Suspense fallback={<span>Loading A...</span>}>
+					<Child timeout={100} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>}>
+					<Child timeout={300} />
+				</Suspense>
+				<Suspense fallback={<span>Loading C...</span>}>
+					<Child timeout={200} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		);
 
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(document.body.innerHTML, "");
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe("");
 
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(document.body.innerHTML, "<span>Child 100</span>");
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe("<span>Child 100</span>");
 
-	await new Promise((resolve) => setTimeout(resolve, 120));
-	Assert.is(document.body.innerHTML, "<span>Child 100</span>");
+		await new Promise((resolve) => setTimeout(resolve, 120));
+		expect(document.body.innerHTML).toBe("<span>Child 100</span>");
 
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Child 100</span><span>Child 300</span><span>Child 200</span>",
-	);
-});
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe(
+			"<span>Child 100</span><span>Child 300</span><span>Child 200</span>",
+		);
+	});
 
-test("suspenselist backwards hidden - no fallbacks", async () => {
-	renderer.render(
-		<SuspenseList revealOrder="backwards" tail="hidden">
-			<Suspense fallback={<span>Loading A...</span>} timeout={50}>
-				<Child timeout={200} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>} timeout={50}>
-				<Child timeout={300} />
-			</Suspense>
-			<Suspense fallback={<span>Loading C...</span>} timeout={50}>
-				<Child timeout={100} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	);
+	test("suspenselist backwards hidden - no fallbacks", async () => {
+		renderer.render(
+			<SuspenseList revealOrder="backwards" tail="hidden">
+				<Suspense fallback={<span>Loading A...</span>} timeout={50}>
+					<Child timeout={200} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>} timeout={50}>
+					<Child timeout={300} />
+				</Suspense>
+				<Suspense fallback={<span>Loading C...</span>} timeout={50}>
+					<Child timeout={100} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		);
 
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(document.body.innerHTML, "");
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe("");
 
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(document.body.innerHTML, "<span>Child 100</span>");
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe("<span>Child 100</span>");
 
-	await new Promise((resolve) => setTimeout(resolve, 120));
-	Assert.is(document.body.innerHTML, "<span>Child 100</span>");
+		await new Promise((resolve) => setTimeout(resolve, 120));
+		expect(document.body.innerHTML).toBe("<span>Child 100</span>");
 
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Child 200</span><span>Child 300</span><span>Child 100</span>",
-	);
-});
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe(
+			"<span>Child 200</span><span>Child 300</span><span>Child 100</span>",
+		);
+	});
 
-test("suspenselist together ignores tail", async () => {
-	await renderer.render(
-		<SuspenseList revealOrder="together" tail="hidden">
-			<Suspense fallback={<span>Loading A...</span>} timeout={50}>
-				<Child timeout={100} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>} timeout={50}>
-				<Child timeout={200} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	);
+	test("suspenselist together ignores tail", async () => {
+		await renderer.render(
+			<SuspenseList revealOrder="together" tail="hidden">
+				<Suspense fallback={<span>Loading A...</span>} timeout={50}>
+					<Child timeout={100} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>} timeout={50}>
+					<Child timeout={200} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		);
 
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Child 100</span><span>Child 200</span>",
-	);
-});
+		expect(document.body.innerHTML).toBe(
+			"<span>Child 100</span><span>Child 200</span>",
+		);
+	});
 
-test("suspenselist forwards resolves with full list", async () => {
-	const result = renderer.render(
-		<SuspenseList revealOrder="forwards" tail="collapsed">
-			<Suspense fallback={<span>Loading A...</span>} timeout={50}>
-				<Child timeout={10} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>} timeout={50}>
-				<Child timeout={1} />
-			</Suspense>
-			<Suspense fallback={<span>Loading C...</span>} timeout={50}>
-				<Child timeout={2} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	) as Promise<Array<HTMLElement>>;
+	test("suspenselist forwards resolves with full list", async () => {
+		const result = renderer.render(
+			<SuspenseList revealOrder="forwards" tail="collapsed">
+				<Suspense fallback={<span>Loading A...</span>} timeout={50}>
+					<Child timeout={10} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>} timeout={50}>
+					<Child timeout={1} />
+				</Suspense>
+				<Suspense fallback={<span>Loading C...</span>} timeout={50}>
+					<Child timeout={2} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		) as Promise<Array<HTMLElement>>;
 
-	Assert.equal(
-		(await result).map((el) => el.outerHTML),
-		["<span>Child 10</span>", "<span>Child 1</span>", "<span>Child 2</span>"],
-	);
-});
+		expect((await result).map((el) => el.outerHTML)).toEqual([
+			"<span>Child 10</span>",
+			"<span>Child 1</span>",
+			"<span>Child 2</span>",
+		]);
+	});
 
-test("suspenselist backwards resolves with full list", async () => {
-	const result = renderer.render(
-		<SuspenseList revealOrder="backwards" tail="collapsed">
-			<Suspense fallback={<span>Loading A...</span>} timeout={50}>
-				<Child timeout={2} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>} timeout={50}>
-				<Child timeout={1} />
-			</Suspense>
-			<Suspense fallback={<span>Loading C...</span>} timeout={50}>
-				<Child timeout={10} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	) as Promise<Array<HTMLElement>>;
+	test("suspenselist backwards resolves with full list", async () => {
+		const result = renderer.render(
+			<SuspenseList revealOrder="backwards" tail="collapsed">
+				<Suspense fallback={<span>Loading A...</span>} timeout={50}>
+					<Child timeout={2} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>} timeout={50}>
+					<Child timeout={1} />
+				</Suspense>
+				<Suspense fallback={<span>Loading C...</span>} timeout={50}>
+					<Child timeout={10} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		) as Promise<Array<HTMLElement>>;
 
-	Assert.equal(
-		(await result).map((el) => el.outerHTML),
-		["<span>Child 2</span>", "<span>Child 1</span>", "<span>Child 10</span>"],
-	);
-});
+		expect((await result).map((el) => el.outerHTML)).toEqual([
+			"<span>Child 2</span>",
+			"<span>Child 1</span>",
+			"<span>Child 10</span>",
+		]);
+	});
 
-test("suspenselist together resolves with full list", async () => {
-	const result = renderer.render(
-		<SuspenseList revealOrder="together" tail="collapsed">
-			<Suspense fallback={<span>Loading A...</span>} timeout={50}>
-				<Child timeout={1} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>} timeout={50}>
-				<Child timeout={3} />
-			</Suspense>
-			<Suspense fallback={<span>Loading C...</span>} timeout={50}>
-				<Child timeout={2} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	) as Promise<Array<HTMLElement>>;
+	test("suspenselist together resolves with full list", async () => {
+		const result = renderer.render(
+			<SuspenseList revealOrder="together" tail="collapsed">
+				<Suspense fallback={<span>Loading A...</span>} timeout={50}>
+					<Child timeout={1} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>} timeout={50}>
+					<Child timeout={3} />
+				</Suspense>
+				<Suspense fallback={<span>Loading C...</span>} timeout={50}>
+					<Child timeout={2} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		) as Promise<Array<HTMLElement>>;
 
-	Assert.equal(
-		(await result).map((el) => el.outerHTML),
-		["<span>Child 1</span>", "<span>Child 3</span>", "<span>Child 2</span>"],
-	);
-});
+		expect((await result).map((el) => el.outerHTML)).toEqual([
+			"<span>Child 1</span>",
+			"<span>Child 3</span>",
+			"<span>Child 2</span>",
+		]);
+	});
 
-test("suspenselist forwards hidden resolves with full list", async () => {
-	const result = renderer.render(
-		<SuspenseList revealOrder="forwards" tail="hidden">
-			<Suspense fallback={<span>Loading A...</span>} timeout={50}>
-				<Child timeout={100} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>} timeout={50}>
-				<Child timeout={60} />
-			</Suspense>
-			<Suspense fallback={<span>Loading C...</span>} timeout={50}>
-				<Child timeout={80} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	) as Promise<Array<HTMLElement>>;
+	test("suspenselist forwards hidden resolves with full list", async () => {
+		const result = renderer.render(
+			<SuspenseList revealOrder="forwards" tail="hidden">
+				<Suspense fallback={<span>Loading A...</span>} timeout={50}>
+					<Child timeout={100} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>} timeout={50}>
+					<Child timeout={60} />
+				</Suspense>
+				<Suspense fallback={<span>Loading C...</span>} timeout={50}>
+					<Child timeout={80} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		) as Promise<Array<HTMLElement>>;
 
-	Assert.equal(
-		(await result).map((el) => el.outerHTML),
-		[
+		expect((await result).map((el) => el.outerHTML)).toEqual([
 			"<span>Child 100</span>",
 			"<span>Child 60</span>",
 			"<span>Child 80</span>",
-		],
-	);
-});
+		]);
+	});
 
-test("suspenselist backwards hidden resolves with full list", async () => {
-	const result = renderer.render(
-		<SuspenseList revealOrder="backwards" tail="hidden">
-			<Suspense fallback={<span>Loading A...</span>} timeout={50}>
-				<Child timeout={80} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>} timeout={50}>
-				<Child timeout={60} />
-			</Suspense>
-			<Suspense fallback={<span>Loading C...</span>} timeout={50}>
-				<Child timeout={100} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	) as Promise<Array<HTMLElement>>;
+	test("suspenselist backwards hidden resolves with full list", async () => {
+		const result = renderer.render(
+			<SuspenseList revealOrder="backwards" tail="hidden">
+				<Suspense fallback={<span>Loading A...</span>} timeout={50}>
+					<Child timeout={80} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>} timeout={50}>
+					<Child timeout={60} />
+				</Suspense>
+				<Suspense fallback={<span>Loading C...</span>} timeout={50}>
+					<Child timeout={100} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		) as Promise<Array<HTMLElement>>;
 
-	Assert.equal(
-		(await result).map((el) => el.outerHTML),
-		[
+		expect((await result).map((el) => el.outerHTML)).toEqual([
 			"<span>Child 80</span>",
 			"<span>Child 60</span>",
 			"<span>Child 100</span>",
-		],
-	);
-});
+		]);
+	});
 
-test("suspenselist together hidden resolves with full list", async () => {
-	const result = renderer.render(
-		<SuspenseList revealOrder="together" tail="hidden">
-			<Suspense fallback={<span>Loading A...</span>} timeout={50}>
-				<Child timeout={1} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>} timeout={50}>
-				<Child timeout={3} />
-			</Suspense>
-			<Suspense fallback={<span>Loading C...</span>} timeout={50}>
-				<Child timeout={2} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	) as Promise<Array<HTMLElement>>;
+	test("suspenselist together hidden resolves with full list", async () => {
+		const result = renderer.render(
+			<SuspenseList revealOrder="together" tail="hidden">
+				<Suspense fallback={<span>Loading A...</span>} timeout={50}>
+					<Child timeout={1} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>} timeout={50}>
+					<Child timeout={3} />
+				</Suspense>
+				<Suspense fallback={<span>Loading C...</span>} timeout={50}>
+					<Child timeout={2} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		) as Promise<Array<HTMLElement>>;
 
-	Assert.equal(
-		(await result).map((el) => el.outerHTML),
-		["<span>Child 1</span>", "<span>Child 3</span>", "<span>Child 2</span>"],
-	);
-});
+		expect((await result).map((el) => el.outerHTML)).toEqual([
+			"<span>Child 1</span>",
+			"<span>Child 3</span>",
+			"<span>Child 2</span>",
+		]);
+	});
 
-test("suspenselist forwards resolves with first children", async () => {
-	const result = renderer.render(
-		<SuspenseList revealOrder="forwards" tail="collapsed">
-			<Suspense fallback={<span>Loading A...</span>} timeout={50}>
-				<Child timeout={10} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>} timeout={50}>
-				<Child timeout={200} />
-			</Suspense>
-			<Suspense fallback={<span>Loading C...</span>} timeout={50}>
-				<Child timeout={300} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	) as Promise<HTMLElement>;
+	test("suspenselist forwards resolves with first children", async () => {
+		const result = renderer.render(
+			<SuspenseList revealOrder="forwards" tail="collapsed">
+				<Suspense fallback={<span>Loading A...</span>} timeout={50}>
+					<Child timeout={10} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>} timeout={50}>
+					<Child timeout={200} />
+				</Suspense>
+				<Suspense fallback={<span>Loading C...</span>} timeout={50}>
+					<Child timeout={300} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		) as Promise<HTMLElement>;
 
-	Assert.equal((await result).outerHTML, "<span>Child 10</span>");
-});
+		expect((await result).outerHTML).toEqual("<span>Child 10</span>");
+	});
 
-test("suspenselist forwards resolves with children and loading", async () => {
-	const result = renderer.render(
-		<SuspenseList revealOrder="forwards" tail="collapsed" timeout={50}>
-			<Suspense fallback={<span>Loading A...</span>}>
-				<Child timeout={200} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>}>
-				<Child timeout={10} />
-			</Suspense>
-			<Suspense fallback={<span>Loading C...</span>}>
-				<Child timeout={300} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	) as Promise<Array<HTMLElement>>;
+	test("suspenselist forwards resolves with children and loading", async () => {
+		const result = renderer.render(
+			<SuspenseList revealOrder="forwards" tail="collapsed" timeout={50}>
+				<Suspense fallback={<span>Loading A...</span>}>
+					<Child timeout={200} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>}>
+					<Child timeout={10} />
+				</Suspense>
+				<Suspense fallback={<span>Loading C...</span>}>
+					<Child timeout={300} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		) as Promise<Array<HTMLElement>>;
 
-	Assert.equal(
-		(await result).map((el) => el.outerHTML),
-		[
+		expect((await result).map((el) => el.outerHTML)).toEqual([
 			"<span>Child 200</span>",
 			"<span>Child 10</span>",
 			"<span>Loading C...</span>",
-		],
-	);
-});
+		]);
+	});
 
-test("suspenselist forwards resolves with children but no loading", async () => {
-	const result = renderer.render(
-		<SuspenseList revealOrder="forwards" tail="collapsed" timeout={50}>
-			<Suspense fallback={<span>Loading A...</span>}>
-				<Child timeout={10} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>}>
-				<Child timeout={20} />
-			</Suspense>
-			<Suspense fallback={<span>Loading C...</span>}>
-				<Child timeout={300} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	) as Promise<HTMLElement>;
+	test("suspenselist forwards resolves with children but no loading", async () => {
+		const result = renderer.render(
+			<SuspenseList revealOrder="forwards" tail="collapsed" timeout={50}>
+				<Suspense fallback={<span>Loading A...</span>}>
+					<Child timeout={10} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>}>
+					<Child timeout={20} />
+				</Suspense>
+				<Suspense fallback={<span>Loading C...</span>}>
+					<Child timeout={300} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		) as Promise<HTMLElement>;
 
-	Assert.equal((await result).outerHTML, "<span>Child 10</span>");
-});
+		expect((await result).outerHTML).toEqual("<span>Child 10</span>");
+	});
 
-test("suspense can override suspenselist timeout", async () => {
-	renderer.render(
-		<SuspenseList revealOrder="forwards" tail="collapsed" timeout={200}>
-			<Suspense fallback={<span>Loading A...</span>} timeout={50}>
-				<Child timeout={100} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>}>
-				<Child timeout={300} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	);
-
-	// First Suspense has timeout=50, should show fallback at 50ms
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(document.body.innerHTML, "<span>Loading A...</span>");
-
-	// Second Suspense inherits timeout=200 from SuspenseList
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(document.body.innerHTML, "<span>Child 100</span>");
-
-	// Second fallback appears after 200ms total (SuspenseList timeout)
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Child 100</span><span>Loading B...</span>",
-	);
-
-	await new Promise((resolve) => setTimeout(resolve, 120));
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Child 100</span><span>Child 300</span>",
-	);
-});
-
-test("suspenselist coordinates nested suspense in components", async () => {
-	function NestedComponent(): Element {
-		return (
-			<Suspense fallback={<span>Loading nested...</span>}>
-				<Child timeout={150} />
-			</Suspense>
+	test("suspense can override suspenselist timeout", async () => {
+		renderer.render(
+			<SuspenseList revealOrder="forwards" tail="collapsed" timeout={200}>
+				<Suspense fallback={<span>Loading A...</span>} timeout={50}>
+					<Child timeout={100} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>}>
+					<Child timeout={300} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
 		);
-	}
 
-	renderer.render(
-		<SuspenseList revealOrder="forwards" tail="collapsed" timeout={50}>
-			<Suspense fallback={<span>Loading A...</span>}>
-				<Child timeout={100} />
-			</Suspense>
-			<NestedComponent />
-		</SuspenseList>,
-		document.body,
-	);
+		// First Suspense has timeout=50, should show fallback at 50ms
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe("<span>Loading A...</span>");
 
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(document.body.innerHTML, "<span>Loading A...</span>");
+		// Second Suspense inherits timeout=200 from SuspenseList
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe("<span>Child 100</span>");
 
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Child 100</span><span>Loading nested...</span>",
-	);
-
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Child 100</span><span>Child 150</span>",
-	);
-});
-
-test("suspenselist re-renders", async () => {
-	renderer.render(
-		<SuspenseList timeout={50}>
-			<Suspense fallback={<span>Loading A...</span>}>
-				<Child timeout={100} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>}>
-				<Child timeout={1} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	);
-
-	renderer.render(
-		<SuspenseList timeout={50}>
-			<Suspense fallback={<span>Loading A...</span>}>
-				<Child timeout={100} />
-			</Suspense>
-			<Suspense fallback={<span>Loading B...</span>}>
-				<Child timeout={1} />
-			</Suspense>
-		</SuspenseList>,
-		document.body,
-	);
-
-	await new Promise((resolve) => setTimeout(resolve, 60));
-	Assert.is(document.body.innerHTML, "<span>Loading A...</span>");
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(
-		document.body.innerHTML,
-		"<span>Child 100</span><span>Child 1</span>",
-	);
-});
-
-// https://github.com/bikeshaving/crank/issues/297
-// TODO: See if we can create a reproduction that does not use setInterval
-test("suspense fallback and children render simultaneously", async () => {
-	// Simple loading fallback that refreshes periodically
-	function* LoadingFallback(this: Context) {
-		let count = 0;
-		const interval = setInterval(
-			() =>
-				this.refresh(() => {
-					count++;
-				}),
-			100,
+		// Second fallback appears after 200ms total (SuspenseList timeout)
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe(
+			"<span>Child 100</span><span>Loading B...</span>",
 		);
-		this.cleanup(() => clearInterval(interval));
 
-		for ({} of this) {
-			yield <div class="fallback">Loading {count}...</div>;
-		}
-	}
+		await new Promise((resolve) => setTimeout(resolve, 120));
+		expect(document.body.innerHTML).toBe(
+			"<span>Child 100</span><span>Child 300</span>",
+		);
+	});
 
-	// Async component that takes time to resolve
-	let apiCallCount = 0;
-	async function SlowAsyncComponent() {
-		const id = ++apiCallCount;
-		// Simulate slow network request
-		await new Promise((resolve) => setTimeout(resolve, 500));
-		return <div class="content">Content {id}</div>;
-	}
-
-	// Parent component with button that triggers refresh
-	function* App(this: Context) {
-		for ({} of this) {
-			yield (
-				<Suspense fallback={<LoadingFallback />} timeout={300}>
-					<SlowAsyncComponent />
+	test("suspenselist coordinates nested suspense in components", async () => {
+		function NestedComponent(): Element {
+			return (
+				<Suspense fallback={<span>Loading nested...</span>}>
+					<Child timeout={150} />
 				</Suspense>
 			);
 		}
-	}
 
-	// Initial render
-	await renderer.render(<App />, document.body);
-	renderer.render(<App />, document.body);
-	// Wait and check for the bug
-	let bugDetected = false;
-	for (let i = 0; i < 20; i++) {
-		await new Promise((resolve) => setTimeout(resolve, 50));
-		const html = document.body.innerHTML;
-		if (i === 2) {
-			renderer.render(<App />, document.body);
+		renderer.render(
+			<SuspenseList revealOrder="forwards" tail="collapsed" timeout={50}>
+				<Suspense fallback={<span>Loading A...</span>}>
+					<Child timeout={100} />
+				</Suspense>
+				<NestedComponent />
+			</SuspenseList>,
+			document.body,
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe("<span>Loading A...</span>");
+
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe(
+			"<span>Child 100</span><span>Loading nested...</span>",
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe(
+			"<span>Child 100</span><span>Child 150</span>",
+		);
+	});
+
+	test("suspenselist re-renders", async () => {
+		renderer.render(
+			<SuspenseList timeout={50}>
+				<Suspense fallback={<span>Loading A...</span>}>
+					<Child timeout={100} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>}>
+					<Child timeout={1} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		);
+
+		renderer.render(
+			<SuspenseList timeout={50}>
+				<Suspense fallback={<span>Loading A...</span>}>
+					<Child timeout={100} />
+				</Suspense>
+				<Suspense fallback={<span>Loading B...</span>}>
+					<Child timeout={1} />
+				</Suspense>
+			</SuspenseList>,
+			document.body,
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.body.innerHTML).toBe("<span>Loading A...</span>");
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe(
+			"<span>Child 100</span><span>Child 1</span>",
+		);
+	});
+
+	// https://github.com/bikeshaving/crank/issues/297
+	// TODO: See if we can create a reproduction that does not use setInterval
+	test("suspense fallback and children render simultaneously", async () => {
+		// Simple loading fallback that refreshes periodically
+		function* LoadingFallback(this: Context) {
+			let count = 0;
+			const interval = setInterval(
+				() =>
+					this.refresh(() => {
+						count++;
+					}),
+				100,
+			);
+			this.cleanup(() => clearInterval(interval));
+
+			for ({} of this) {
+				yield <div class="fallback">Loading {count}...</div>;
+			}
 		}
 
-		// Check if BOTH fallback and content are visible
-		const hasFallback = html.includes('class="fallback"');
-		const hasContent = html.includes('class="content"');
-
-		if (hasFallback && hasContent) {
-			bugDetected = true;
-			break;
+		// Async component that takes time to resolve
+		let apiCallCount = 0;
+		async function SlowAsyncComponent() {
+			const id = ++apiCallCount;
+			// Simulate slow network request
+			await new Promise((resolve) => setTimeout(resolve, 500));
+			return <div class="content">Content {id}</div>;
 		}
-	}
 
-	// Test fails if bug is detected
-	Assert.not.ok(
-		bugDetected,
-		"Fallback and content should not render simultaneously",
-	);
+		// Parent component with button that triggers refresh
+		function* App(this: Context) {
+			for ({} of this) {
+				yield (
+					<Suspense fallback={<LoadingFallback />} timeout={300}>
+						<SlowAsyncComponent />
+					</Suspense>
+				);
+			}
+		}
+
+		// Initial render
+		await renderer.render(<App />, document.body);
+		renderer.render(<App />, document.body);
+		// Wait and check for the bug
+		let bugDetected = false;
+		for (let i = 0; i < 20; i++) {
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			const html = document.body.innerHTML;
+			if (i === 2) {
+				renderer.render(<App />, document.body);
+			}
+
+			// Check if BOTH fallback and content are visible
+			const hasFallback = html.includes('class="fallback"');
+			const hasContent = html.includes('class="content"');
+
+			if (hasFallback && hasContent) {
+				bugDetected = true;
+				break;
+			}
+		}
+
+		// Test fails if bug is detected
+		expect(
+			bugDetected,
+		).toBeFalsy() /* Fallback and content should not render simultaneously */;
+	});
 });
-
-test.run();

--- a/test/svg.tsx
+++ b/test/svg.tsx
@@ -1,269 +1,269 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import {createElement} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("svg");
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
+describe("svg", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
+
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
+
+	test("simple", () => {
+		renderer.render(<svg>Hello world</svg>, document.body);
+		expect(document.body.firstChild instanceof SVGElement).toBeTruthy();
+		expect(document.body.firstChild!.firstChild instanceof Text).toBeTruthy();
+		expect(document.body.firstChild!.firstChild!.nodeValue).toBe("Hello world");
+	});
+
+	test("mdn example", () => {
+		renderer.render(
+			<svg
+				version="1.1"
+				baseProfile="full"
+				width="300"
+				height="200"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<rect width="100%" height="100%" fill="red" />
+				<circle cx="150" cy="100" r="80" fill="green" />
+				<text x="150" y="125" font-size="60" text-anchor="middle" fill="white">
+					SVG
+				</text>
+			</svg>,
+			document.body,
+		);
+
+		let svgRoot = document.body.firstChild;
+		expect(document.body.firstChild instanceof SVGElement).toBeTruthy();
+
+		let rect = svgRoot!.childNodes[0] as SVGElement;
+		expect(rect instanceof SVGElement).toBeTruthy();
+		expect(rect.tagName).toBe("rect");
+		expect(rect.getAttribute("width")).toBe("100%");
+		expect(rect.getAttribute("height")).toBe("100%");
+		expect(rect.getAttribute("fill")).toBe("red");
+
+		let circle = svgRoot!.childNodes[1] as SVGElement;
+		expect(circle instanceof SVGElement).toBeTruthy();
+		expect(circle.tagName).toBe("circle");
+		expect(circle.getAttribute("cx")).toBe("150");
+		expect(circle.getAttribute("cy")).toBe("100");
+		expect(circle.getAttribute("r")).toBe("80");
+		expect(circle.getAttribute("fill")).toBe("green");
+
+		let text = svgRoot!.childNodes[2] as SVGElement;
+		expect(text instanceof SVGElement).toBeTruthy();
+		expect(text.tagName).toBe("text");
+		expect(text.getAttribute("x")).toBe("150");
+		expect(text.getAttribute("y")).toBe("125");
+		expect(text.getAttribute("font-size")).toBe("60");
+		expect(text.getAttribute("text-anchor")).toBe("middle");
+		expect(text.getAttribute("fill")).toBe("white");
+	});
+
+	test("foreignObject", () => {
+		renderer.render(
+			<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+				<foreignObject x="20" y="20" width="160" height="160">
+					<div xmlns="http://www.w3.org/1999/xhtml">
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed mollis
+						mollis mi ut ultricies. Nullam magna ipsum, porta vel dui convallis,
+						rutrum imperdiet eros. Aliquam erat volutpat.
+					</div>
+				</foreignObject>
+			</svg>,
+			document.body,
+		);
+		expect(document.body.firstChild instanceof SVGElement).toBeTruthy();
+
+		const foreignObject = document.body.firstChild!.firstChild!;
+		expect(foreignObject instanceof SVGElement).toBeTruthy();
+		expect((foreignObject as Element).namespaceURI).toBe(
+			"http://www.w3.org/2000/svg",
+		);
+
+		const div = foreignObject.firstChild! as HTMLElement;
+		expect(div instanceof HTMLElement).toBeTruthy();
+		expect(div.namespaceURI).toBe("http://www.w3.org/1999/xhtml");
+	});
+
+	test("foreignObject children are HTML without explicit xmlns", () => {
+		renderer.render(
+			<svg viewBox="0 0 200 200">
+				<foreignObject x="20" y="20" width="160" height="160">
+					<div>
+						<p>Hello</p>
+					</div>
+				</foreignObject>
+			</svg>,
+			document.body,
+		);
+		const foreignObject = document.body.firstChild!.firstChild!;
+		expect(foreignObject instanceof SVGElement).toBeTruthy();
+
+		const div = foreignObject.firstChild! as Element;
+		expect(div instanceof HTMLDivElement).toBeTruthy();
+		expect(div.namespaceURI).toBe("http://www.w3.org/1999/xhtml");
+
+		const p = div.firstChild! as Element;
+		expect(p instanceof HTMLParagraphElement).toBeTruthy();
+		expect(p.namespaceURI).toBe("http://www.w3.org/1999/xhtml");
+	});
+
+	test("foreignObject itself gets SVG prop normalization", () => {
+		renderer.render(
+			<svg viewBox="0 0 200 200">
+				{/* eslint-disable-next-line crank/no-react-svg-props */}
+				<foreignObject clipPath="url(#clip)" colorInterpolation="sRGB">
+					<div>Hello</div>
+				</foreignObject>
+			</svg>,
+			document.body,
+		);
+		const foreignObject = document.body.firstChild!.firstChild! as SVGElement;
+		expect(foreignObject instanceof SVGElement).toBeTruthy();
+		// SVG props should be normalized on foreignObject itself
+		expect(foreignObject.getAttribute("clip-path")).toBe("url(#clip)");
+		expect(foreignObject.getAttribute("color-interpolation")).toBe("sRGB");
+	});
+
+	test("classes", () => {
+		renderer.render(
+			<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+				<rect class="rectClass" x="10" y="10" width="100" height="100" />
+				<circle class="circleClass" cx="40" cy="50" r="26" />
+			</svg>,
+			document.body,
+		);
+
+		const rect = document.body.firstChild!.firstChild as SVGElement;
+		const circle = rect.nextSibling as SVGElement;
+		expect(rect instanceof SVGElement).toBeTruthy();
+		expect(rect.tagName).toBe("rect");
+		expect(circle instanceof SVGElement).toBeTruthy();
+		expect(circle.tagName).toBe("circle");
+		expect(rect.getAttribute("class")).toBe("rectClass");
+		expect(circle.getAttribute("class")).toBe("circleClass");
+	});
+
+	test("g", () => {
+		renderer.render(
+			<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+				<g fill="white" stroke="green" stroke-width="5">
+					<path d="M10 10" />
+					<path d="M 10 10 H 90 V 90 H 10 L 10 10" />
+				</g>
+			</svg>,
+			document.body,
+		);
+
+		const g = document.body.firstChild!.firstChild as SVGElement;
+		expect(g instanceof SVGElement).toBeTruthy();
+		expect(g.tagName).toBe("g");
+		expect(g.childNodes[0] instanceof SVGElement).toBeTruthy();
+		expect(g.childNodes[1] instanceof SVGElement).toBeTruthy();
+	});
+
+	test("nested", () => {
+		renderer.render(
+			<svg width="750" height="500" style="background: gray">
+				<svg x="200" y="200">
+					<circle cx="50" cy="50" r="50" style="fill: red" />
+				</svg>
+			</svg>,
+			document.body,
+		);
+		const nested = document.body.firstChild!.firstChild as SVGElement;
+		expect(nested instanceof SVGElement).toBeTruthy();
+		expect(nested.tagName).toBe("svg");
+		expect(nested.firstChild instanceof SVGElement).toBeTruthy();
+		expect((nested.firstChild as SVGElement).tagName).toBe("circle");
+	});
+
+	test("non-string values", () => {
+		renderer.render(
+			<svg xmlns="http://www.w3.org/2000/svg">
+				<rect class="rectClass" x={10} y={20.5} width={5000} height={null} />
+			</svg>,
+			document.body,
+		);
+
+		const rect = document.body.firstChild!.firstChild! as SVGElement;
+		expect(rect instanceof SVGElement).toBeTruthy();
+		expect(rect.getAttribute("x")).toBe("10");
+		expect(rect.getAttribute("y")).toBe("20.5");
+		expect(rect.getAttribute("width")).toBe("5000");
+		expect(rect.getAttribute("height")).toBe(null);
+	});
+
+	test("custom attributes", () => {
+		renderer.render(
+			<svg xmlns="http://www.w3.org/2000/svg">
+				<circle cx="25" cy="10" r="5" data-foo="abc" barBaz={true} />
+			</svg>,
+			document.body,
+		);
+
+		const circle = document.body.firstChild!.firstChild! as SVGElement;
+		expect(circle instanceof SVGElement).toBeTruthy();
+		expect(circle.getAttribute("cx")).toBe("25");
+		expect(circle.getAttribute("cy")).toBe("10");
+		expect(circle.getAttribute("r")).toBe("5");
+		expect(circle.getAttribute("data-foo")).toBe("abc");
+		expect(circle.getAttribute("barBaz")).toBe("");
+		expect(circle.getAttribute("does-not-exist")).toBe(null);
+	});
+
+	/* eslint-disable crank/no-react-svg-props */
+	test("React-style camelCase SVG attributes", () => {
+		renderer.render(
+			<svg>
+				<path
+					strokeWidth="2"
+					strokeLinecap="round"
+					fillOpacity="0.5"
+					clipPath="url(#clip)"
+				/>
+			</svg>,
+			document.body,
+		);
+
+		const path = document.body.firstChild!.firstChild! as SVGElement;
+		expect(path instanceof SVGElement).toBeTruthy();
+		expect(path.getAttribute("stroke-width")).toBe("2");
+		expect(path.getAttribute("stroke-linecap")).toBe("round");
+		expect(path.getAttribute("fill-opacity")).toBe("0.5");
+		expect(path.getAttribute("clip-path")).toBe("url(#clip)");
+	});
+
+	test("React-style text SVG attributes", () => {
+		renderer.render(
+			<svg>
+				<text textAnchor="middle" dominantBaseline="central" />
+			</svg>,
+			document.body,
+		);
+
+		const text = document.body.firstChild!.firstChild! as SVGElement;
+		expect(text.getAttribute("text-anchor")).toBe("middle");
+		expect(text.getAttribute("dominant-baseline")).toBe("central");
+	});
+
+	test("SVG camelCase attributes that are already correct", () => {
+		renderer.render(
+			<svg viewBox="0 0 100 100" preserveAspectRatio="xMidYMid">
+				<circle cx="50" cy="50" r="40" />
+			</svg>,
+			document.body,
+		);
+
+		const svg = document.body.firstChild! as SVGElement;
+		expect(svg.getAttribute("viewBox")).toBe("0 0 100 100");
+		expect(svg.getAttribute("preserveAspectRatio")).toBe("xMidYMid");
+	});
 });
-
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
-
-test("simple", () => {
-	renderer.render(<svg>Hello world</svg>, document.body);
-	Assert.ok(document.body.firstChild instanceof SVGElement);
-	Assert.ok(document.body.firstChild!.firstChild instanceof Text);
-	Assert.is(document.body.firstChild!.firstChild!.nodeValue, "Hello world");
-});
-
-test("mdn example", () => {
-	renderer.render(
-		<svg
-			version="1.1"
-			baseProfile="full"
-			width="300"
-			height="200"
-			xmlns="http://www.w3.org/2000/svg"
-		>
-			<rect width="100%" height="100%" fill="red" />
-			<circle cx="150" cy="100" r="80" fill="green" />
-			<text x="150" y="125" font-size="60" text-anchor="middle" fill="white">
-				SVG
-			</text>
-		</svg>,
-		document.body,
-	);
-
-	let svgRoot = document.body.firstChild;
-	Assert.ok(document.body.firstChild instanceof SVGElement);
-
-	let rect = svgRoot!.childNodes[0] as SVGElement;
-	Assert.ok(rect instanceof SVGElement);
-	Assert.is(rect.tagName, "rect");
-	Assert.is(rect.getAttribute("width"), "100%");
-	Assert.is(rect.getAttribute("height"), "100%");
-	Assert.is(rect.getAttribute("fill"), "red");
-
-	let circle = svgRoot!.childNodes[1] as SVGElement;
-	Assert.ok(circle instanceof SVGElement);
-	Assert.is(circle.tagName, "circle");
-	Assert.is(circle.getAttribute("cx"), "150");
-	Assert.is(circle.getAttribute("cy"), "100");
-	Assert.is(circle.getAttribute("r"), "80");
-	Assert.is(circle.getAttribute("fill"), "green");
-
-	let text = svgRoot!.childNodes[2] as SVGElement;
-	Assert.ok(text instanceof SVGElement);
-	Assert.is(text.tagName, "text");
-	Assert.is(text.getAttribute("x"), "150");
-	Assert.is(text.getAttribute("y"), "125");
-	Assert.is(text.getAttribute("font-size"), "60");
-	Assert.is(text.getAttribute("text-anchor"), "middle");
-	Assert.is(text.getAttribute("fill"), "white");
-});
-
-test("foreignObject", () => {
-	renderer.render(
-		<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
-			<foreignObject x="20" y="20" width="160" height="160">
-				<div xmlns="http://www.w3.org/1999/xhtml">
-					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed mollis
-					mollis mi ut ultricies. Nullam magna ipsum, porta vel dui convallis,
-					rutrum imperdiet eros. Aliquam erat volutpat.
-				</div>
-			</foreignObject>
-		</svg>,
-		document.body,
-	);
-	Assert.ok(document.body.firstChild instanceof SVGElement);
-
-	const foreignObject = document.body.firstChild!.firstChild!;
-	Assert.ok(foreignObject instanceof SVGElement);
-	Assert.is(foreignObject.namespaceURI, "http://www.w3.org/2000/svg");
-
-	const div = foreignObject.firstChild! as HTMLElement;
-	Assert.ok(div instanceof HTMLElement);
-	Assert.is(div.namespaceURI, "http://www.w3.org/1999/xhtml");
-});
-
-test("foreignObject children are HTML without explicit xmlns", () => {
-	renderer.render(
-		<svg viewBox="0 0 200 200">
-			<foreignObject x="20" y="20" width="160" height="160">
-				<div>
-					<p>Hello</p>
-				</div>
-			</foreignObject>
-		</svg>,
-		document.body,
-	);
-	const foreignObject = document.body.firstChild!.firstChild!;
-	Assert.ok(foreignObject instanceof SVGElement);
-
-	const div = foreignObject.firstChild! as Element;
-	Assert.ok(div instanceof HTMLDivElement);
-	Assert.is(div.namespaceURI, "http://www.w3.org/1999/xhtml");
-
-	const p = div.firstChild! as Element;
-	Assert.ok(p instanceof HTMLParagraphElement);
-	Assert.is(p.namespaceURI, "http://www.w3.org/1999/xhtml");
-});
-
-test("foreignObject itself gets SVG prop normalization", () => {
-	renderer.render(
-		<svg viewBox="0 0 200 200">
-			{/* eslint-disable-next-line crank/no-react-svg-props */}
-			<foreignObject clipPath="url(#clip)" colorInterpolation="sRGB">
-				<div>Hello</div>
-			</foreignObject>
-		</svg>,
-		document.body,
-	);
-	const foreignObject = document.body.firstChild!.firstChild! as SVGElement;
-	Assert.ok(foreignObject instanceof SVGElement);
-	// SVG props should be normalized on foreignObject itself
-	Assert.is(foreignObject.getAttribute("clip-path"), "url(#clip)");
-	Assert.is(foreignObject.getAttribute("color-interpolation"), "sRGB");
-});
-
-test("classes", () => {
-	renderer.render(
-		<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
-			<rect class="rectClass" x="10" y="10" width="100" height="100" />
-			<circle class="circleClass" cx="40" cy="50" r="26" />
-		</svg>,
-		document.body,
-	);
-
-	const rect = document.body.firstChild!.firstChild as SVGElement;
-	const circle = rect.nextSibling as SVGElement;
-	Assert.ok(rect instanceof SVGElement);
-	Assert.is(rect.tagName, "rect");
-	Assert.ok(circle instanceof SVGElement);
-	Assert.is(circle.tagName, "circle");
-	Assert.is(rect.getAttribute("class"), "rectClass");
-	Assert.is(circle.getAttribute("class"), "circleClass");
-});
-
-test("g", () => {
-	renderer.render(
-		<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-			<g fill="white" stroke="green" stroke-width="5">
-				<path d="M10 10" />
-				<path d="M 10 10 H 90 V 90 H 10 L 10 10" />
-			</g>
-		</svg>,
-		document.body,
-	);
-
-	const g = document.body.firstChild!.firstChild as SVGElement;
-	Assert.ok(g instanceof SVGElement);
-	Assert.is(g.tagName, "g");
-	Assert.ok(g.childNodes[0] instanceof SVGElement);
-	Assert.ok(g.childNodes[1] instanceof SVGElement);
-});
-
-test("nested", () => {
-	renderer.render(
-		<svg width="750" height="500" style="background: gray">
-			<svg x="200" y="200">
-				<circle cx="50" cy="50" r="50" style="fill: red" />
-			</svg>
-		</svg>,
-		document.body,
-	);
-	const nested = document.body.firstChild!.firstChild as SVGElement;
-	Assert.ok(nested instanceof SVGElement);
-	Assert.is(nested.tagName, "svg");
-	Assert.ok(nested.firstChild instanceof SVGElement);
-	Assert.is((nested.firstChild as SVGElement).tagName, "circle");
-});
-
-test("non-string values", () => {
-	renderer.render(
-		<svg xmlns="http://www.w3.org/2000/svg">
-			<rect class="rectClass" x={10} y={20.5} width={5000} height={null} />
-		</svg>,
-		document.body,
-	);
-
-	const rect = document.body.firstChild!.firstChild! as SVGElement;
-	Assert.ok(rect instanceof SVGElement);
-	Assert.is(rect.getAttribute("x"), "10");
-	Assert.is(rect.getAttribute("y"), "20.5");
-	Assert.is(rect.getAttribute("width"), "5000");
-	Assert.is(rect.getAttribute("height"), null);
-});
-
-test("custom attributes", () => {
-	renderer.render(
-		<svg xmlns="http://www.w3.org/2000/svg">
-			<circle cx="25" cy="10" r="5" data-foo="abc" barBaz={true} />
-		</svg>,
-		document.body,
-	);
-
-	const circle = document.body.firstChild!.firstChild! as SVGElement;
-	Assert.ok(circle instanceof SVGElement);
-	Assert.is(circle.getAttribute("cx"), "25");
-	Assert.is(circle.getAttribute("cy"), "10");
-	Assert.is(circle.getAttribute("r"), "5");
-	Assert.is(circle.getAttribute("data-foo"), "abc");
-	Assert.is(circle.getAttribute("barBaz"), "");
-	Assert.is(circle.getAttribute("does-not-exist"), null);
-});
-
-/* eslint-disable crank/no-react-svg-props */
-test("React-style camelCase SVG attributes", () => {
-	renderer.render(
-		<svg>
-			<path
-				strokeWidth="2"
-				strokeLinecap="round"
-				fillOpacity="0.5"
-				clipPath="url(#clip)"
-			/>
-		</svg>,
-		document.body,
-	);
-
-	const path = document.body.firstChild!.firstChild! as SVGElement;
-	Assert.ok(path instanceof SVGElement);
-	Assert.is(path.getAttribute("stroke-width"), "2");
-	Assert.is(path.getAttribute("stroke-linecap"), "round");
-	Assert.is(path.getAttribute("fill-opacity"), "0.5");
-	Assert.is(path.getAttribute("clip-path"), "url(#clip)");
-});
-
-test("React-style text SVG attributes", () => {
-	renderer.render(
-		<svg>
-			<text textAnchor="middle" dominantBaseline="central" />
-		</svg>,
-		document.body,
-	);
-
-	const text = document.body.firstChild!.firstChild! as SVGElement;
-	Assert.is(text.getAttribute("text-anchor"), "middle");
-	Assert.is(text.getAttribute("dominant-baseline"), "central");
-});
-
-test("SVG camelCase attributes that are already correct", () => {
-	renderer.render(
-		<svg viewBox="0 0 100 100" preserveAspectRatio="xMidYMid">
-			<circle cx="50" cy="50" r="40" />
-		</svg>,
-		document.body,
-	);
-
-	const svg = document.body.firstChild! as SVGElement;
-	Assert.is(svg.getAttribute("viewBox"), "0 0 100 100");
-	Assert.is(svg.getAttribute("preserveAspectRatio"), "xMidYMid");
-});
-
-test.run();

--- a/test/sync-function.tsx
+++ b/test/sync-function.tsx
@@ -1,125 +1,123 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import * as Sinon from "sinon";
 
 import {createElement} from "../src/crank.js";
 import type {Context, Element} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("sync function");
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
+describe("sync function", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
+
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
+
+	test("basic", () => {
+		function Component({message}: {message: string}): Element {
+			return <span>{message}</span>;
+		}
+
+		renderer.render(
+			<div>
+				<Component message="Hello" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+
+		renderer.render(
+			<div>
+				<Component message="Goodbye" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Goodbye</span></div>");
+	});
+
+	test("rerender different return value", () => {
+		function Component({ChildTag}: {ChildTag: string}): Element {
+			return <ChildTag>Hello world</ChildTag>;
+		}
+
+		renderer.render(<Component ChildTag="div" />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello world</div>");
+		renderer.render(<Component ChildTag="span" />, document.body);
+		expect(document.body.innerHTML).toBe("<span>Hello world</span>");
+	});
+
+	test("async children enqueue", async () => {
+		const fn = Sinon.fake();
+		async function Child({message}: {message: string}): Promise<Element> {
+			fn();
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			return <div>{message}</div>;
+		}
+
+		function Parent({message}: {message: string}): Element {
+			return <Child message={message} />;
+		}
+
+		const p1 = renderer.render(<Parent message="Hello 1" />, document.body);
+		const p2 = renderer.render(<Parent message="Hello 2" />, document.body);
+		const p3 = renderer.render(<Parent message="Hello 3" />, document.body);
+		const p4 = renderer.render(<Parent message="Hello 4" />, document.body);
+		expect(await p1).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>Hello 1</div>");
+		expect(await p2).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>Hello 4</div>");
+		expect(await p3).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>Hello 4</div>");
+		const p5 = renderer.render(<Parent message="Hello 5" />, document.body);
+		const p6 = renderer.render(<Parent message="Hello 6" />, document.body);
+		const p7 = renderer.render(<Parent message="Hello 7" />, document.body);
+		const p8 = renderer.render(<Parent message="Hello 8" />, document.body);
+		expect(await p4).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>Hello 4</div>");
+		expect(await p5).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>Hello 5</div>");
+		expect(await p6).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>Hello 8</div>");
+		expect(await p7).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>Hello 8</div>");
+		expect(await p8).toBe(document.body.firstChild);
+		expect(document.body.innerHTML).toBe("<div>Hello 8</div>");
+		expect(fn.callCount).toBe(4);
+	});
+
+	test("refresh called on unmounted component", () => {
+		let ctx!: Context;
+		function Component(this: Context) {
+			ctx = this;
+			return null;
+		}
+
+		renderer.render(<Component />, document.body);
+		renderer.render(null, document.body);
+		const mock = Sinon.stub(console, "error");
+		try {
+			ctx.refresh();
+			ctx.refresh();
+			expect(mock.callCount).toBe(2);
+		} finally {
+			mock.restore();
+		}
+	});
+
+	test("context is passed as second argument", () => {
+		let ctx1!: Context;
+		let ctx2!: Context;
+
+		function Component(this: Context, _props: any, ctx: Context) {
+			ctx1 = this;
+			ctx2 = ctx;
+			return null;
+		}
+
+		renderer.render(<Component />, document.body);
+		expect(ctx1).toBe(ctx2);
+	});
 });
-
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
-
-test("basic", () => {
-	function Component({message}: {message: string}): Element {
-		return <span>{message}</span>;
-	}
-
-	renderer.render(
-		<div>
-			<Component message="Hello" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-
-	renderer.render(
-		<div>
-			<Component message="Goodbye" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Goodbye</span></div>");
-});
-
-test("rerender different return value", () => {
-	function Component({ChildTag}: {ChildTag: string}): Element {
-		return <ChildTag>Hello world</ChildTag>;
-	}
-
-	renderer.render(<Component ChildTag="div" />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello world</div>");
-	renderer.render(<Component ChildTag="span" />, document.body);
-	Assert.is(document.body.innerHTML, "<span>Hello world</span>");
-});
-
-test("async children enqueue", async () => {
-	const fn = Sinon.fake();
-	async function Child({message}: {message: string}): Promise<Element> {
-		fn();
-		await new Promise((resolve) => setTimeout(resolve, 100));
-		return <div>{message}</div>;
-	}
-
-	function Parent({message}: {message: string}): Element {
-		return <Child message={message} />;
-	}
-
-	const p1 = renderer.render(<Parent message="Hello 1" />, document.body);
-	const p2 = renderer.render(<Parent message="Hello 2" />, document.body);
-	const p3 = renderer.render(<Parent message="Hello 3" />, document.body);
-	const p4 = renderer.render(<Parent message="Hello 4" />, document.body);
-	Assert.is(await p1, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>Hello 1</div>");
-	Assert.is(await p2, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>Hello 4</div>");
-	Assert.is(await p3, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>Hello 4</div>");
-	const p5 = renderer.render(<Parent message="Hello 5" />, document.body);
-	const p6 = renderer.render(<Parent message="Hello 6" />, document.body);
-	const p7 = renderer.render(<Parent message="Hello 7" />, document.body);
-	const p8 = renderer.render(<Parent message="Hello 8" />, document.body);
-	Assert.is(await p4, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>Hello 4</div>");
-	Assert.is(await p5, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>Hello 5</div>");
-	Assert.is(await p6, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>Hello 8</div>");
-	Assert.is(await p7, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>Hello 8</div>");
-	Assert.is(await p8, document.body.firstChild);
-	Assert.is(document.body.innerHTML, "<div>Hello 8</div>");
-	Assert.is(fn.callCount, 4);
-});
-
-test("refresh called on unmounted component", () => {
-	let ctx!: Context;
-	function Component(this: Context) {
-		ctx = this;
-		return null;
-	}
-
-	renderer.render(<Component />, document.body);
-	renderer.render(null, document.body);
-	const mock = Sinon.stub(console, "error");
-	try {
-		ctx.refresh();
-		ctx.refresh();
-		Assert.is(mock.callCount, 2);
-	} finally {
-		mock.restore();
-	}
-});
-
-test("context is passed as second argument", () => {
-	let ctx1!: Context;
-	let ctx2!: Context;
-
-	function Component(this: Context, _props: any, ctx: Context) {
-		ctx1 = this;
-		ctx2 = ctx;
-		return null;
-	}
-
-	renderer.render(<Component />, document.body);
-	Assert.is(ctx1, ctx2);
-});
-
-test.run();

--- a/test/sync-generator.tsx
+++ b/test/sync-generator.tsx
@@ -1,752 +1,759 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import * as Sinon from "sinon";
 
 import {createElement, Fragment, Raw} from "../src/crank.js";
 import type {Child, Children, Context, Element} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("sync generator");
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
-
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
-
-test("basic", () => {
-	const Component = Sinon.fake(function* Component(
-		this: Context,
-		{message}: {message: string},
-	): Generator<Element> {
-		let i = 0;
-		for ({message} of this) {
-			if (++i > 2) {
-				return <span>Final</span>;
-			}
-
-			yield <span>{message}</span>;
-		}
+describe("sync generator", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
 	});
 
-	renderer.render(
-		<div>
-			<Component message="Hello 1" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 1</span></div>");
-	renderer.render(
-		<div>
-			<Component message="Hello 2" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Hello 2</span></div>");
-	renderer.render(
-		<div>
-			<Component message="Hello 3" />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Final</span></div>");
-	Assert.is(Component.callCount, 1);
-});
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
 
-test("refresh", () => {
-	let ctx!: Context;
-	function* Component(this: Context): Generator<Element> {
-		ctx = this;
-		let i = 1;
-		while (true) {
-			yield <span>Hello {i++}</span>;
-		}
-	}
+	test("basic", () => {
+		const Component = Sinon.fake(function* Component(
+			this: Context,
+			{message}: {message: string},
+		): Generator<Element> {
+			let i = 0;
+			for ({message} of this) {
+				if (++i > 2) {
+					return <span>Final</span>;
+				}
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-
-	Assert.is(document.body.innerHTML, "<div><span>Hello 1</span></div>");
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div><span>Hello 2</span></div>");
-	ctx.refresh();
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div><span>Hello 4</span></div>");
-});
-
-test("updating undefined to component", () => {
-	function NestedComponent() {
-		return <span>Hello</span>;
-	}
-
-	let ctx!: Context;
-	function* Component(this: Context): Generator<Element> {
-		ctx = this;
-		let mounted = false;
-		while (true) {
-			let component: Element | undefined;
-			if (mounted) {
-				component = <NestedComponent />;
+				yield <span>{message}</span>;
 			}
+		});
 
-			yield <span>{component}</span>;
-			mounted = true;
-		}
-	}
+		renderer.render(
+			<div>
+				<Component message="Hello 1" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 1</span></div>");
+		renderer.render(
+			<div>
+				<Component message="Hello 2" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Hello 2</span></div>");
+		renderer.render(
+			<div>
+				<Component message="Hello 3" />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Final</span></div>");
+		expect(Component.callCount).toBe(1);
+	});
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span></span></div>");
-	ctx.refresh();
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span><span>Hello</span></span></div>",
-	);
-});
-
-test("refresh undefined to nested component", () => {
-	function NestedComponent() {
-		return <span>Hello</span>;
-	}
-
-	let ctx!: Context;
-	function* Component(this: Context): Generator<Element> {
-		ctx = this;
-		let mounted = false;
-		while (true) {
-			let component: Element | undefined;
-			if (mounted) {
-				component = <NestedComponent />;
-			}
-
-			yield <span>{component}</span>;
-			mounted = true;
-		}
-	}
-
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span></span></div>");
-	ctx.refresh();
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span><span>Hello</span></span></div>",
-	);
-});
-
-test("refresh null to element", () => {
-	let ctx!: Context;
-	function* Component(this: Context): Generator<Child> {
-		ctx = this;
-		yield null;
-		yield <span>Hello</span>;
-		yield null;
-		yield <span>Hello again</span>;
-	}
-
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div></div>");
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div></div>");
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div><span>Hello again</span></div>");
-});
-
-test("refresh with different child", () => {
-	let ctx!: Context;
-	function* Component(this: Context): Generator<Child> {
-		ctx = this;
-		yield <span>1</span>;
-		yield <div>2</div>;
-		yield <span>3</span>;
-		yield null;
-	}
-
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div><div>2</div></div>");
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div><span>3</span></div>");
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div></div>");
-});
-
-test("refresh with different child and siblings", () => {
-	let ctx!: Context;
-	function* Component(this: Context): Generator<Child> {
-		if (ctx === undefined) {
+	test("refresh", () => {
+		let ctx!: Context;
+		function* Component(this: Context): Generator<Element> {
 			ctx = this;
+			let i = 1;
+			while (true) {
+				yield <span>Hello {i++}</span>;
+			}
 		}
 
-		yield <span>Hello</span>;
-		yield <div>Hello</div>;
-		yield <span>Hello</span>;
-		yield null;
-	}
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
 
-	renderer.render(
-		<div>
-			<Component />
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Hello</span><span>Hello</span></div>",
-	);
-	ctx.refresh();
-	Assert.is(
-		document.body.innerHTML,
-		"<div><div>Hello</div><span>Hello</span></div>",
-	);
-	ctx.refresh();
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>Hello</span><span>Hello</span></div>",
-	);
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-});
+		expect(document.body.innerHTML).toBe("<div><span>Hello 1</span></div>");
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div><span>Hello 2</span></div>");
+		ctx.refresh();
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div><span>Hello 4</span></div>");
+	});
 
-test("refresh fragment", () => {
-	let ctx!: Context;
-	function* Component(this: Context): Generator<Child> {
-		ctx = this;
-		yield (
-			<Fragment>
-				{null}
-				<span>2</span>
-				{null}
-			</Fragment>
-		);
-		yield (
-			<Fragment>
-				<span>1</span>
-				<span>2</span>
-				<span>3</span>
-			</Fragment>
-		);
-		yield (
-			<Fragment>
-				<span>1</span>
-				{null}
-				{null}
-			</Fragment>
-		);
-		yield (
-			<Fragment>
-				{null}
-				{null}
-				<span>3</span>
-			</Fragment>
-		);
-		yield (
-			<Fragment>
-				{true}
-				{false}
-				{undefined}
-			</Fragment>
-		);
-	}
-
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>2</span></div>");
-	ctx.refresh();
-	Assert.is(
-		document.body.innerHTML,
-		"<div><span>1</span><span>2</span><span>3</span></div>",
-	);
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div><span>1</span></div>");
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div><span>3</span></div>");
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div></div>");
-});
-
-test("refresh component yielding raw with static content", () => {
-	let ctx!: Context;
-	function* Component(this: Context): Generator<Child> {
-		ctx = this;
-		while (true) {
-			yield (
-				<span>
-					<Raw value="Hello" />
-				</span>
-			);
+	test("updating undefined to component", () => {
+		function NestedComponent() {
+			return <span>Hello</span>;
 		}
-	}
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div><span>Hello</span></div>");
-});
+		let ctx!: Context;
+		function* Component(this: Context): Generator<Element> {
+			ctx = this;
+			let mounted = false;
+			while (true) {
+				let component: Element | undefined;
+				if (mounted) {
+					component = <NestedComponent />;
+				}
 
-test("async children", async () => {
-	const mock = Sinon.fake();
-	async function Component({children}: {children: Children}): Promise<Element> {
-		await new Promise((resolve) => setTimeout(resolve, 100));
-		return <span>{children}</span>;
-	}
-
-	let ctx!: Context;
-	function* Gen(this: Context): Generator<Element> {
-		ctx = this;
-		let i = 0;
-		for (const _ of this) {
-			const yielded = yield <Component>Hello {i++}</Component>;
-			mock((yielded as any).outerHTML);
+				yield <span>{component}</span>;
+				mounted = true;
+			}
 		}
-	}
 
-	const renderP = renderer.render(
-		<div>
-			<Gen />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "");
-	await renderP;
-	Assert.is(document.body.innerHTML, "<div><span>Hello 0</span></div>");
-	const refreshP = ctx.refresh();
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(mock.callCount, 1);
-	Assert.is(mock.lastCall.firstArg, "<span>Hello 0</span>");
-	Assert.is(document.body.innerHTML, "<div><span>Hello 0</span></div>");
-	await refreshP;
-	Assert.is(document.body.innerHTML, "<div><span>Hello 1</span></div>");
-	ctx.refresh();
-	await new Promise((resolve) => setTimeout(resolve));
-	Assert.is(mock.callCount, 2);
-	Assert.is(mock.lastCall.firstArg, "<span>Hello 1</span>");
-});
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span></span></div>");
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe(
+			"<div><span><span>Hello</span></span></div>",
+		);
+	});
 
-test("refreshing doesn’t cause siblings to update", () => {
-	const mock = Sinon.fake();
-	function Sibling(): Element {
-		mock();
-		return <div>Sibling</div>;
-	}
-
-	let ctx!: Context;
-	function* Component(this: Context): Generator<Element> {
-		ctx = this;
-		let i = 0;
-		while (true) {
-			i++;
-			yield <div>Hello {i}</div>;
+	test("refresh undefined to nested component", () => {
+		function NestedComponent() {
+			return <span>Hello</span>;
 		}
-	}
-	renderer.render(
-		<Fragment>
-			<Component />
-			<Sibling />
-		</Fragment>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div>Hello 1</div><div>Sibling</div>");
-	Assert.is(mock.callCount, 1);
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div>Hello 2</div><div>Sibling</div>");
-	Assert.is(mock.callCount, 1);
-	ctx.refresh();
-	ctx.refresh();
-	ctx.refresh();
-	ctx.refresh();
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div>Hello 7</div><div>Sibling</div>");
-	Assert.is(mock.callCount, 1);
-	renderer.render(
-		<Fragment>
-			<Component />
-			<Sibling />
-		</Fragment>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div>Hello 8</div><div>Sibling</div>");
-	Assert.is(mock.callCount, 2);
-});
 
-test("refreshing child doesn’t cause siblings to update", () => {
-	const mock = Sinon.fake();
-	function Sibling(): Element {
-		mock();
-		return <div>Sibling</div>;
-	}
+		let ctx!: Context;
+		function* Component(this: Context): Generator<Element> {
+			ctx = this;
+			let mounted = false;
+			while (true) {
+				let component: Element | undefined;
+				if (mounted) {
+					component = <NestedComponent />;
+				}
 
-	let ctx!: Context;
-	function* Child(this: Context): Generator<Element> {
-		ctx = this;
-		let i = 0;
-		while (true) {
-			i++;
-			yield <div>Hello {i}</div>;
+				yield <span>{component}</span>;
+				mounted = true;
+			}
 		}
-	}
 
-	function* Parent(): Generator<Element> {
-		while (true) {
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span></span></div>");
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe(
+			"<div><span><span>Hello</span></span></div>",
+		);
+	});
+
+	test("refresh null to element", () => {
+		let ctx!: Context;
+		function* Component(this: Context): Generator<Child> {
+			ctx = this;
+			yield null;
+			yield <span>Hello</span>;
+			yield null;
+			yield <span>Hello again</span>;
+		}
+
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div></div>");
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div></div>");
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div><span>Hello again</span></div>");
+	});
+
+	test("refresh with different child", () => {
+		let ctx!: Context;
+		function* Component(this: Context): Generator<Child> {
+			ctx = this;
+			yield <span>1</span>;
+			yield <div>2</div>;
+			yield <span>3</span>;
+			yield null;
+		}
+
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div><div>2</div></div>");
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div><span>3</span></div>");
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div></div>");
+	});
+
+	test("refresh with different child and siblings", () => {
+		let ctx!: Context;
+		function* Component(this: Context): Generator<Child> {
+			if (ctx === undefined) {
+				ctx = this;
+			}
+
+			yield <span>Hello</span>;
+			yield <div>Hello</div>;
+			yield <span>Hello</span>;
+			yield null;
+		}
+
+		renderer.render(
+			<div>
+				<Component />
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Hello</span><span>Hello</span></div>",
+		);
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe(
+			"<div><div>Hello</div><span>Hello</span></div>",
+		);
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe(
+			"<div><span>Hello</span><span>Hello</span></div>",
+		);
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+	});
+
+	test("refresh fragment", () => {
+		let ctx!: Context;
+		function* Component(this: Context): Generator<Child> {
+			ctx = this;
 			yield (
 				<Fragment>
-					<Child />
-					<Sibling />
+					{null}
+					<span>2</span>
+					{null}
+				</Fragment>
+			);
+			yield (
+				<Fragment>
+					<span>1</span>
+					<span>2</span>
+					<span>3</span>
+				</Fragment>
+			);
+			yield (
+				<Fragment>
+					<span>1</span>
+					{null}
+					{null}
+				</Fragment>
+			);
+			yield (
+				<Fragment>
+					{null}
+					{null}
+					<span>3</span>
+				</Fragment>
+			);
+			yield (
+				<Fragment>
+					{true}
+					{false}
+					{undefined}
 				</Fragment>
 			);
 		}
-	}
 
-	renderer.render(<Parent />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello 1</div><div>Sibling</div>");
-	Assert.is(mock.callCount, 1);
-	ctx.refresh();
-	Assert.is(document.body.innerHTML, "<div>Hello 2</div><div>Sibling</div>");
-	Assert.is(mock.callCount, 1);
-});
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>2</span></div>");
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe(
+			"<div><span>1</span><span>2</span><span>3</span></div>",
+		);
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div><span>1</span></div>");
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div><span>3</span></div>");
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div></div>");
+	});
 
-test("yield resumes with a node", () => {
-	let html: string | undefined;
-	function* Component(): Generator<Element> {
-		let i = 0;
-		while (true) {
-			const node: any = yield <div id={i}>{i}</div>;
-			html = node.outerHTML;
-			i++;
+	test("refresh component yielding raw with static content", () => {
+		let ctx!: Context;
+		function* Component(this: Context): Generator<Child> {
+			ctx = this;
+			while (true) {
+				yield (
+					<span>
+						<Raw value="Hello" />
+					</span>
+				);
+			}
 		}
-	}
 
-	renderer.render(<Component />, document.body);
-	Assert.is(html, undefined);
-	renderer.render(<Component />, document.body);
-	Assert.is(html, '<div id="0">0</div>');
-	Assert.is(document.body.innerHTML, '<div id="1">1</div>');
-	renderer.render(<Component />, document.body);
-	Assert.is(html, '<div id="1">1</div>');
-	Assert.is(document.body.innerHTML, '<div id="2">2</div>');
-});
-
-test("generator returns", () => {
-	const Component = Sinon.fake(function* Component(): Generator<Child> {
-		yield "Hello";
-		return "Goodbye";
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe("<div><span>Hello</span></div>");
 	});
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div>Hello</div>");
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div>Goodbye</div>");
-	Assert.is(Component.callCount, 1);
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div>Hello</div>");
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div>Goodbye</div>");
-	Assert.is(Component.callCount, 2);
-	renderer.render(<div>{null}</div>, document.body);
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div>Hello</div>");
-	Assert.is(Component.callCount, 3);
-});
+	test("async children", async () => {
+		const mock = Sinon.fake();
+		async function Component({
+			children,
+		}: {
+			children: Children;
+		}): Promise<Element> {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			return <span>{children}</span>;
+		}
 
-// TODO: not sure what the point of this test is with the new generator return behavior
-test("generator returns with async children and concurrent updates", async () => {
-	async function Child(): Promise<string> {
-		return "child";
-	}
+		let ctx!: Context;
+		function* Gen(this: Context): Generator<Element> {
+			ctx = this;
+			let i = 0;
+			for (const _ of this) {
+				const yielded = yield <Component>Hello {i++}</Component>;
+				mock((yielded as any).outerHTML);
+			}
+		}
 
-	// eslint-disable-next-line require-yield
-	const Component = Sinon.fake(function* Component(): Generator<Child> {
-		return <Child />;
+		const renderP = renderer.render(
+			<div>
+				<Gen />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("");
+		await renderP;
+		expect(document.body.innerHTML).toBe("<div><span>Hello 0</span></div>");
+		const refreshP = ctx.refresh();
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(mock.callCount).toBe(1);
+		expect(mock.lastCall.firstArg).toBe("<span>Hello 0</span>");
+		expect(document.body.innerHTML).toBe("<div><span>Hello 0</span></div>");
+		await refreshP;
+		expect(document.body.innerHTML).toBe("<div><span>Hello 1</span></div>");
+		ctx.refresh();
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(mock.callCount).toBe(2);
+		expect(mock.lastCall.firstArg).toBe("<span>Hello 1</span>");
 	});
 
-	renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	await renderer.render(
-		<div>
-			<Component />
-		</div>,
-		document.body,
-	);
-	Assert.is(document.body.innerHTML, "<div>child</div>");
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(Component.callCount, 2);
-});
+	test("refreshing doesn’t cause siblings to update", () => {
+		const mock = Sinon.fake();
+		function Sibling(): Element {
+			mock();
+			return <div>Sibling</div>;
+		}
 
-test("while true try/finally", () => {
-	const beforeYieldFn = Sinon.fake();
-	const afterYieldFn = Sinon.fake();
-	const finallyFn = Sinon.fake();
-	function* Component() {
-		try {
+		let ctx!: Context;
+		function* Component(this: Context): Generator<Element> {
+			ctx = this;
 			let i = 0;
 			while (true) {
-				beforeYieldFn();
-				yield <div>Hello {i++}</div>;
-				afterYieldFn();
+				i++;
+				yield <div>Hello {i}</div>;
 			}
-		} finally {
-			finallyFn();
 		}
-	}
+		renderer.render(
+			<Fragment>
+				<Component />
+				<Sibling />
+			</Fragment>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div>Hello 1</div><div>Sibling</div>",
+		);
+		expect(mock.callCount).toBe(1);
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe(
+			"<div>Hello 2</div><div>Sibling</div>",
+		);
+		expect(mock.callCount).toBe(1);
+		ctx.refresh();
+		ctx.refresh();
+		ctx.refresh();
+		ctx.refresh();
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe(
+			"<div>Hello 7</div><div>Sibling</div>",
+		);
+		expect(mock.callCount).toBe(1);
+		renderer.render(
+			<Fragment>
+				<Component />
+				<Sibling />
+			</Fragment>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe(
+			"<div>Hello 8</div><div>Sibling</div>",
+		);
+		expect(mock.callCount).toBe(2);
+	});
 
-	renderer.render(<Component />, document.body);
-	Assert.is(beforeYieldFn.callCount, 1);
-	Assert.is(afterYieldFn.callCount, 0);
-	renderer.render(<Component />, document.body);
-	Assert.is(beforeYieldFn.callCount, 2);
-	Assert.is(afterYieldFn.callCount, 1);
-	renderer.render(<Component />, document.body);
-	Assert.is(beforeYieldFn.callCount, 3);
-	Assert.is(afterYieldFn.callCount, 2);
-	Assert.is(document.body.innerHTML, "<div>Hello 2</div>");
-	Assert.is(finallyFn.callCount, 0);
-	renderer.render(null, document.body);
-	Assert.is(beforeYieldFn.callCount, 3);
-	Assert.is(afterYieldFn.callCount, 2);
-	Assert.is(document.body.innerHTML, "");
-	Assert.is(finallyFn.callCount, 1);
-});
+	test("refreshing child doesn’t cause siblings to update", () => {
+		const mock = Sinon.fake();
+		function Sibling(): Element {
+			mock();
+			return <div>Sibling</div>;
+		}
 
-test("for... of", () => {
-	const beforeYieldFn = Sinon.fake();
-	const afterYieldFn = Sinon.fake();
-	const afterLoopFn = Sinon.fake();
-	const finallyFn = Sinon.fake();
-	function* Component(this: Context) {
-		try {
+		let ctx!: Context;
+		function* Child(this: Context): Generator<Element> {
+			ctx = this;
+			let i = 0;
+			while (true) {
+				i++;
+				yield <div>Hello {i}</div>;
+			}
+		}
+
+		function* Parent(): Generator<Element> {
+			while (true) {
+				yield (
+					<Fragment>
+						<Child />
+						<Sibling />
+					</Fragment>
+				);
+			}
+		}
+
+		renderer.render(<Parent />, document.body);
+		expect(document.body.innerHTML).toBe(
+			"<div>Hello 1</div><div>Sibling</div>",
+		);
+		expect(mock.callCount).toBe(1);
+		ctx.refresh();
+		expect(document.body.innerHTML).toBe(
+			"<div>Hello 2</div><div>Sibling</div>",
+		);
+		expect(mock.callCount).toBe(1);
+	});
+
+	test("yield resumes with a node", () => {
+		let html: string | undefined;
+		function* Component(): Generator<Element> {
+			let i = 0;
+			while (true) {
+				const node: any = yield <div id={i}>{i}</div>;
+				html = node.outerHTML;
+				i++;
+			}
+		}
+
+		renderer.render(<Component />, document.body);
+		expect(html).toBe(undefined);
+		renderer.render(<Component />, document.body);
+		expect(html).toBe('<div id="0">0</div>');
+		expect(document.body.innerHTML).toBe('<div id="1">1</div>');
+		renderer.render(<Component />, document.body);
+		expect(html).toBe('<div id="1">1</div>');
+		expect(document.body.innerHTML).toBe('<div id="2">2</div>');
+	});
+
+	test("generator returns", () => {
+		const Component = Sinon.fake(function* Component(): Generator<Child> {
+			yield "Hello";
+			return "Goodbye";
+		});
+
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div>Hello</div>");
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div>Goodbye</div>");
+		expect(Component.callCount).toBe(1);
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div>Hello</div>");
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div>Goodbye</div>");
+		expect(Component.callCount).toBe(2);
+		renderer.render(<div>{null}</div>, document.body);
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div>Hello</div>");
+		expect(Component.callCount).toBe(3);
+	});
+
+	// TODO: not sure what the point of this test is with the new generator return behavior
+	test("generator returns with async children and concurrent updates", async () => {
+		async function Child(): Promise<string> {
+			return "child";
+		}
+
+		// eslint-disable-next-line require-yield
+		const Component = Sinon.fake(function* Component(): Generator<Child> {
+			return <Child />;
+		});
+
+		renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		await renderer.render(
+			<div>
+				<Component />
+			</div>,
+			document.body,
+		);
+		expect(document.body.innerHTML).toBe("<div>child</div>");
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(Component.callCount).toBe(2);
+	});
+
+	test("while true try/finally", () => {
+		const beforeYieldFn = Sinon.fake();
+		const afterYieldFn = Sinon.fake();
+		const finallyFn = Sinon.fake();
+		function* Component() {
+			try {
+				let i = 0;
+				while (true) {
+					beforeYieldFn();
+					yield <div>Hello {i++}</div>;
+					afterYieldFn();
+				}
+			} finally {
+				finallyFn();
+			}
+		}
+
+		renderer.render(<Component />, document.body);
+		expect(beforeYieldFn.callCount).toBe(1);
+		expect(afterYieldFn.callCount).toBe(0);
+		renderer.render(<Component />, document.body);
+		expect(beforeYieldFn.callCount).toBe(2);
+		expect(afterYieldFn.callCount).toBe(1);
+		renderer.render(<Component />, document.body);
+		expect(beforeYieldFn.callCount).toBe(3);
+		expect(afterYieldFn.callCount).toBe(2);
+		expect(document.body.innerHTML).toBe("<div>Hello 2</div>");
+		expect(finallyFn.callCount).toBe(0);
+		renderer.render(null, document.body);
+		expect(beforeYieldFn.callCount).toBe(3);
+		expect(afterYieldFn.callCount).toBe(2);
+		expect(document.body.innerHTML).toBe("");
+		expect(finallyFn.callCount).toBe(1);
+	});
+
+	test("for... of", () => {
+		const beforeYieldFn = Sinon.fake();
+		const afterYieldFn = Sinon.fake();
+		const afterLoopFn = Sinon.fake();
+		const finallyFn = Sinon.fake();
+		function* Component(this: Context) {
+			try {
+				let i = 0;
+				for ({} of this) {
+					beforeYieldFn();
+					yield <div>Hello {i++}</div>;
+					afterYieldFn();
+				}
+
+				afterLoopFn();
+			} finally {
+				finallyFn();
+			}
+		}
+
+		renderer.render(<Component />, document.body);
+		expect(beforeYieldFn.callCount).toBe(1);
+		expect(afterYieldFn.callCount).toBe(0);
+		renderer.render(<Component />, document.body);
+		expect(beforeYieldFn.callCount).toBe(2);
+		expect(afterYieldFn.callCount).toBe(1);
+		renderer.render(<Component />, document.body);
+		expect(beforeYieldFn.callCount).toBe(3);
+		expect(afterYieldFn.callCount).toBe(2);
+		expect(document.body.innerHTML).toBe("<div>Hello 2</div>");
+		expect(finallyFn.callCount).toBe(0);
+		renderer.render(null, document.body);
+		expect(beforeYieldFn.callCount).toBe(3);
+		expect(afterYieldFn.callCount).toBe(3);
+		expect(document.body.innerHTML).toBe("");
+		expect(afterLoopFn.callCount).toBe(1);
+		expect(finallyFn.callCount).toBe(1);
+	});
+
+	test("try/finally triggered by div", () => {
+		const mock = Sinon.fake();
+		function* Component(): Generator<Element> {
+			try {
+				let i = 0;
+				while (true) {
+					yield <div>Hello {i++}</div>;
+				}
+			} finally {
+				mock();
+			}
+		}
+
+		renderer.render(<Component />, document.body);
+		renderer.render(<Component />, document.body);
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello 2</div>");
+		expect(mock.callCount).toBe(0);
+		renderer.render(<div>Goodbye</div>, document.body);
+		expect(document.body.innerHTML).toBe("<div>Goodbye</div>");
+		expect(mock.callCount).toBe(1);
+	});
+
+	test("try/finally triggered by rendering string", () => {
+		const mock = Sinon.fake();
+		function* Component(): Generator<Element> {
+			try {
+				let i = 0;
+				while (true) {
+					yield <div>Hello {i++}</div>;
+				}
+			} finally {
+				mock();
+			}
+		}
+		renderer.render(<Component />, document.body);
+		renderer.render(<Component />, document.body);
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello 2</div>");
+		expect(mock.callCount).toBe(0);
+		renderer.render(["Goodbye", null], document.body);
+		expect(document.body.innerHTML).toBe("Goodbye");
+		expect(mock.callCount).toBe(1);
+	});
+
+	test("try/finally triggerd by rendering async", async () => {
+		const mock = Sinon.fake();
+		function* Component(): Generator<Element> {
+			try {
+				let i = 0;
+				while (true) {
+					yield <div>Hello {i++}</div>;
+				}
+			} finally {
+				mock();
+			}
+		}
+
+		async function Async(): Promise<Element> {
+			return <div>Goodbye</div>;
+		}
+
+		renderer.render(<Component />, document.body);
+		renderer.render(<Component />, document.body);
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello 2</div>");
+		expect(mock.callCount).toBe(0);
+		await renderer.render(<Async />, document.body);
+		expect(mock.callCount).toBe(1);
+		expect(document.body.innerHTML).toBe("<div>Goodbye</div>");
+	});
+
+	test("Context iterator returns on unmount", () => {
+		const mock = Sinon.fake();
+		function* Component(this: Context): Generator<Element> {
 			let i = 0;
 			for ({} of this) {
-				beforeYieldFn();
-				yield <div>Hello {i++}</div>;
-				afterYieldFn();
-			}
-
-			afterLoopFn();
-		} finally {
-			finallyFn();
-		}
-	}
-
-	renderer.render(<Component />, document.body);
-	Assert.is(beforeYieldFn.callCount, 1);
-	Assert.is(afterYieldFn.callCount, 0);
-	renderer.render(<Component />, document.body);
-	Assert.is(beforeYieldFn.callCount, 2);
-	Assert.is(afterYieldFn.callCount, 1);
-	renderer.render(<Component />, document.body);
-	Assert.is(beforeYieldFn.callCount, 3);
-	Assert.is(afterYieldFn.callCount, 2);
-	Assert.is(document.body.innerHTML, "<div>Hello 2</div>");
-	Assert.is(finallyFn.callCount, 0);
-	renderer.render(null, document.body);
-	Assert.is(beforeYieldFn.callCount, 3);
-	Assert.is(afterYieldFn.callCount, 3);
-	Assert.is(document.body.innerHTML, "");
-	Assert.is(afterLoopFn.callCount, 1);
-	Assert.is(finallyFn.callCount, 1);
-});
-
-test("try/finally triggered by div", () => {
-	const mock = Sinon.fake();
-	function* Component(): Generator<Element> {
-		try {
-			let i = 0;
-			while (true) {
 				yield <div>Hello {i++}</div>;
 			}
-		} finally {
+
 			mock();
 		}
-	}
 
-	renderer.render(<Component />, document.body);
-	renderer.render(<Component />, document.body);
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello 2</div>");
-	Assert.is(mock.callCount, 0);
-	renderer.render(<div>Goodbye</div>, document.body);
-	Assert.is(document.body.innerHTML, "<div>Goodbye</div>");
-	Assert.is(mock.callCount, 1);
-});
+		renderer.render(<Component />, document.body);
+		renderer.render(<Component />, document.body);
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello 2</div>");
+		expect(mock.callCount).toBe(0);
+		renderer.render(null, document.body);
+		expect(mock.callCount).toBe(1);
+	});
 
-test("try/finally triggered by rendering string", () => {
-	const mock = Sinon.fake();
-	function* Component(): Generator<Element> {
-		try {
+	test("return called when component continues to yield", () => {
+		const mock = Sinon.fake();
+		function* Component(this: Context, {}): Generator<Element> {
 			let i = 0;
-			while (true) {
+			for ({} of this) {
 				yield <div>Hello {i++}</div>;
 			}
-		} finally {
+
 			mock();
-		}
-	}
-	renderer.render(<Component />, document.body);
-	renderer.render(<Component />, document.body);
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello 2</div>");
-	Assert.is(mock.callCount, 0);
-	renderer.render(["Goodbye", null], document.body);
-	Assert.is(document.body.innerHTML, "Goodbye");
-	Assert.is(mock.callCount, 1);
-});
-
-test("try/finally triggerd by rendering async", async () => {
-	const mock = Sinon.fake();
-	function* Component(): Generator<Element> {
-		try {
-			let i = 0;
-			while (true) {
-				yield <div>Hello {i++}</div>;
-			}
-		} finally {
+			yield <div>Exited {i++}</div>;
 			mock();
+			throw new Error("unreachable");
 		}
-	}
 
-	async function Async(): Promise<Element> {
-		return <div>Goodbye</div>;
-	}
+		renderer.render(<Component />, document.body);
+		renderer.render(<Component />, document.body);
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello 2</div>");
+		expect(mock.callCount).toBe(0);
+		renderer.render(null, document.body);
+		expect(mock.callCount).toBe(1);
+	});
 
-	renderer.render(<Component />, document.body);
-	renderer.render(<Component />, document.body);
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello 2</div>");
-	Assert.is(mock.callCount, 0);
-	await renderer.render(<Async />, document.body);
-	Assert.is(mock.callCount, 1);
-	Assert.is(document.body.innerHTML, "<div>Goodbye</div>");
-});
-
-test("Context iterator returns on unmount", () => {
-	const mock = Sinon.fake();
-	function* Component(this: Context): Generator<Element> {
+	test("multiple iterations without a yield throw", () => {
 		let i = 0;
-		for ({} of this) {
-			yield <div>Hello {i++}</div>;
-		}
+		function* Component(this: Context) {
+			for (const _ of this) {
+				// just so the test suite doesn’t enter an infinite loop
+				if (i > 100) {
+					yield;
+					return;
+				}
 
-		mock();
-	}
-
-	renderer.render(<Component />, document.body);
-	renderer.render(<Component />, document.body);
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello 2</div>");
-	Assert.is(mock.callCount, 0);
-	renderer.render(null, document.body);
-	Assert.is(mock.callCount, 1);
-});
-
-test("return called when component continues to yield", () => {
-	const mock = Sinon.fake();
-	function* Component(this: Context, {}): Generator<Element> {
-		let i = 0;
-		for ({} of this) {
-			yield <div>Hello {i++}</div>;
-		}
-
-		mock();
-		yield <div>Exited {i++}</div>;
-		mock();
-		Assert.unreachable();
-	}
-
-	renderer.render(<Component />, document.body);
-	renderer.render(<Component />, document.body);
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello 2</div>");
-	Assert.is(mock.callCount, 0);
-	renderer.render(null, document.body);
-	Assert.is(mock.callCount, 1);
-});
-
-test("multiple iterations without a yield throw", () => {
-	let i = 0;
-	function* Component(this: Context) {
-		for (const _ of this) {
-			// just so the test suite doesn’t enter an infinite loop
-			if (i > 100) {
-				yield;
-				return;
+				i++;
 			}
-
-			i++;
 		}
-	}
 
-	Assert.throws(
-		() => renderer.render(<Component />, document.body),
-		"Context iterated twice",
-	);
-	Assert.is(i, 1);
+		expect(() => renderer.render(<Component />, document.body)).toThrow(
+			"context iterated twice without a yield",
+		);
+		expect(i).toBe(1);
+	});
 });
-
-test.run();

--- a/test/text.tsx
+++ b/test/text.tsx
@@ -1,112 +1,120 @@
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 /// <ref lib="dom" />
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
 import {createElement, Text} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 import * as Sinon from "sinon";
 
-const test = suite("Text");
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
+describe("Text", () => {
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
+
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+	});
+
+	test("render text element", () => {
+		const element = <Text value="Hello, World!" />;
+		const root = document.createElement("div");
+		renderer.render(element, root);
+		expect(root.innerHTML).toBe("Hello, World!");
+	});
+
+	test("component which returns string produces text node", () => {
+		function Component({text}: {text: string}) {
+			return text;
+		}
+
+		const result = renderer.render(
+			<Component text="Hello, Crank!" />,
+			document.body,
+		);
+
+		expect(result).toBeInstanceOf(globalThis.Text);
+		expect((result as globalThis.Text).data).toBe("Hello, Crank!");
+		expect(document.body.innerHTML).toBe("Hello, Crank!");
+
+		const result1 = renderer.render(
+			<Component text="Hello again, Crank!" />,
+			document.body,
+		);
+		expect(result1).toBeInstanceOf(globalThis.Text);
+		expect((result1 as globalThis.Text).data).toBe("Hello again, Crank!");
+		expect(result).toBe(result1);
+	});
+
+	test("component which returns array of strings produces multiple text nodes", () => {
+		function Component({children}: {children: Array<string>}) {
+			return children;
+		}
+
+		const result = renderer.render(
+			<Component>{["Hello, ", "Crank!"]}</Component>,
+			document.body,
+		) as Array<globalThis.Text>;
+
+		expect(document.body.childNodes.length).toBe(2);
+		expect(document.body.childNodes[0]).toBeInstanceOf(globalThis.Text);
+		expect((document.body.childNodes[0] as globalThis.Text).data).toBe(
+			"Hello, ",
+		);
+		expect(document.body.childNodes[1]).toBeInstanceOf(globalThis.Text);
+		expect((document.body.childNodes[1] as globalThis.Text).data).toBe(
+			"Crank!",
+		);
+		expect(result).toBeInstanceOf(Array);
+		expect(result.length).toBe(2);
+
+		expect(result[0]).toBe(document.body.childNodes[0]);
+		expect(result[1]).toBe(document.body.childNodes[1]);
+
+		const result1 = renderer.render(
+			<Component>{["Hello ", "again, ", "Crank!"]}</Component>,
+			document.body,
+		) as Array<globalThis.Text>;
+
+		expect(document.body.childNodes.length).toBe(3);
+		expect(document.body.childNodes[0]).toBeInstanceOf(globalThis.Text);
+		expect((document.body.childNodes[0] as globalThis.Text).data).toBe(
+			"Hello ",
+		);
+		expect(document.body.childNodes[1]).toBeInstanceOf(globalThis.Text);
+		expect((document.body.childNodes[1] as globalThis.Text).data).toBe(
+			"again, ",
+		);
+		expect(document.body.childNodes[2]).toBeInstanceOf(globalThis.Text);
+		expect((document.body.childNodes[2] as globalThis.Text).data).toBe(
+			"Crank!",
+		);
+		expect(result1).toBeInstanceOf(Array);
+		expect(result1.length).toBe(3);
+		expect(result[0]).toBe(result1[0]);
+		expect(result[1]).toBe(result1[1]);
+		expect(result1[2]).toBe(document.body.childNodes[2]);
+	});
+
+	test("Text element with ref prop", () => {
+		const ref = Sinon.mock();
+		const root = document.createElement("div");
+		renderer.render(
+			<div>
+				<Text value="Hello, Ref!" ref={ref} />
+			</div>,
+			root,
+		);
+		expect(root.innerHTML).toBe("<div>Hello, Ref!</div>");
+		expect(ref.callCount).toBe(1);
+		expect(ref.firstCall.args[0]).toBeInstanceOf(globalThis.Text);
+		expect((ref.firstCall.args[0] as globalThis.Text).data).toBe("Hello, Ref!");
+		renderer.render(
+			<div>
+				<Text value="Hello again, Ref!" ref={ref} />
+			</div>,
+			root,
+		);
+		expect(root.innerHTML).toBe("<div>Hello again, Ref!</div>");
+		expect(ref.callCount).toBe(1);
+	});
 });
-
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-});
-
-test("render text element", () => {
-	const element = <Text value="Hello, World!" />;
-	const root = document.createElement("div");
-	renderer.render(element, root);
-	Assert.is(root.innerHTML, "Hello, World!");
-});
-
-test("component which returns string produces text node", () => {
-	function Component({text}: {text: string}) {
-		return text;
-	}
-
-	const result = renderer.render(
-		<Component text="Hello, Crank!" />,
-		document.body,
-	);
-
-	Assert.instance(result, globalThis.Text);
-	Assert.is((result as globalThis.Text).data, "Hello, Crank!");
-	Assert.is(document.body.innerHTML, "Hello, Crank!");
-
-	const result1 = renderer.render(
-		<Component text="Hello again, Crank!" />,
-		document.body,
-	);
-	Assert.instance(result1, globalThis.Text);
-	Assert.is((result1 as globalThis.Text).data, "Hello again, Crank!");
-	Assert.is(result, result1);
-});
-
-test("component which returns array of strings produces multiple text nodes", () => {
-	function Component({children}: {children: Array<string>}) {
-		return children;
-	}
-
-	const result = renderer.render(
-		<Component>{["Hello, ", "Crank!"]}</Component>,
-		document.body,
-	) as Array<globalThis.Text>;
-
-	Assert.is(document.body.childNodes.length, 2);
-	Assert.instance(document.body.childNodes[0], globalThis.Text);
-	Assert.is((document.body.childNodes[0] as globalThis.Text).data, "Hello, ");
-	Assert.instance(document.body.childNodes[1], globalThis.Text);
-	Assert.is((document.body.childNodes[1] as globalThis.Text).data, "Crank!");
-	Assert.instance(result, Array);
-	Assert.is(result.length, 2);
-
-	Assert.is(result[0], document.body.childNodes[0]);
-	Assert.is(result[1], document.body.childNodes[1]);
-
-	const result1 = renderer.render(
-		<Component>{["Hello ", "again, ", "Crank!"]}</Component>,
-		document.body,
-	) as Array<globalThis.Text>;
-
-	Assert.is(document.body.childNodes.length, 3);
-	Assert.instance(document.body.childNodes[0], globalThis.Text);
-	Assert.is((document.body.childNodes[0] as globalThis.Text).data, "Hello ");
-	Assert.instance(document.body.childNodes[1], globalThis.Text);
-	Assert.is((document.body.childNodes[1] as globalThis.Text).data, "again, ");
-	Assert.instance(document.body.childNodes[2], globalThis.Text);
-	Assert.is((document.body.childNodes[2] as globalThis.Text).data, "Crank!");
-	Assert.instance(result1, Array);
-	Assert.is(result1.length, 3);
-	Assert.is(result[0], result1[0]);
-	Assert.is(result[1], result1[1]);
-	Assert.is(result1[2], document.body.childNodes[2]);
-});
-
-test("Text element with ref prop", () => {
-	const ref = Sinon.mock();
-	const root = document.createElement("div");
-	renderer.render(
-		<div>
-			<Text value="Hello, Ref!" ref={ref} />
-		</div>,
-		root,
-	);
-	Assert.is(root.innerHTML, "<div>Hello, Ref!</div>");
-	Assert.is(ref.callCount, 1);
-	Assert.instance(ref.firstCall.args[0], globalThis.Text);
-	Assert.is((ref.firstCall.args[0] as globalThis.Text).data, "Hello, Ref!");
-	renderer.render(
-		<div>
-			<Text value="Hello again, Ref!" ref={ref} />
-		</div>,
-		root,
-	);
-	Assert.is(root.innerHTML, "<div>Hello again, Ref!</div>");
-	Assert.is(ref.callCount, 1);
-});
-
-test.run();

--- a/test/types.tsx
+++ b/test/types.tsx
@@ -1,5 +1,5 @@
+import {test} from "@b9g/libuild/test";
 /* eslint @typescript-eslint/no-unused-vars: "off" */
-import {suite} from "uvu";
 import {Component, Context, createElement} from "../src/crank.js";
 
 declare global {
@@ -15,8 +15,6 @@ declare global {
 type MyProps = {
 	message: string;
 };
-
-const test = suite("types");
 
 let elem: any;
 test("createElement", () => {
@@ -347,5 +345,3 @@ test("loose typings", () => {
 	elem = <MyAsyncGeneratorComponent />;
 	elem = <MyAsyncGeneratorComponent message={"message"} />;
 });
-
-test.run();

--- a/test/warnings.tsx
+++ b/test/warnings.tsx
@@ -1,283 +1,276 @@
-import {suite} from "uvu";
-import * as Assert from "uvu/assert";
+import {describe, test, beforeEach, afterEach, expect} from "@b9g/libuild/test";
 import * as Sinon from "sinon";
 
 import {createElement, Fragment, Portal, Raw, Text} from "../src/crank.js";
 import type {Child, Context} from "../src/crank.js";
 import {renderer} from "../src/dom.js";
 
-const test = suite("warnings");
+describe("warnings", () => {
+	Error.stackTraceLimit = 1000;
 
-Error.stackTraceLimit = 1000;
+	let mock: Sinon.SinonStub;
 
-let mock: Sinon.SinonStub;
+	beforeEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+		mock = Sinon.stub(console, "error");
+	});
 
-test.before.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-	mock = Sinon.stub(console, "error");
-});
+	afterEach(() => {
+		renderer.render(null, document.body);
+		document.body.innerHTML = "";
+		mock.restore();
+	});
 
-test.after.each(() => {
-	renderer.render(null, document.body);
-	document.body.innerHTML = "";
-	mock.restore();
-});
+	test("sync component warns on implicit return", () => {
+		function Component() {}
 
-test("sync component warns on implicit return", () => {
-	function Component() {}
+		renderer.render(<Component />, document.body);
+		expect(mock.callCount).toBe(1);
+	});
 
-	renderer.render(<Component />, document.body);
-	Assert.is(mock.callCount, 1);
-});
+	test("async component warns on implicit return", async () => {
+		async function Component() {}
 
-test("async component warns on implicit return", async () => {
-	async function Component() {}
+		await renderer.render(<Component />, document.body);
+		expect(mock.callCount).toBe(1);
+	});
 
-	await renderer.render(<Component />, document.body);
-	Assert.is(mock.callCount, 1);
-});
+	test("sync generator component warns on implicit return", async () => {
+		function* Component() {}
 
-test("sync generator component warns on implicit return", async () => {
-	function* Component() {}
+		await renderer.render(<Component />, document.body);
+		expect(mock.callCount).toBe(1);
+	});
 
-	await renderer.render(<Component />, document.body);
-	Assert.is(mock.callCount, 1);
-});
-
-test("for of with multiple yields", async () => {
-	function* Component(this: Context): Generator<Child> {
-		for ({} of this) {
-			yield <div>Hello</div>;
-			yield <div>Goodbye</div>;
-		}
-	}
-
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello</div>");
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Goodbye</div>");
-	Assert.is(mock.callCount, 1);
-});
-
-test("for of with multiple yields is fine when scheduling", () => {
-	let ctx: Context;
-	function* Component(this: Context): Generator<Child> {
-		ctx = this;
-		let renderCount = 0;
-		for ({} of this) {
-			renderCount++;
-			// Only call schedule on first and second renders
-			if (renderCount <= 2) {
-				this.schedule(() => this.refresh());
+	test("for of with multiple yields", async () => {
+		function* Component(this: Context): Generator<Child> {
+			for ({} of this) {
+				yield <div>Hello</div>;
+				yield <div>Goodbye</div>;
 			}
-			yield <div>Render {renderCount}</div>;
-			yield <div>Second {renderCount}</div>;
 		}
-	}
 
-	renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Second 1</div>");
-	Assert.is(mock.callCount, 0);
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello</div>");
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Goodbye</div>");
+		expect(mock.callCount).toBe(1);
+	});
 
-	// Second render - should not warn because schedule() is called
-	ctx!.refresh();
-	Assert.is(document.body.innerHTML, "<div>Second 2</div>");
-	Assert.is(mock.callCount, 0);
-
-	// Third render - should warn because schedule() is NOT called
-	ctx!.refresh();
-	Assert.is(document.body.innerHTML, "<div>Render 3</div>");
-	ctx!.refresh();
-	Assert.is(document.body.innerHTML, "<div>Second 3</div>");
-	Assert.is(mock.callCount, 1);
-});
-
-test("for of with multiple yields in async generator component", async () => {
-	async function* Component(this: Context): AsyncGenerator<Child> {
-		for ({} of this) {
-			yield <div>Hello</div>;
-			yield <div>Goodbye</div>;
-		}
-	}
-
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Hello</div>");
-	await new Promise((resolve) => setTimeout(resolve, 100));
-	Assert.is(document.body.innerHTML, "<div>Hello</div>");
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Goodbye</div>");
-	Assert.is(mock.callCount, 1);
-});
-
-test("for of with multiple yields is fine when scheduling in async generator component", async () => {
-	let ctx: Context;
-	async function* Component(this: Context): AsyncGenerator<Child> {
-		ctx = this;
-		let renderCount = 0;
-		for ({} of this) {
-			renderCount++;
-			// Only call schedule on first and second renders
-			if (renderCount <= 2) {
-				this.schedule(() => this.refresh());
+	test("for of with multiple yields is fine when scheduling", () => {
+		let ctx: Context;
+		function* Component(this: Context): Generator<Child> {
+			ctx = this;
+			let renderCount = 0;
+			for ({} of this) {
+				renderCount++;
+				// Only call schedule on first and second renders
+				if (renderCount <= 2) {
+					this.schedule(() => this.refresh());
+				}
+				yield <div>Render {renderCount}</div>;
+				yield <div>Second {renderCount}</div>;
 			}
-			yield <div>Render {renderCount}</div>;
-			yield <div>Second {renderCount}</div>;
 		}
-	}
 
-	// First render - should not warn because schedule() is called
-	await renderer.render(<Component />, document.body);
-	Assert.is(document.body.innerHTML, "<div>Second 1</div>");
-	Assert.is(mock.callCount, 0);
+		renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Second 1</div>");
+		expect(mock.callCount).toBe(0);
 
-	// Second render - should not warn because schedule() is called
-	await ctx!.refresh();
-	// TODO: async updating is not yet implemented
-	Assert.is(document.body.innerHTML, "<div>Render 2</div>");
-	Assert.is(mock.callCount, 0);
+		// Second render - should not warn because schedule() is called
+		ctx!.refresh();
+		expect(document.body.innerHTML).toBe("<div>Second 2</div>");
+		expect(mock.callCount).toBe(0);
 
-	// Third render - should warn because schedule() is NOT called
-	await ctx!.refresh();
-	// TODO: async updating is not yet implemented
-	Assert.is(document.body.innerHTML, "<div>Render 3</div>");
+		// Third render - should warn because schedule() is NOT called
+		ctx!.refresh();
+		expect(document.body.innerHTML).toBe("<div>Render 3</div>");
+		ctx!.refresh();
+		expect(document.body.innerHTML).toBe("<div>Second 3</div>");
+		expect(mock.callCount).toBe(1);
+	});
 
-	await ctx!.refresh();
-	Assert.is(mock.callCount, 1);
-});
+	test("for of with multiple yields in async generator component", async () => {
+		async function* Component(this: Context): AsyncGenerator<Child> {
+			for ({} of this) {
+				yield <div>Hello</div>;
+				yield <div>Goodbye</div>;
+			}
+		}
 
-test("class and className both defined warns", () => {
-	renderer.render(
-		<div class="foo" className="bar">
-			Test
-		</div>,
-		document.body,
-	);
-	Assert.is(mock.callCount, 1);
-	Assert.match(mock.firstCall.args[0], /Both "class" and "className" set/);
-});
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Hello</div>");
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(document.body.innerHTML).toBe("<div>Hello</div>");
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Goodbye</div>");
+		expect(mock.callCount).toBe(1);
+	});
 
-test("string copy prop on Fragment warns", () => {
-	renderer.render(<Fragment copy="!children">Test</Fragment>, document.body);
-	Assert.is(mock.callCount, 1);
-	Assert.match(mock.firstCall.args[0], /String copy prop ignored for <>/);
-});
+	test("for of with multiple yields is fine when scheduling in async generator component", async () => {
+		let ctx: Context;
+		async function* Component(this: Context): AsyncGenerator<Child> {
+			ctx = this;
+			let renderCount = 0;
+			for ({} of this) {
+				renderCount++;
+				// Only call schedule on first and second renders
+				if (renderCount <= 2) {
+					this.schedule(() => this.refresh());
+				}
+				yield <div>Render {renderCount}</div>;
+				yield <div>Second {renderCount}</div>;
+			}
+		}
 
-test("string hydrate prop on Fragment warns", () => {
-	renderer.render(<Fragment hydrate="!children">Test</Fragment>, document.body);
-	Assert.is(mock.callCount, 1);
-	Assert.match(mock.firstCall.args[0], /String hydrate prop ignored for <>/);
-});
+		// First render - should not warn because schedule() is called
+		await renderer.render(<Component />, document.body);
+		expect(document.body.innerHTML).toBe("<div>Second 1</div>");
+		expect(mock.callCount).toBe(0);
 
-test("string copy prop on Portal warns", () => {
-	const portal = document.createElement("div");
-	renderer.render(
-		<Portal root={portal} copy="!children">
-			Test
-		</Portal>,
-		document.body,
-	);
-	Assert.is(mock.callCount, 1);
-	Assert.match(
-		mock.firstCall.args[0],
-		/String copy prop ignored for <crank\.Portal>/,
-	);
-});
+		// Second render - should not warn because schedule() is called
+		await ctx!.refresh();
+		// TODO: async updating is not yet implemented
+		expect(document.body.innerHTML).toBe("<div>Render 2</div>");
+		expect(mock.callCount).toBe(0);
 
-test("string hydrate prop on Portal warns", () => {
-	const portal = document.createElement("div");
-	renderer.render(
-		<Portal root={portal} hydrate="!children">
-			Test
-		</Portal>,
-		document.body,
-	);
-	Assert.is(mock.callCount, 1);
-	Assert.match(
-		mock.firstCall.args[0],
-		/String hydrate prop ignored for <crank\.Portal>/,
-	);
-});
+		// Third render - should warn because schedule() is NOT called
+		await ctx!.refresh();
+		// TODO: async updating is not yet implemented
+		expect(document.body.innerHTML).toBe("<div>Render 3</div>");
 
-test("string copy prop on Text warns", () => {
-	renderer.render(<Text value="Test" copy="!children" />, document.body);
-	Assert.is(mock.callCount, 1);
-	Assert.match(
-		mock.firstCall.args[0],
-		/String copy prop ignored for <crank\.Text>/,
-	);
-});
+		await ctx!.refresh();
+		expect(mock.callCount).toBe(1);
+	});
 
-test("string hydrate prop on Text warns", () => {
-	renderer.render(<Text value="Test" hydrate="!children" />, document.body);
-	Assert.is(mock.callCount, 1);
-	Assert.match(
-		mock.firstCall.args[0],
-		/String hydrate prop ignored for <crank\.Text>/,
-	);
-});
-
-test("string copy prop on Raw warns", () => {
-	renderer.render(
-		<Raw value="<div>Test</div>" copy="!children" />,
-		document.body,
-	);
-	Assert.is(mock.callCount, 1);
-	Assert.match(
-		mock.firstCall.args[0],
-		/String copy prop ignored for <crank\.Raw>/,
-	);
-});
-
-test("string hydrate prop on Raw warns", () => {
-	renderer.render(
-		<Raw value="<div>Test</div>" hydrate="!children" />,
-		document.body,
-	);
-	Assert.is(mock.callCount, 1);
-	Assert.match(
-		mock.firstCall.args[0],
-		/String hydrate prop ignored for <crank\.Raw>/,
-	);
-});
-
-test("string copy prop on component warns", () => {
-	function TestComponent() {
-		return <div>Test</div>;
-	}
-	renderer.render(<TestComponent copy="!children" />, document.body);
-	Assert.is(mock.callCount, 1);
-	Assert.match(
-		mock.firstCall.args[0],
-		/String copy prop ignored for <TestComponent>/,
-	);
-});
-
-test("string hydrate prop on component warns", () => {
-	function TestComponent() {
-		return <div>Test</div>;
-	}
-	renderer.render(<TestComponent hydrate="!children" />, document.body);
-	Assert.is(mock.callCount, 1);
-	Assert.match(
-		mock.firstCall.args[0],
-		/String hydrate prop ignored for <TestComponent>/,
-	);
-});
-
-test("hydrating document.body warns", () => {
-	const warnMock = Sinon.stub(console, "warn");
-	try {
-		document.body.innerHTML = "<div>test</div>";
-		renderer.hydrate(<div>test</div>, document.body);
-		Assert.is(warnMock.callCount, 1);
-		Assert.match(
-			warnMock.firstCall.args[0],
-			/Hydrating body is discouraged as it is destructive/,
+	test("class and className both defined warns", () => {
+		renderer.render(
+			<div class="foo" className="bar">
+				Test
+			</div>,
+			document.body,
 		);
-	} finally {
-		warnMock.restore();
-	}
-});
+		expect(mock.callCount).toBe(1);
+		expect(mock.firstCall.args[0]).toMatch(/Both "class" and "className" set/);
+	});
 
-test.run();
+	test("string copy prop on Fragment warns", () => {
+		renderer.render(<Fragment copy="!children">Test</Fragment>, document.body);
+		expect(mock.callCount).toBe(1);
+		expect(mock.firstCall.args[0]).toMatch(/String copy prop ignored for <>/);
+	});
+
+	test("string hydrate prop on Fragment warns", () => {
+		renderer.render(
+			<Fragment hydrate="!children">Test</Fragment>,
+			document.body,
+		);
+		expect(mock.callCount).toBe(1);
+		expect(mock.firstCall.args[0]).toMatch(
+			/String hydrate prop ignored for <>/,
+		);
+	});
+
+	test("string copy prop on Portal warns", () => {
+		const portal = document.createElement("div");
+		renderer.render(
+			<Portal root={portal} copy="!children">
+				Test
+			</Portal>,
+			document.body,
+		);
+		expect(mock.callCount).toBe(1);
+		expect(mock.firstCall.args[0]).toMatch(
+			/String copy prop ignored for <crank\.Portal>/,
+		);
+	});
+
+	test("string hydrate prop on Portal warns", () => {
+		const portal = document.createElement("div");
+		renderer.render(
+			<Portal root={portal} hydrate="!children">
+				Test
+			</Portal>,
+			document.body,
+		);
+		expect(mock.callCount).toBe(1);
+		expect(mock.firstCall.args[0]).toMatch(
+			/String hydrate prop ignored for <crank\.Portal>/,
+		);
+	});
+
+	test("string copy prop on Text warns", () => {
+		renderer.render(<Text value="Test" copy="!children" />, document.body);
+		expect(mock.callCount).toBe(1);
+		expect(mock.firstCall.args[0]).toMatch(
+			/String copy prop ignored for <crank\.Text>/,
+		);
+	});
+
+	test("string hydrate prop on Text warns", () => {
+		renderer.render(<Text value="Test" hydrate="!children" />, document.body);
+		expect(mock.callCount).toBe(1);
+		expect(mock.firstCall.args[0]).toMatch(
+			/String hydrate prop ignored for <crank\.Text>/,
+		);
+	});
+
+	test("string copy prop on Raw warns", () => {
+		renderer.render(
+			<Raw value="<div>Test</div>" copy="!children" />,
+			document.body,
+		);
+		expect(mock.callCount).toBe(1);
+		expect(mock.firstCall.args[0]).toMatch(
+			/String copy prop ignored for <crank\.Raw>/,
+		);
+	});
+
+	test("string hydrate prop on Raw warns", () => {
+		renderer.render(
+			<Raw value="<div>Test</div>" hydrate="!children" />,
+			document.body,
+		);
+		expect(mock.callCount).toBe(1);
+		expect(mock.firstCall.args[0]).toMatch(
+			/String hydrate prop ignored for <crank\.Raw>/,
+		);
+	});
+
+	test("string copy prop on component warns", () => {
+		function TestComponent() {
+			return <div>Test</div>;
+		}
+		renderer.render(<TestComponent copy="!children" />, document.body);
+		expect(mock.callCount).toBe(1);
+		expect(mock.firstCall.args[0]).toMatch(
+			/String copy prop ignored for <TestComponent>/,
+		);
+	});
+
+	test("string hydrate prop on component warns", () => {
+		function TestComponent() {
+			return <div>Test</div>;
+		}
+		renderer.render(<TestComponent hydrate="!children" />, document.body);
+		expect(mock.callCount).toBe(1);
+		expect(mock.firstCall.args[0]).toMatch(
+			/String hydrate prop ignored for <TestComponent>/,
+		);
+	});
+
+	test("hydrating document.body warns", () => {
+		const warnMock = Sinon.stub(console, "warn");
+		try {
+			document.body.innerHTML = "<div>test</div>";
+			renderer.hydrate(<div>test</div>, document.body);
+			expect(warnMock.callCount).toBe(1);
+			expect(warnMock.firstCall.args[0]).toMatch(
+				/Hydrating body is discouraged as it is destructive/,
+			);
+		} finally {
+			warnMock.restore();
+		}
+	});
+});


### PR DESCRIPTION
Moves the core suite from `playwright-test --runner uvu` to `libuild test`, so crank consumes libuild's test stack alongside its build stack.

Verified on a clean install of libuild 0.2.17, no patching: **602 passed, 3 skipped, exit 0.**

## What changed

| before | after |
|---|---|
| `uvu` `suite()` | `describe()` |
| `test.before.each` / `test.after.each` | `beforeEach` / `afterEach` |
| `uvu/assert` (`Assert.is`, …) | `expect(...)` |
| `playwright-test --runner uvu` | `libuild test test/ --platform <browser>` |
| `playwright-test` (bundled browsers) | `playwright` (explicit `playwright install`) |

`playwright-test.config.js` is deleted; CI's browser matrix (chromium/firefox/webkit) is unchanged and now drives `--platform`.

Each file is wrapped in `describe()` rather than left flat. That is not cosmetic: uvu's `suite()` scoped hooks per file, but libuild bundles all 30 files into one root suite, so top-level `beforeEach` hooks would run before *every* test in the suite. Left flat, all 602 tests failed with Sinon's "Attempted to wrap error which is already wrapped" — 26 files' hooks each stubbing `console.error` on top of one another.

## Three bugs the conversion shook out

**`test/jsx-tag.ts` has never run.** `playwright-test.config.js` declared `input: ["test/*.tsx"]`, which does not match the one `.ts` test file. Its 25 tests were silently excluded from every CI run. Including them takes the suite from 577 to 602. They pass.

**One assertion was never actually checked.** uvu's `throws(fn, expects, msg)` treats a *string* second argument as the failure message, not a matcher — only a RegExp or function is compared. So:

```js
Assert.throws(() => renderer.render(<Component />, document.body), "Context iterated twice");
```

asserted only that *something* threw. `expect().toThrow(string)` does substring-match, which surfaced that the real message is `<Component> context iterated twice without a yield` — lowercase, and differently worded. The expected string is corrected.

**Two spots leaned on assertion signatures.** uvu types `ok(val): asserts val`, so `Assert.ok(x instanceof Element)` narrowed `x` for later lines. `expect().toBeTruthy()` does not narrow, so `mathml.tsx` and `svg.tsx` now access those values explicitly.

## Fidelity

- 602 `test()` declarations and 3 `test.skip`s before and after — nothing added or lost. The run reports exactly `602 passed, 3 skipped`.
- Assertion messages, which `expect()` has no parameter for, are kept as block comments instead of being dropped (`expect(x).toBe(1) /* cleanup should be called */;`).

## libuild bugs this found, fixed in 0.2.17

This PR was blocked on two of them; both are now fixed upstream and the workarounds are gone.

1. **The browser runner started before any test registered.** `@b9g/libuild/test` picks its backend with top-level await, making it an async module, so every importing test file's body is deferred past the runner's `queueMicrotask` start. It ran with zero tests and reported a green empty run. Fixed by having the generated entry set a ready flag as its last statement, which ESM guarantees runs after every imported file has evaluated.

2. **A zero-test run exited 0.** Merging this against 0.2.16 would have silently disabled crank's entire suite with CI green. Now a hard failure — verified here: an empty selection exits 1 with "test files were bundled and loaded, but zero tests registered".

Also fixed in 0.2.17 and used here: `test.skip` exists in the browser runner (the three disabled hydration tests use it again instead of a local no-op, and are reported as skipped), and `libuild test test/` discovers files correctly when the root is itself named `test/` (so discovery is the plain directory form rather than explicit globs).

## Verification

`602 passed, 3 skipped, 0 failed` on chromium against a clean install with no patching, exit 0. `tsc --noEmit` clean, eslint clean. A deliberately empty selection exits 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pggktip8wsuxzy2VCY9p7
