### PR TITLE
Don't rely on Node/Element globals in the DOM renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
     deprecated `Context.value` getter.
 
 ### Bug Fixes
+- **The DOM renderer no longer relies on the `Node`/`Element` globals** (#381)
+  `nodeType` constants are inlined and the Portal root is duck-typed, so the
+  renderer works with custom DOM implementations (e.g. termdom) which don’t
+  install the browser globals.
+
 - **`createElement` no longer mutates the caller's props object** (#356)
   Children are spread into a fresh props object instead of being assigned onto
   the passed-in props, so reusing a props object across calls (e.g. a

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -12,12 +12,18 @@ import {REACT_SVG_PROPS} from "./_svg.js";
 const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
 const MATHML_NAMESPACE = "http://www.w3.org/1998/Math/MathML";
 
+// Node.ELEMENT_NODE and friends, inlined so this module works with DOM
+// implementations which do not install the Node/Element globals.
+const ELEMENT_NODE = 1;
+const TEXT_NODE = 3;
+const DOCUMENT_NODE = 9;
+
 function getRootDocument(root: Node | undefined): Document {
 	if (root && root.ownerDocument) {
 		return root.ownerDocument;
 	}
 
-	if (root && root.nodeType === Node.DOCUMENT_NODE) {
+	if (root && root.nodeType === DOCUMENT_NODE) {
 		return root as unknown as Document;
 	}
 
@@ -536,7 +542,10 @@ export const adapter: Partial<RenderAdapter<Node, string, Node>> = {
 	}): string | undefined {
 		switch (tag) {
 			case Portal: {
-				const ns = root instanceof Element ? root.namespaceURI : null;
+				const ns =
+					root && root.nodeType === ELEMENT_NODE
+						? (root as Element).namespaceURI
+						: null;
 				xmlns =
 					ns === SVG_NAMESPACE
 						? SVG_NAMESPACE
@@ -614,7 +623,7 @@ export const adapter: Partial<RenderAdapter<Node, string, Node>> = {
 		if (
 			node == null ||
 			(typeof tag === "string" &&
-				(node.nodeType !== Node.ELEMENT_NODE ||
+				(node.nodeType !== ELEMENT_NODE ||
 					tag.toLowerCase() !== (node as Element).tagName.toLowerCase()))
 		) {
 			console.warn(`Expected <${tagName}> while hydrating but found: `, node);
@@ -646,7 +655,7 @@ export const adapter: Partial<RenderAdapter<Node, string, Node>> = {
 		quietProps: Set<string> | undefined;
 		isHydrating: boolean;
 	}): void {
-		if (node.nodeType !== Node.ELEMENT_NODE) {
+		if (node.nodeType !== ELEMENT_NODE) {
 			throw new TypeError(`Cannot patch node: ${String(node)}`);
 		} else if (props.class && props.className) {
 			console.error(
@@ -761,7 +770,7 @@ export const adapter: Partial<RenderAdapter<Node, string, Node>> = {
 		const doc = getRootDocument(root);
 		if (hydrationNodes != null) {
 			let node = hydrationNodes.shift();
-			if (!node || node.nodeType !== Node.TEXT_NODE) {
+			if (!node || node.nodeType !== TEXT_NODE) {
 				console.warn(`Expected "${value}" while hydrating but found:`, node);
 			} else {
 				// value is a text node, check if it matches the expected text
@@ -886,7 +895,7 @@ function validateRoot(root: unknown): asserts root is Element {
 		(typeof root === "object" && typeof (root as any).nodeType !== "number")
 	) {
 		throw new TypeError(`Render root is not a node. Received: ${String(root)}`);
-	} else if ((root as Node).nodeType !== Node.ELEMENT_NODE) {
+	} else if ((root as Node).nodeType !== ELEMENT_NODE) {
 		throw new TypeError(
 			`Render root must be an element node. Received: ${String(root)}`,
 		);


### PR DESCRIPTION
The DOM renderer assumed the browser globals `Node` and `Element` exist. Against a custom DOM implementation which doesn't install them — the motivating case is termdom — every render threw a `ReferenceError`.

Five sites, all in `dom.js` (measured against 0.7.10):

- `validateRoot` read `Node.ELEMENT_NODE` on every `render()`/`hydrate()`
- the Portal case of `adapter.scope` did `root instanceof Element`, which the root render always passes through
- `adapter.patch` read `Node.ELEMENT_NODE` on every host-element patch
- the hydration path read `Node.ELEMENT_NODE` and `Node.TEXT_NODE`
- `getRootDocument` read `Node.DOCUMENT_NODE` on its fallback path

The fix inlines the `nodeType` constants (they're fixed by the DOM spec: 1, 3, 9) and duck-types the Portal root on `nodeType === 1` instead of `instanceof Element`. Behavior against a real DOM is unchanged, including for document and fragment/shadow roots (non-element roots still scope to `null` namespace).

`document` is still read in `getRootDocument`'s final fallback, but only when the root has neither an `ownerDocument` nor `nodeType === 9` — custom-DOM roots don't hit it.

Intended for cherry-pick to `release/0.7` for 0.7.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pggktip8wsuxzy2VCY9p7