### PR TITLE
Run the package test suites through libuild

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@b9g/crank",
       "devDependencies": {
-        "@b9g/libuild": "^0.2.18",
+        "@b9g/libuild": "^0.2.19",
         "@types/node": "^22.14.0",
         "@types/sinon": "^17.0.4",
         "@typescript-eslint/eslint-plugin": "^8.29.1",
@@ -47,7 +47,7 @@
       "version": "0.1.3",
       "devDependencies": {
         "@b9g/crank": "file:../../",
-        "@b9g/libuild": "^0.2.18",
+        "@b9g/libuild": "^0.2.19",
         "marked": "^18.0.0",
         "typescript": "^5.9.3",
       },
@@ -67,7 +67,7 @@
       "name": "eslint-plugin-crank",
       "version": "0.2.2",
       "devDependencies": {
-        "@b9g/libuild": "^0.2.18",
+        "@b9g/libuild": "^0.2.19",
         "@eslint/js": "^9.37.0",
         "@tsconfig/recommended": "^1.0.10",
         "@types/node": "^20.0.0",
@@ -100,7 +100,7 @@
 
     "@b9g/crankdown": ["@b9g/crankdown@workspace:packages/crankdown"],
 
-    "@b9g/libuild": ["@b9g/libuild@0.2.18", "", { "dependencies": { "commander": "^15.0.0", "esbuild": "^0.28.1", "expect": "^30.4.1", "glob": "^13.0.6", "pretty-format": "^30.4.1" }, "peerDependencies": { "playwright": "^1.40.0", "typescript": "^5.0.0" }, "optionalPeers": ["playwright", "typescript"], "bin": { "libuild": "cli.js" } }, "sha512-hp1eJUWAFJgAvm3Ll8ZJY10pWCBToDdXJUtAWgzM+qgvqv3u++Y82SIe7Xums+HNPk4f3dDNLkTFG0ZKdnfhhQ=="],
+    "@b9g/libuild": ["@b9g/libuild@0.2.19", "", { "dependencies": { "commander": "^15.0.0", "esbuild": "^0.28.1", "expect": "^30.4.1", "glob": "^13.0.6", "pretty-format": "^30.4.1" }, "peerDependencies": { "playwright": "^1.40.0", "typescript": "^5.0.0" }, "optionalPeers": ["playwright", "typescript"], "bin": { "libuild": "cli.js" } }, "sha512-pqBEIAO2yIRyIpxM87F3Q5Kmvo0OZq9YVjupZ4+BwiuBHIRF3xs8mJYVpNbjugoC3fy3l5croA2tsJlmN8vlWQ=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -1595,8 +1595,6 @@
     "zod-to-ts": ["zod-to-ts@1.2.0", "", { "peerDependencies": { "typescript": "^4.9.4 || ^5.0.2", "zod": "^3" } }, "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
-
-    "@b9g/crankdown/@b9g/crank": ["@b9g/crank@root:", {}],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@b9g/crank",
       "devDependencies": {
-        "@b9g/libuild": "^0.2.17",
+        "@b9g/libuild": "^0.2.18",
         "@types/node": "^22.14.0",
         "@types/sinon": "^17.0.4",
         "@typescript-eslint/eslint-plugin": "^8.29.1",
@@ -47,7 +47,7 @@
       "version": "0.1.3",
       "devDependencies": {
         "@b9g/crank": "file:../../",
-        "@b9g/libuild": "^0.2.17",
+        "@b9g/libuild": "^0.2.18",
         "marked": "^18.0.0",
         "typescript": "^5.9.3",
       },
@@ -67,7 +67,7 @@
       "name": "eslint-plugin-crank",
       "version": "0.2.2",
       "devDependencies": {
-        "@b9g/libuild": "^0.2.17",
+        "@b9g/libuild": "^0.2.18",
         "@eslint/js": "^9.37.0",
         "@tsconfig/recommended": "^1.0.10",
         "@types/node": "^20.0.0",
@@ -100,7 +100,7 @@
 
     "@b9g/crankdown": ["@b9g/crankdown@workspace:packages/crankdown"],
 
-    "@b9g/libuild": ["@b9g/libuild@0.2.17", "", { "dependencies": { "commander": "^15.0.0", "esbuild": "^0.28.1", "expect": "^30.4.1", "glob": "^13.0.6", "pretty-format": "^30.4.1" }, "peerDependencies": { "playwright": "^1.40.0", "typescript": "^5.0.0" }, "optionalPeers": ["playwright", "typescript"], "bin": { "libuild": "cli.js" } }, "sha512-7TXKet+ZCwmGqsp4ICWkQUvGWu6tVFFAeRfUF5Y3VlLrsZFMk1NlQLESzbdudvx3GMk2+2wOi3lDRPLtWUT9AA=="],
+    "@b9g/libuild": ["@b9g/libuild@0.2.18", "", { "dependencies": { "commander": "^15.0.0", "esbuild": "^0.28.1", "expect": "^30.4.1", "glob": "^13.0.6", "pretty-format": "^30.4.1" }, "peerDependencies": { "playwright": "^1.40.0", "typescript": "^5.0.0" }, "optionalPeers": ["playwright", "typescript"], "bin": { "libuild": "cli.js" } }, "sha512-hp1eJUWAFJgAvm3Ll8ZJY10pWCBToDdXJUtAWgzM+qgvqv3u++Y82SIe7Xums+HNPk4f3dDNLkTFG0ZKdnfhhQ=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -1595,6 +1595,8 @@
     "zod-to-ts": ["zod-to-ts@1.2.0", "", { "peerDependencies": { "typescript": "^4.9.4 || ^5.0.2", "zod": "^3" } }, "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@b9g/crankdown/@b9g/crank": ["@b9g/crank@root:", {}],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@b9g/crank",
       "devDependencies": {
-        "@b9g/libuild": "^0.2.4",
+        "@b9g/libuild": "^0.2.17",
         "@types/node": "^22.14.0",
         "@types/sinon": "^17.0.4",
         "@typescript-eslint/eslint-plugin": "^8.29.1",
@@ -47,7 +47,7 @@
       "version": "0.1.3",
       "devDependencies": {
         "@b9g/crank": "file:../../",
-        "@b9g/libuild": "^0.1.25",
+        "@b9g/libuild": "^0.2.17",
         "marked": "^18.0.0",
         "typescript": "^5.9.3",
       },
@@ -67,6 +67,7 @@
       "name": "eslint-plugin-crank",
       "version": "0.2.2",
       "devDependencies": {
+        "@b9g/libuild": "^0.2.17",
         "@eslint/js": "^9.37.0",
         "@tsconfig/recommended": "^1.0.10",
         "@types/node": "^20.0.0",
@@ -99,7 +100,7 @@
 
     "@b9g/crankdown": ["@b9g/crankdown@workspace:packages/crankdown"],
 
-    "@b9g/libuild": ["@b9g/libuild@0.2.4", "", { "dependencies": { "commander": "^15.0.0", "esbuild": "^0.28.1", "expect": "^30.4.1", "glob": "^13.0.6" }, "peerDependencies": { "playwright": "^1.40.0", "typescript": "^5.0.0" }, "optionalPeers": ["playwright", "typescript"], "bin": { "libuild": "cli.js" } }, "sha512-mD4nXusXSu5EjQyfMdttyr2hfCn1VUAV96IJxCbQAHXLOQfsv8pIULKCgYmaAkSjUEzuuAeDg5G6gox/wn5yyw=="],
+    "@b9g/libuild": ["@b9g/libuild@0.2.17", "", { "dependencies": { "commander": "^15.0.0", "esbuild": "^0.28.1", "expect": "^30.4.1", "glob": "^13.0.6", "pretty-format": "^30.4.1" }, "peerDependencies": { "playwright": "^1.40.0", "typescript": "^5.0.0" }, "optionalPeers": ["playwright", "typescript"], "bin": { "libuild": "cli.js" } }, "sha512-7TXKet+ZCwmGqsp4ICWkQUvGWu6tVFFAeRfUF5Y3VlLrsZFMk1NlQLESzbdudvx3GMk2+2wOi3lDRPLtWUT9AA=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -501,7 +502,7 @@
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
@@ -1595,8 +1596,6 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
-    "@b9g/crankdown/@b9g/libuild": ["@b9g/libuild@0.1.25", "", { "dependencies": { "commander": "^14.0.2", "esbuild": "^0.19.0", "expect": "^30.2.0", "glob": "^13.0.0" }, "peerDependencies": { "playwright": "^1.40.0", "typescript": "^5.0.0" }, "optionalPeers": ["playwright", "typescript"], "bin": { "libuild": "src/cli.js" } }, "sha512-ibMExggG0YxDdHIUQynAqXTBlv/ka8YpsnJ43LOwyKjD8tsjCwQKBFTQL8EpfuGhl+6gMjTvZPwgQTnUMeGocg=="],
-
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
@@ -1628,6 +1627,8 @@
     "boxen/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "boxen/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -1687,8 +1688,6 @@
 
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
-
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
@@ -1717,13 +1716,11 @@
 
     "wrap-ansi/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "@b9g/crankdown/@b9g/libuild/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild": ["esbuild@0.19.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.19.12", "@esbuild/android-arm": "0.19.12", "@esbuild/android-arm64": "0.19.12", "@esbuild/android-x64": "0.19.12", "@esbuild/darwin-arm64": "0.19.12", "@esbuild/darwin-x64": "0.19.12", "@esbuild/freebsd-arm64": "0.19.12", "@esbuild/freebsd-x64": "0.19.12", "@esbuild/linux-arm": "0.19.12", "@esbuild/linux-arm64": "0.19.12", "@esbuild/linux-ia32": "0.19.12", "@esbuild/linux-loong64": "0.19.12", "@esbuild/linux-mips64el": "0.19.12", "@esbuild/linux-ppc64": "0.19.12", "@esbuild/linux-riscv64": "0.19.12", "@esbuild/linux-s390x": "0.19.12", "@esbuild/linux-x64": "0.19.12", "@esbuild/netbsd-x64": "0.19.12", "@esbuild/openbsd-x64": "0.19.12", "@esbuild/sunos-x64": "0.19.12", "@esbuild/win32-arm64": "0.19.12", "@esbuild/win32-ia32": "0.19.12", "@esbuild/win32-x64": "0.19.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -1782,6 +1779,8 @@
     "astro/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "eslint-plugin-crank/eslint/@eslint/eslintrc": ["@eslint/eslintrc@3.3.3", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ=="],
 
@@ -1924,52 +1923,6 @@
     "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.19.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.19.12", "", { "os": "android", "cpu": "arm" }, "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.19.12", "", { "os": "android", "cpu": "arm64" }, "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.19.12", "", { "os": "android", "cpu": "x64" }, "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.19.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.19.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.19.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.19.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.19.12", "", { "os": "linux", "cpu": "arm" }, "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.19.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.19.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.19.12", "", { "os": "linux", "cpu": "none" }, "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.19.12", "", { "os": "linux", "cpu": "none" }, "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.19.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.19.12", "", { "os": "linux", "cpu": "none" }, "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.19.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.19.12", "", { "os": "linux", "cpu": "x64" }, "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.19.12", "", { "os": "none", "cpu": "x64" }, "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.19.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.19.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.19.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.19.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ=="],
-
-    "@b9g/crankdown/@b9g/libuild/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.19.12", "", { "os": "win32", "cpu": "x64" }, "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA=="],
 
     "eslint-plugin-crank/eslint/@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "module": "./dist/crank.js",
   "types": "./dist/crank.d.ts",
   "devDependencies": {
-    "@b9g/libuild": "^0.2.18",
+    "@b9g/libuild": "^0.2.19",
     "@types/node": "^22.14.0",
     "@types/sinon": "^17.0.4",
     "@typescript-eslint/eslint-plugin": "^8.29.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "module": "./dist/crank.js",
   "types": "./dist/crank.d.ts",
   "devDependencies": {
-    "@b9g/libuild": "^0.2.17",
+    "@b9g/libuild": "^0.2.18",
     "@types/node": "^22.14.0",
     "@types/sinon": "^17.0.4",
     "@typescript-eslint/eslint-plugin": "^8.29.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "module": "./dist/crank.js",
   "types": "./dist/crank.d.ts",
   "devDependencies": {
-    "@b9g/libuild": "^0.2.4",
+    "@b9g/libuild": "^0.2.17",
     "@types/node": "^22.14.0",
     "@types/sinon": "^17.0.4",
     "@typescript-eslint/eslint-plugin": "^8.29.1",

--- a/packages/crankdown/package.json
+++ b/packages/crankdown/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@b9g/crank": "file:../../",
-    "@b9g/libuild": "^0.2.17",
+    "@b9g/libuild": "^0.2.18",
     "marked": "^18.0.0",
     "typescript": "^5.9.3"
   },

--- a/packages/crankdown/package.json
+++ b/packages/crankdown/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "build": "libuild build",
-    "test": "bun test",
+    "test": "libuild test \"test/**/*.test.ts\" --platform bun node",
     "typecheck": "tsc --noEmit",
     "publish": "libuild publish",
     "prepublishOnly": "echo 'ERROR: Cannot publish from root directory. Use libuild publish instead.' && exit 1"
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@b9g/crank": "file:../../",
-    "@b9g/libuild": "^0.1.25",
+    "@b9g/libuild": "^0.2.17",
     "marked": "^18.0.0",
     "typescript": "^5.9.3"
   },

--- a/packages/crankdown/package.json
+++ b/packages/crankdown/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@b9g/crank": "file:../../",
-    "@b9g/libuild": "^0.2.18",
+    "@b9g/libuild": "^0.2.19",
     "marked": "^18.0.0",
     "typescript": "^5.9.3"
   },

--- a/packages/crankdown/test/marked.test.ts
+++ b/packages/crankdown/test/marked.test.ts
@@ -1,4 +1,4 @@
-import {test, expect} from "bun:test";
+import {test, expect} from "@b9g/libuild/test";
 import {renderer} from "@b9g/crank/html";
 import {Marked} from "../src/index.ts";
 

--- a/packages/eslint-plugin-crank/package.json
+++ b/packages/eslint-plugin-crank/package.json
@@ -26,11 +26,12 @@
   },
   "scripts": {
     "build": "rm -rf dist && tsc",
-    "test": "bun test",
+    "test": "libuild test \"src/**/*.test.ts\" --platform bun node",
     "lint": "eslint .",
     "prepare": "npm run build"
   },
   "devDependencies": {
+    "@b9g/libuild": "^0.2.17",
     "@eslint/js": "^9.37.0",
     "@tsconfig/recommended": "^1.0.10",
     "@types/node": "^20.0.0",

--- a/packages/eslint-plugin-crank/package.json
+++ b/packages/eslint-plugin-crank/package.json
@@ -31,7 +31,7 @@
     "prepare": "npm run build"
   },
   "devDependencies": {
-    "@b9g/libuild": "^0.2.17",
+    "@b9g/libuild": "^0.2.18",
     "@eslint/js": "^9.37.0",
     "@tsconfig/recommended": "^1.0.10",
     "@types/node": "^20.0.0",

--- a/packages/eslint-plugin-crank/package.json
+++ b/packages/eslint-plugin-crank/package.json
@@ -31,7 +31,7 @@
     "prepare": "npm run build"
   },
   "devDependencies": {
-    "@b9g/libuild": "^0.2.18",
+    "@b9g/libuild": "^0.2.19",
     "@eslint/js": "^9.37.0",
     "@tsconfig/recommended": "^1.0.10",
     "@types/node": "^20.0.0",

--- a/packages/eslint-plugin-crank/src/rules/jsx-no-duplicate-props.test.ts
+++ b/packages/eslint-plugin-crank/src/rules/jsx-no-duplicate-props.test.ts
@@ -1,4 +1,4 @@
-import {describe, it} from "bun:test";
+import {describe, it} from "@b9g/libuild/test";
 import {jsxNoDuplicateProps} from "./jsx-no-duplicate-props.js";
 import {createJsRuleTester} from "../test-helpers/rule-tester.js";
 

--- a/packages/eslint-plugin-crank/src/rules/jsx-no-undef.test.ts
+++ b/packages/eslint-plugin-crank/src/rules/jsx-no-undef.test.ts
@@ -1,4 +1,4 @@
-import {describe, it} from "bun:test";
+import {describe, it} from "@b9g/libuild/test";
 import {jsxNoUndef} from "./jsx-no-undef.js";
 import {createJsRuleTester} from "../test-helpers/rule-tester.js";
 

--- a/packages/eslint-plugin-crank/src/rules/jsx-uses-crank.test.ts
+++ b/packages/eslint-plugin-crank/src/rules/jsx-uses-crank.test.ts
@@ -1,4 +1,4 @@
-import {describe, it} from "bun:test";
+import {describe, it} from "@b9g/libuild/test";
 import {jsxUsesCrank} from "./jsx-uses-crank.js";
 import {createJsRuleTester} from "../test-helpers/rule-tester.js";
 

--- a/packages/eslint-plugin-crank/src/rules/jsx-uses-vars.test.ts
+++ b/packages/eslint-plugin-crank/src/rules/jsx-uses-vars.test.ts
@@ -1,4 +1,4 @@
-import {describe, it} from "bun:test";
+import {describe, it} from "@b9g/libuild/test";
 import {jsxUsesVars} from "./jsx-uses-vars.js";
 import {createJsRuleTester} from "../test-helpers/rule-tester.js";
 

--- a/packages/eslint-plugin-crank/src/rules/no-deprecated-flush.test.ts
+++ b/packages/eslint-plugin-crank/src/rules/no-deprecated-flush.test.ts
@@ -1,4 +1,4 @@
-import {describe, it} from "bun:test";
+import {describe, it} from "@b9g/libuild/test";
 import {noDeprecatedFlush} from "./no-deprecated-flush.js";
 import {
 	createTsRuleTester,

--- a/packages/eslint-plugin-crank/src/rules/no-deprecated-special-props.test.ts
+++ b/packages/eslint-plugin-crank/src/rules/no-deprecated-special-props.test.ts
@@ -1,4 +1,4 @@
-import {describe, it} from "bun:test";
+import {describe, it} from "@b9g/libuild/test";
 import {noDeprecatedSpecialProps} from "./no-deprecated-special-props.js";
 import {createJsRuleTester} from "../test-helpers/rule-tester.js";
 

--- a/packages/eslint-plugin-crank/src/rules/no-react-event-props.test.ts
+++ b/packages/eslint-plugin-crank/src/rules/no-react-event-props.test.ts
@@ -32,7 +32,7 @@ describe("no-react-event-props", () => {
 	});
 
 	describe("should detect and fix React-style camelCase event handlers", () => {
-		it.each([
+		for (const {event, correct, code, output} of [
 			{
 				event: "onClick",
 				correct: "onclick",
@@ -57,169 +57,183 @@ describe("no-react-event-props", () => {
 				code: `<form onSubmit={handleSubmit}>Submit</form>`,
 				output: `<form onsubmit={handleSubmit}>Submit</form>`,
 			},
-		])("should fix $event to $correct", ({event, correct, code, output}) => {
-			ruleTester.run("no-react-event-props", noReactEventProps, {
-				valid: [],
-				invalid: [
-					{
-						code,
-						output,
-						errors: [
-							{
-								messageId: "noReactEventProp",
-								data: {react: event, standard: correct},
-							},
-						],
-					},
-				],
+		]) {
+			it(`should fix ${event} to ${correct}`, () => {
+				ruleTester.run("no-react-event-props", noReactEventProps, {
+					valid: [],
+					invalid: [
+						{
+							code,
+							output,
+							errors: [
+								{
+									messageId: "noReactEventProp",
+									data: {react: event, standard: correct},
+								},
+							],
+						},
+					],
+				});
 			});
-		});
+		}
 	});
 
 	describe("keyboard events", () => {
-		it.each([
+		for (const {camel, lower} of [
 			{camel: "onKeyDown", lower: "onkeydown"},
 			{camel: "onKeyUp", lower: "onkeyup"},
 			{camel: "onKeyPress", lower: "onkeypress"},
-		])("should detect and fix $camel", ({camel, lower}) => {
-			ruleTester.run("no-react-event-props", noReactEventProps, {
-				valid: [],
-				invalid: [
-					{
-						code: `<input ${camel}={handleKey} />`,
-						output: `<input ${lower}={handleKey} />`,
-						errors: [
-							{
-								messageId: "noReactEventProp",
-								data: {react: camel, standard: lower},
-							},
-						],
-					},
-				],
+		]) {
+			it(`should detect and fix ${camel}`, () => {
+				ruleTester.run("no-react-event-props", noReactEventProps, {
+					valid: [],
+					invalid: [
+						{
+							code: `<input ${camel}={handleKey} />`,
+							output: `<input ${lower}={handleKey} />`,
+							errors: [
+								{
+									messageId: "noReactEventProp",
+									data: {react: camel, standard: lower},
+								},
+							],
+						},
+					],
+				});
 			});
-		});
+		}
 	});
 
 	describe("mouse events", () => {
-		it.each([
+		for (const {camel, lower} of [
 			{camel: "onMouseDown", lower: "onmousedown"},
 			{camel: "onMouseUp", lower: "onmouseup"},
 			{camel: "onMouseOver", lower: "onmouseover"},
 			{camel: "onMouseOut", lower: "onmouseout"},
 			{camel: "onMouseEnter", lower: "onmouseenter"},
 			{camel: "onMouseLeave", lower: "onmouseleave"},
-		])("should detect and fix $camel", ({camel, lower}) => {
-			ruleTester.run("no-react-event-props", noReactEventProps, {
-				valid: [],
-				invalid: [
-					{
-						code: `<div ${camel}={handleMouse} />`,
-						output: `<div ${lower}={handleMouse} />`,
-						errors: [
-							{
-								messageId: "noReactEventProp",
-								data: {react: camel, standard: lower},
-							},
-						],
-					},
-				],
+		]) {
+			it(`should detect and fix ${camel}`, () => {
+				ruleTester.run("no-react-event-props", noReactEventProps, {
+					valid: [],
+					invalid: [
+						{
+							code: `<div ${camel}={handleMouse} />`,
+							output: `<div ${lower}={handleMouse} />`,
+							errors: [
+								{
+									messageId: "noReactEventProp",
+									data: {react: camel, standard: lower},
+								},
+							],
+						},
+					],
+				});
 			});
-		});
+		}
 	});
 
 	describe("focus/blur events", () => {
-		it.each([
+		for (const {camel, lower, handler} of [
 			{camel: "onFocus", lower: "onfocus", handler: "handleFocus"},
 			{camel: "onBlur", lower: "onblur", handler: "handleBlur"},
-		])("should detect and fix $camel", ({camel, lower, handler}) => {
-			ruleTester.run("no-react-event-props", noReactEventProps, {
-				valid: [],
-				invalid: [
-					{
-						code: `<input ${camel}={${handler}} />`,
-						output: `<input ${lower}={${handler}} />`,
-						errors: [
-							{
-								messageId: "noReactEventProp",
-								data: {react: camel, standard: lower},
-							},
-						],
-					},
-				],
+		]) {
+			it(`should detect and fix ${camel}`, () => {
+				ruleTester.run("no-react-event-props", noReactEventProps, {
+					valid: [],
+					invalid: [
+						{
+							code: `<input ${camel}={${handler}} />`,
+							output: `<input ${lower}={${handler}} />`,
+							errors: [
+								{
+									messageId: "noReactEventProp",
+									data: {react: camel, standard: lower},
+								},
+							],
+						},
+					],
+				});
 			});
-		});
+		}
 	});
 
 	describe("touch events", () => {
-		it.each([
+		for (const {camel, lower} of [
 			{camel: "onTouchStart", lower: "ontouchstart"},
 			{camel: "onTouchMove", lower: "ontouchmove"},
 			{camel: "onTouchEnd", lower: "ontouchend"},
-		])("should detect and fix $camel", ({camel, lower}) => {
-			ruleTester.run("no-react-event-props", noReactEventProps, {
-				valid: [],
-				invalid: [
-					{
-						code: `<div ${camel}={handleTouch} />`,
-						output: `<div ${lower}={handleTouch} />`,
-						errors: [
-							{
-								messageId: "noReactEventProp",
-								data: {react: camel, standard: lower},
-							},
-						],
-					},
-				],
+		]) {
+			it(`should detect and fix ${camel}`, () => {
+				ruleTester.run("no-react-event-props", noReactEventProps, {
+					valid: [],
+					invalid: [
+						{
+							code: `<div ${camel}={handleTouch} />`,
+							output: `<div ${lower}={handleTouch} />`,
+							errors: [
+								{
+									messageId: "noReactEventProp",
+									data: {react: camel, standard: lower},
+								},
+							],
+						},
+					],
+				});
 			});
-		});
+		}
 	});
 
 	describe("drag events", () => {
-		it.each([
+		for (const {camel, lower, handler} of [
 			{camel: "onDragStart", lower: "ondragstart", handler: "handleDrag"},
 			{camel: "onDragEnd", lower: "ondragend", handler: "handleDrag"},
 			{camel: "onDrop", lower: "ondrop", handler: "handleDrop"},
-		])("should detect and fix $camel", ({camel, lower, handler}) => {
-			ruleTester.run("no-react-event-props", noReactEventProps, {
-				valid: [],
-				invalid: [
-					{
-						code: `<div ${camel}={${handler}} />`,
-						output: `<div ${lower}={${handler}} />`,
-						errors: [
-							{
-								messageId: "noReactEventProp",
-								data: {react: camel, standard: lower},
-							},
-						],
-					},
-				],
+		]) {
+			it(`should detect and fix ${camel}`, () => {
+				ruleTester.run("no-react-event-props", noReactEventProps, {
+					valid: [],
+					invalid: [
+						{
+							code: `<div ${camel}={${handler}} />`,
+							output: `<div ${lower}={${handler}} />`,
+							errors: [
+								{
+									messageId: "noReactEventProp",
+									data: {react: camel, standard: lower},
+								},
+							],
+						},
+					],
+				});
 			});
-		});
+		}
 	});
 
 	describe("media events", () => {
-		it.each([
+		for (const {camel, lower, handler} of [
 			{camel: "onPlay", lower: "onplay", handler: "handlePlay"},
 			{camel: "onPause", lower: "onpause", handler: "handlePause"},
 			{camel: "onEnded", lower: "onended", handler: "handleEnded"},
-		])("should detect and fix $camel", ({camel, lower, handler}) => {
-			ruleTester.run("no-react-event-props", noReactEventProps, {
-				valid: [],
-				invalid: [
-					{
-						code: `<video ${camel}={${handler}} />`,
-						output: `<video ${lower}={${handler}} />`,
-						errors: [
-							{
-								messageId: "noReactEventProp",
-								data: {react: camel, standard: lower},
-							},
-						],
-					},
-				],
+		]) {
+			it(`should detect and fix ${camel}`, () => {
+				ruleTester.run("no-react-event-props", noReactEventProps, {
+					valid: [],
+					invalid: [
+						{
+							code: `<video ${camel}={${handler}} />`,
+							output: `<video ${lower}={${handler}} />`,
+							errors: [
+								{
+									messageId: "noReactEventProp",
+									data: {react: camel, standard: lower},
+								},
+							],
+						},
+					],
+				});
 			});
-		});
+		}
 	});
 
 	it("should handle multiple event handlers in one component", () => {

--- a/packages/eslint-plugin-crank/src/rules/no-react-event-props.test.ts
+++ b/packages/eslint-plugin-crank/src/rules/no-react-event-props.test.ts
@@ -1,4 +1,4 @@
-import {describe, it} from "bun:test";
+import {describe, it} from "@b9g/libuild/test";
 import {noReactEventProps} from "./no-react-event-props.js";
 import {createTsRuleTester} from "../test-helpers/rule-tester.js";
 

--- a/packages/eslint-plugin-crank/src/rules/no-react-props.test.ts
+++ b/packages/eslint-plugin-crank/src/rules/no-react-props.test.ts
@@ -21,7 +21,7 @@ describe("no-react-props", () => {
 	});
 
 	describe("className transformation", () => {
-		it.each([
+		for (const {name, code, output} of [
 			{
 				name: "should detect and fix className -> class",
 				code: `<div className="container">Content</div>`,
@@ -42,23 +42,25 @@ describe("no-react-props", () => {
 				code: `<div className={\`container \${active ? 'active' : ''}\`}>Content</div>`,
 				output: `<div class={\`container \${active ? 'active' : ''}\`}>Content</div>`,
 			},
-		])("$name", ({code, output}) => {
-			ruleTester.run("no-react-props", noReactProps, {
-				valid: [],
-				invalid: [
-					{
-						code,
-						output,
-						errors: [
-							{
-								messageId: "useStandardAttribute",
-								data: {react: "className", standard: "class"},
-							},
-						],
-					},
-				],
+		]) {
+			it(`${name}`, () => {
+				ruleTester.run("no-react-props", noReactProps, {
+					valid: [],
+					invalid: [
+						{
+							code,
+							output,
+							errors: [
+								{
+									messageId: "useStandardAttribute",
+									data: {react: "className", standard: "class"},
+								},
+							],
+						},
+					],
+				});
 			});
-		});
+		}
 	});
 
 	describe("htmlFor transformation", () => {

--- a/packages/eslint-plugin-crank/src/rules/no-react-props.test.ts
+++ b/packages/eslint-plugin-crank/src/rules/no-react-props.test.ts
@@ -1,4 +1,4 @@
-import {describe, it} from "bun:test";
+import {describe, it} from "@b9g/libuild/test";
 import {noReactProps} from "./no-react-props.js";
 import {createTsRuleTester} from "../test-helpers/rule-tester.js";
 

--- a/packages/eslint-plugin-crank/src/rules/no-react-svg-props.test.ts
+++ b/packages/eslint-plugin-crank/src/rules/no-react-svg-props.test.ts
@@ -1,4 +1,4 @@
-import {describe, it} from "bun:test";
+import {describe, it} from "@b9g/libuild/test";
 import {noReactSvgProps} from "./no-react-svg-props.js";
 import {createTsRuleTester} from "../test-helpers/rule-tester.js";
 

--- a/packages/eslint-plugin-crank/src/rules/no-yield-in-lifecycle-methods.test.ts
+++ b/packages/eslint-plugin-crank/src/rules/no-yield-in-lifecycle-methods.test.ts
@@ -114,7 +114,7 @@ describe("no-yield-in-lifecycle-methods", () => {
 	});
 
 	describe("invalid cases - yield in lifecycle methods", () => {
-		it.each([
+		for (const {method, yieldValue, line, column} of [
 			{
 				method: "schedule",
 				yieldValue: "<div>Bad</div>",
@@ -133,9 +133,8 @@ describe("no-yield-in-lifecycle-methods", () => {
 				line: 4,
 				column: 19,
 			},
-		])(
-			"should detect yield in this.$method()",
-			({method, yieldValue, line, column}) => {
+		]) {
+			it(`should detect yield in this.${method}()`, () => {
 				ruleTester.run(
 					"no-yield-in-lifecycle-methods",
 					noYieldInLifecycleMethods,
@@ -165,8 +164,8 @@ describe("no-yield-in-lifecycle-methods", () => {
 						],
 					},
 				);
-			},
-		);
+			});
+		}
 	});
 
 	describe("invalid cases - return with value in after()", () => {

--- a/packages/eslint-plugin-crank/src/rules/no-yield-in-lifecycle-methods.test.ts
+++ b/packages/eslint-plugin-crank/src/rules/no-yield-in-lifecycle-methods.test.ts
@@ -1,4 +1,4 @@
-import {describe, it} from "bun:test";
+import {describe, it} from "@b9g/libuild/test";
 import {noYieldInLifecycleMethods} from "./no-yield-in-lifecycle-methods.js";
 import {
 	createTsRuleTester,

--- a/packages/eslint-plugin-crank/src/rules/prefer-props-iterator-typescript.test.ts
+++ b/packages/eslint-plugin-crank/src/rules/prefer-props-iterator-typescript.test.ts
@@ -1,4 +1,4 @@
-import {describe, it} from "bun:test";
+import {describe, it} from "@b9g/libuild/test";
 import {preferPropsIterator} from "./prefer-props-iterator.js";
 import {createTsRuleTester} from "../test-helpers/rule-tester.js";
 

--- a/packages/eslint-plugin-crank/src/rules/prefer-props-iterator.test.ts
+++ b/packages/eslint-plugin-crank/src/rules/prefer-props-iterator.test.ts
@@ -1,4 +1,4 @@
-import {describe, it} from "bun:test";
+import {describe, it} from "@b9g/libuild/test";
 import {preferPropsIterator} from "./prefer-props-iterator.js";
 import {createJsRuleTester} from "../test-helpers/rule-tester.js";
 

--- a/packages/eslint-plugin-crank/src/rules/prefer-refresh-callback.test.ts
+++ b/packages/eslint-plugin-crank/src/rules/prefer-refresh-callback.test.ts
@@ -1,4 +1,4 @@
-import {describe, it} from "bun:test";
+import {describe, it} from "@b9g/libuild/test";
 import {preferRefreshCallback} from "./prefer-refresh-callback.js";
 import {
 	createTsRuleTester,

--- a/packages/eslint-plugin-crank/src/rules/prop-destructuring-consistency.test.ts
+++ b/packages/eslint-plugin-crank/src/rules/prop-destructuring-consistency.test.ts
@@ -1,4 +1,4 @@
-import {describe, it} from "bun:test";
+import {describe, it} from "@b9g/libuild/test";
 import {propDestructuringConsistency} from "./prop-destructuring-consistency.js";
 import {
 	createJsRuleTester,

--- a/packages/eslint-plugin-crank/src/rules/require-cleanup-for-timers.test.ts
+++ b/packages/eslint-plugin-crank/src/rules/require-cleanup-for-timers.test.ts
@@ -1,4 +1,4 @@
-import {describe, it} from "bun:test";
+import {describe, it} from "@b9g/libuild/test";
 import {requireCleanupForTimers} from "./require-cleanup-for-timers.js";
 import {
 	createTsRuleTester,
@@ -105,7 +105,7 @@ describe("require-cleanup-for-timers", () => {
 		});
 	});
 
-	describe.each([
+	for (const {timerType, clearFunction, varName, componentName, action} of [
 		{
 			timerType: "setInterval",
 			clearFunction: "clearInterval",
@@ -120,9 +120,8 @@ describe("require-cleanup-for-timers", () => {
 			componentName: "Component",
 			action: 'console.log("Done")',
 		},
-	])(
-		"invalid cases - $timerType without cleanup",
-		({timerType, clearFunction, varName, componentName, action}) => {
+	]) {
+		describe(`invalid cases - ${timerType} without cleanup`, () => {
 			it(`should detect ${timerType} without any cleanup call`, () => {
 				ruleTester.run("require-cleanup-for-timers", requireCleanupForTimers, {
 					valid: [],
@@ -221,8 +220,8 @@ describe("require-cleanup-for-timers", () => {
 					],
 				});
 			});
-		},
-	);
+		});
+	}
 
 	describe("multiple timers", () => {
 		it("should detect multiple timers without cleanup", () => {

--- a/packages/eslint-plugin-crank/src/test-helpers/rule-tester.ts
+++ b/packages/eslint-plugin-crank/src/test-helpers/rule-tester.ts
@@ -1,10 +1,11 @@
 import {RuleTester} from "eslint";
-import {createRequire} from "module";
+import * as tsParser from "@typescript-eslint/parser";
 
-// Override RuleTester's internal describe/it to avoid nesting issues with bun:test.
-// bun:test does not allow describe() inside it(), but RuleTester.run() calls
-// this.constructor.describe/it internally. Bypassing them makes RuleTester run
-// assertions synchronously within the outer it() block.
+// Override RuleTester's internal describe/it to avoid nesting issues with the
+// test runner. bun:test (and @b9g/libuild/test) do not allow describe() inside
+// it(), but RuleTester.run() calls this.constructor.describe/it internally.
+// Bypassing them makes RuleTester run assertions synchronously within the
+// outer it() block.
 (RuleTester as any).describe = function (_text: string, fn: () => void) {
 	fn();
 };
@@ -16,9 +17,6 @@ import {createRequire} from "module";
  * Creates a RuleTester configured for TypeScript with JSX support
  */
 export function createTsRuleTester(): RuleTester {
-	const require = createRequire(import.meta.url);
-	const tsParser = require("@typescript-eslint/parser");
-
 	return new RuleTester({
 		languageOptions: {
 			parser: tsParser,

--- a/packages/eslint-plugin-crank/src/utils/callback-formatters.test.ts
+++ b/packages/eslint-plugin-crank/src/utils/callback-formatters.test.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect} from "bun:test";
+import {describe, it, expect} from "@b9g/libuild/test";
 import {
 	extractCallbackBodyWithoutRefresh,
 	formatCallbackBodyWithIndentation,

--- a/packages/eslint-plugin-crank/tsconfig.json
+++ b/packages/eslint-plugin-crank/tsconfig.json
@@ -8,7 +8,7 @@
 		"sourceMap": true,
 		"module": "ESNext",
 		"target": "ES2022",
-		"moduleResolution": "node",
+		"moduleResolution": "bundler",
 		"allowSyntheticDefaultImports": true,
 		"esModuleInterop": true,
 		"skipLibCheck": true,


### PR DESCRIPTION
## Summary

Converts the two package test suites (excluding the root `test/` directory, which is already being migrated separately in #375) from `bun:test` to `@b9g/libuild/test`, and runs them through the `libuild test` CLI instead of `bun test`.

- `packages/eslint-plugin-crank`: 16 `*.test.ts` files under `src/`.
- `packages/crankdown`: `test/marked.test.ts`.

Both packages' `test` scripts now run:

    libuild test "src/**/*.test.ts" --platform bun node   # eslint-plugin-crank
    libuild test "test/**/*.test.ts" --platform bun node  # crankdown

Uses `@b9g/libuild@0.2.17` (bumped from `^0.2.4`/`^0.1.25`; the version was pinned down from the 0.2.16 originally suggested after a fix landed that makes `--platform node` work for packages without `"type": "module"`).

## Before / after test counts

| Package | Before (`bun test`) | After, `--platform bun` | After, `--platform node` |
|---|---|---|---|
| eslint-plugin-crank | 126 pass | 126 pass | 95 pass |
| crankdown | 28 pass | 28 pass | 28 pass |

crankdown's node count matches bun's exactly. eslint-plugin-crank's node count (95) is lower than bun's (126) but **not** a sign of dropped coverage: ESLint's `RuleTester` only registers real per-case sub-tests when the global `describe`/`it` are defined — bun:test always installs those globals, so bun sees the deeper subtree; `node:test` does not install globals, so RuleTester falls back to running those same cases synchronously inside our own outer `it()` blocks, and node only counts the outer blocks (95, matching the number of explicit top-level `it()` calls with `RuleTester.run()`). All assertions still execute either way — it's a difference in how granularly each backend reports sub-tests, not fewer tests run. Both platforms report 0 failures.

## Other changes needed to make this work

- Replaced a `describe.each(...)` in `require-cleanup-for-timers.test.ts` (a bun:test/Jest-only API) with a plain `for` loop calling `describe()`, since `@b9g/libuild/test`'s node backend (`node:test`) has no `.each` support.
- `src/test-helpers/rule-tester.ts` used `createRequire(import.meta.url)` to load `@typescript-eslint/parser`. Under `--platform bun`, libuild's bundler auto-injects its own `import { createRequire } from "module"` shim for CJS interop, which collided with our explicit import of the same name and produced a "createRequire has already been declared" bundling error. Replaced it with a plain static `import * as tsParser from "@typescript-eslint/parser"`, which works because that package ships an ESM build. This required switching `eslint-plugin-crank`'s `tsconfig.json` `moduleResolution` from `"node"` to `"bundler"`, since the parser package only exposes types via its `exports` map, which classic Node resolution doesn't read.
- The comment above the `RuleTester.describe`/`.it` override in `rule-tester.ts` (previously bun:test-specific) was reworded to note it applies to both bun:test and `@b9g/libuild/test`. The override itself still works unmodified — verified via the passing RuleTester-based tests on both platforms.
- Bumped `@b9g/libuild` to `^0.2.17` in the repo root as well, so the whole workspace resolves to a single consistent libuild version (root `libuild build` is what produces the `dist/` that `crankdown`'s tests import as `@b9g/crank`).

## Verification

- [x] `libuild test` passes on `--platform bun` and `--platform node` for both packages, with counts matching (or exceeding, for the documented reason above) the `bun test` baseline.
- [x] `npx tsc --noEmit` passes in both packages.
- [x] `eslint` (via `--resolve-plugins-relative-to .`) passes with no errors on all touched files (pre-existing `no-explicit-any` warnings unrelated to this change remain).

No CHANGELOG entry: this is an internal test-framework/tooling change, not a public-facing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)