### PR TITLE
Fix stale children committing when refresh() supersedes an async generator yield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@
   renderer works with custom DOM implementations (e.g. termdom) which don’t
   install the browser globals.
 
+- **A self-refresh() during an async generator's execution no longer flashes the superseded children into the DOM on newer Safari.**
+  When an async generator component calls `refresh()` before its next `yield`
+  has committed, the yielded children are stale: the refresh immediately
+  resumes the generator, and only the fresh children should commit. Crank
+  relied on unspecified microtask ordering for this, and JavaScriptCore as of
+  Safari 26 resolves `.finally()` two ticks faster than V8, which flipped the
+  race: the stale children briefly committed and the render promise resolved
+  with them. The superseded children are now skipped explicitly, on every
+  engine. External re-renders are unaffected: an update requested while a
+  render is in flight still coalesces into the enqueued render, and the
+  in-flight render still commits its own children.
+
 - **`createElement` no longer mutates the caller's props object** (#356)
   Children are spread into a fresh props object instead of being assigned onto
   the passed-in props, so reusing a props object across calls (e.g. a

--- a/src/crank.ts
+++ b/src/crank.ts
@@ -326,6 +326,13 @@ const NeedsToYield = 1 << 15;
 const PropsAvailable = 1 << 16;
 const IsSchedulingRefresh = 1 << 17;
 
+/**
+ * A flag which indicates that refresh() was called while a run of the
+ * component was already in flight, meaning the in-flight run's yielded
+ * children are stale before they have committed.
+ */
+const IsSupersededByRefresh = 1 << 18;
+
 function getFlag(ret: Retainer<unknown>, flag: number): boolean {
 	return !!(ret.f & flag);
 }
@@ -2570,6 +2577,12 @@ export class Context<
 		const schedulePromises: Array<PromiseLike<unknown>> = [];
 		try {
 			setFlag(ctx.ret, IsRefreshing);
+			if (ctx.inflight) {
+				// This refresh supersedes the in-flight run: the component itself has
+				// declared that whatever that run yields is already stale.
+				setFlag(ctx.ret, IsSupersededByRefresh);
+			}
+
 			diff = enqueueComponent(ctx);
 			if (isPromiseLike(diff)) {
 				return diff
@@ -2921,6 +2934,9 @@ function runComponent<TNode, TResult>(
 	const ret = ctx.ret;
 	const initial = !ctx.iterator;
 	const tagName = getTagName(ret.el.tag);
+	// Each run starts unsuperseded; the flag describes the run in flight, and a
+	// rejected diff would otherwise leave it set for the next run.
+	setFlag(ctx.ret, IsSupersededByRefresh, false);
 	if (initial) {
 		setFlag(ctx.ret, IsExecuting);
 		clearEventListeners(ctx.ctx);
@@ -3067,8 +3083,13 @@ function runComponent<TNode, TResult>(
 				() => measureMark(tagName),
 				() => measureMark(tagName),
 			);
+			// The block chain below adopts this via a closure rather than deriving
+			// from diff, because in the superseded branch diff resolves with the
+			// enqueued run's diff, and the enqueued run only starts once the block
+			// settles — deriving the block from diff would deadlock.
+			let childDiff: Promise<undefined> | undefined;
 			const diff = iteration.then(
-				(iteration) => {
+				(iteration): Promise<undefined> | undefined => {
 					if (getFlag(ctx.ret, IsInForAwaitOfLoop)) {
 						// We have entered a for await...of loop, so we start pulling
 						pullComponent(ctx, iteration);
@@ -3091,12 +3112,33 @@ function runComponent<TNode, TResult>(
 						setFlag(ctx.ret, IsAsyncGen, false);
 						ctx.iterator = undefined;
 					}
-					return diffComponentChildren<TNode, TResult>(
+
+					if (getFlag(ctx.ret, IsSupersededByRefresh) && !iteration.done) {
+						// The component refreshed itself while this iteration was still
+						// pending, so the yielded children are stale before they have
+						// committed. Skip diffing them and resolve with the enqueued
+						// run's diff instead, so the parent's commit waits for the fresh
+						// children rather than racing them. The relative order of the
+						// two microtask chains depends on how many ticks the engine
+						// gives promise combinators (JavaScriptCore resolves .finally()
+						// two ticks faster than V8 as of Safari 26), so without this the
+						// stale children never appear on some engines and flash into the
+						// DOM on others.
+						//
+						// External updates deliberately do not take this branch: a
+						// re-render requested while a run is in flight coalesces into
+						// the enqueued run, but the in-flight run still commits its own
+						// children (see the "for...of enqueues" test).
+						setFlag(ctx.ret, IsSupersededByRefresh, false);
+						return ctx.enqueued ? ctx.enqueued[1] : undefined;
+					}
+
+					return (childDiff = diffComponentChildren<TNode, TResult>(
 						ctx,
 						// Children can be void so we eliminate that here
 						iteration.value as Children,
 						!iteration.done,
-					);
+					));
 				},
 				(err) => {
 					setFlag(ctx.ret, IsErrored);
@@ -3104,7 +3146,16 @@ function runComponent<TNode, TResult>(
 				},
 			);
 
-			return [diff.catch(NOOP), diff];
+			// This reaction is registered after diff's, so childDiff is assigned
+			// by the time it runs.
+			const block = iteration
+				.then(
+					() => childDiff,
+					() => undefined,
+				)
+				.catch(NOOP);
+
+			return [block, diff];
 		}
 	}
 }


### PR DESCRIPTION
Fixes the webkit failure discovered on #375.

## The bug

When an async generator component calls `refresh()` before its next `yield` has committed, the yielded children are stale: the refresh immediately resumes the generator, and only the fresh children should commit.

```js
async function* Component(this: Context) {
  await Promise.resolve();
  this.refresh();
  yield <span>Hello</span>;    // stale before it commits
  yield <span>Goodbye</span>;  // what should commit
}
```

Whether that held depended on a race between two unsynchronized microtask chains: the parent's commit walk vs. the enqueued run's diff. On V8 and older JavaScriptCore the enqueued diff won (Hello never appears — the behavior the cascades test asserts). On JSC as of Safari 26 the commit walk wins: **Hello flashes into the DOM and `render()` resolves with it.**

## Root cause, measured

Pure-JS probe, no crank involved:

| shape | V8 | old JSC (webkit-2191) | new JSC (webkit-2336) |
|---|---|---|---|
| `Promise.resolve().finally().then()` | tick 4 | tick 4 | **tick 2** |
| `catch().finally().then()` | tick 5 | tick 5 | **tick 3** |

JSC optimized `.finally()` by two microtask ticks. Crank's enqueue machinery (`block.finally(advance)`, `inflight[0].finally(runComponent)`) sits exactly on those ticks, so the race flipped with no crank code changing. Generator resumption and `await` hops are identical across all three engines — it is `.finally` alone.

Main's CI cannot see this: `playwright-test` pins playwright-core 1.54 → webkit-2191. #375's CI installs current webkit → 2336, which is how it surfaced. It reproduces deterministically (3/3 locally), file run alone.

## The fix

Make the supersede explicit instead of racing for it:

- `refresh()` sets a new `IsSupersededByRefresh` flag when a run is already in flight — self-refresh origin only.
- When the pending iteration arrives with the flag set (and not `done`), the stale children are not diffed at all, and the parent's diff resolves with the enqueued run's diff.
- The block chain derives from the iteration via a closure rather than from the parent diff — the enqueued run only starts once the block settles, so deriving it from the now-chasing diff would deadlock.

Two constraints shaped this, both enforced by existing tests:

- **External updates must not chase.** A re-render requested while a run is in flight coalesces into the enqueued run, but the in-flight run commits its own children (`"for...of enqueues"`: p1 resolves showing "Hello 1" while p2–p5 coalesce). The flag keys on refresh origin for exactly this reason.
- **The promise graph must be unchanged when no supersede occurs.** Earlier drafts added one microtask hop to every async-gen diff and broke tests whose assertions sample the DOM mid-flight. The final shape adds zero reactions on the clean path.

## Verification

- chromium (playwright-test, main's runner): **577 passed**
- webkit-2336, webkit-2191, chromium (libuild runner on the #375 branch with this `crank.ts`): **602 passed, 0 failed** each
- Instrumented MutationObserver trace: identical on V8 and new JSC — a single commit of the fresh children; the stale children never appear
- `tsc --noEmit` clean, eslint clean

The 22 other webkit failures on #375 were fallout from this one (libuild's browser runner runs `afterEach` inside its `try`, so the failing test leaked a Sinon `console.error` stub into every later test that stubs — being reported to libuild separately).

Intended for a 0.7.11 patch release via `release/0.7` as well; this is the main-line landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pggktip8wsuxzy2VCY9p7