### PR TITLE
README: rewrite the Motivation prose in the project's own voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,20 +51,19 @@ async function UserProfile({userId}) {
 await renderer.render(<UserProfile />, document.body);
 ```
 
-### Why Developers Choose Crank
+### Why Crank?
 
-- **Intuitive**: Uses `async`/`await` for loading states and generator functions for lifecycles. Updates are just execution and control flow makes sense
-- **Fast**: Comparable to React in benchmarks, lightweight with zero dependencies
-- **Flexible**: Write build-free vanilla JavaScript with template literals or write ergonomic JSX
-- **Transparent**: State lives in function scope. Explicit re-execution means no mysterious why did you render bugs.
-- **Future-proof**: Built on stable JavaScript features, not evolving framework abstractions
+Crank leans on the language instead of reinventing it. State is a local
+variable, held in a generator’s scope. Updates are re-execution: calling
+`refresh()` runs the loop again. A loading state is an `async` function,
+awaited. Setup is the code before the loop; cleanup is the code after it.
+There are no hooks, no dependency arrays, no compiler, and no rules about
+what you can call where — control flow is the lifecycle.
 
-### The "Just JavaScript" Promise, Delivered
-
-Other frameworks claim to be "just JavaScript" but ask you to think in terms of
-effects, dependencies, and framework-specific patterns. Crank actually delivers
-on that promise — your components are literally just functions that use standard
-JavaScript control flow.
+Because components are plain functions and generators, everything you already
+know about JavaScript applies. Closures hold state, modules share logic, and
+`try`/`finally` handles teardown. If you can read JavaScript, you can read a
+Crank component.
 
 ## Installation
 


### PR DESCRIPTION
Replaces the "Why Developers Choose Crank" listicle and "The 'Just JavaScript' Promise, Delivered" section with a short "Why Crank?" in the project's register.

That prose arrived in 4d756bc2 ("Why Crank?"), which described itself as "a relatively low effort change via Claude", and it reads like it: marketing-bullet cadence ("Fast", "Future-proof", "Promise, Delivered") and claims pitched at a landing page rather than a README. The replacement says the same true things the way the rest of the project says them — concrete mechanism, no superlatives: state is a variable in generator scope, updates are re-execution, control flow is the lifecycle.

The code example above the section is untouched; it was already right.

Also cherry-picked to `release/0.7` so the 0.7.11 npm tarball ships the same README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pggktip8wsuxzy2VCY9p7